### PR TITLE
Add James quota sync utility with CLI options

### DIFF
--- a/bin/sync-james.mjs
+++ b/bin/sync-james.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Sync utility to verify and fix consistency between LDAP and James
+ * Ensures James quotas match LDAP mailQuota values
+ * @author Generated with Claude Code
+ */
+
+import fetch from 'node-fetch';
+import { DM } from '../dist/bin/index.js';
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const quiet = args.includes('--quiet') || args.includes('-q');
+const dryRun = args.includes('--dry-run') || args.includes('-n');
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`
+Usage: sync-james [options]
+
+Synchronizes James quotas with LDAP mailQuota values.
+LDAP is considered the source of truth.
+
+Options:
+  --quiet, -q      Only show summary and errors
+  --dry-run, -n    Show what would be changed without making changes
+  --help, -h       Show this help message
+
+Environment variables:
+  DM_JAMES_WEBADMIN_URL    James WebAdmin URL (required)
+  DM_JAMES_WEBADMIN_TOKEN  James WebAdmin authentication token
+  DM_LDAP_BASE             LDAP search base
+  DM_MAIL_ATTRIBUTE        Mail attribute name (default: mail)
+  DM_QUOTA_ATTRIBUTE       Quota attribute name (default: mailQuota)
+`);
+  process.exit(0);
+}
+
+async function syncJamesQuotas() {
+  const dm = new DM();
+  await dm.ready;
+
+  const mailAttr = dm.config.mail_attribute || 'mail';
+  const quotaAttr = dm.config.quota_attribute || 'mailQuota';
+  const jamesUrl = dm.config.james_webadmin_url;
+  const jamesToken = dm.config.james_webadmin_token;
+
+  if (!jamesUrl) {
+    dm.logger.error('DM_JAMES_WEBADMIN_URL is not configured');
+    process.exit(1);
+  }
+
+  if (!quiet) {
+    dm.logger.info('Starting LDAP to James quota synchronization...');
+    dm.logger.info(`LDAP base: ${dm.config.ldap_base}`);
+    dm.logger.info(`James URL: ${jamesUrl}`);
+    if (dryRun) {
+      dm.logger.info('DRY RUN MODE: No changes will be made');
+    }
+    dm.logger.info('');
+  }
+
+  try {
+    // Search for all users with mail and quota attributes (paginated for large directories)
+    const resultGenerator = await dm.ldap.search({
+      paged: true,
+      filter: `(&(${mailAttr}=*)(${quotaAttr}=*))`,
+      attributes: [mailAttr, quotaAttr, 'dn'],
+    });
+
+    let checked = 0;
+    let synced = 0;
+    let errors = 0;
+
+    // Process results page by page
+    for await (const result of resultGenerator) {
+      if (!result.searchEntries || result.searchEntries.length === 0) {
+        continue;
+      }
+
+      if (!quiet) {
+        dm.logger.info(
+          `Processing batch of ${result.searchEntries.length} users...`
+        );
+      }
+
+      for (const entry of result.searchEntries) {
+        const dn = entry.dn;
+        const mail = Array.isArray(entry[mailAttr])
+          ? entry[mailAttr][0]
+          : entry[mailAttr];
+        const ldapQuota = Array.isArray(entry[quotaAttr])
+          ? Number(entry[quotaAttr][0])
+          : Number(entry[quotaAttr]);
+
+        if (!mail || isNaN(ldapQuota)) {
+          dm.logger.warn(`Skipping ${dn}: invalid mail or quota`);
+          continue;
+        }
+
+        checked++;
+
+        try {
+          // Get James quota
+          const getUrl = `${jamesUrl}/quota/users/${mail}/size`;
+          const headers = {};
+          if (jamesToken) {
+            headers.Authorization = `Bearer ${jamesToken}`;
+          }
+
+          const getRes = await fetch(getUrl, { method: 'GET', headers });
+
+          if (!getRes.ok) {
+            if (getRes.status === 404) {
+              dm.logger.warn(
+                `User ${mail} not found in James, skipping (DN: ${dn})`
+              );
+            } else {
+              dm.logger.error(
+                `Error getting quota for ${mail}: ${getRes.status} ${getRes.statusText}`
+              );
+              errors++;
+            }
+            continue;
+          }
+
+          const jamesQuota = Number(await getRes.text());
+
+          if (jamesQuota === ldapQuota) {
+            if (!quiet) {
+              dm.logger.info(`${mail}: quota OK (${ldapQuota})`);
+            }
+          } else {
+            dm.logger.warn(
+              `${mail}: quota mismatch - LDAP: ${ldapQuota}, James: ${jamesQuota}`
+            );
+            if (dryRun) {
+              dm.logger.info(`  Would update James quota to ${ldapQuota}`);
+              synced++;
+            } else {
+              if (!quiet) {
+                dm.logger.info(`  Updating James quota to ${ldapQuota}...`);
+              }
+
+              // Update James quota
+              const putUrl = `${jamesUrl}/quota/users/${mail}/size`;
+              const putRes = await fetch(putUrl, {
+                method: 'PUT',
+                headers,
+                body: ldapQuota.toString(),
+              });
+
+              if (putRes.ok) {
+                if (!quiet) {
+                  dm.logger.info(`  Updated successfully`);
+                }
+                synced++;
+              } else {
+                dm.logger.error(
+                  `  Failed to update: ${putRes.status} ${putRes.statusText}`
+                );
+                errors++;
+              }
+            }
+          }
+        } catch (err) {
+          dm.logger.error(`Error processing ${mail}: ${err.message}`);
+          errors++;
+        }
+      }
+    }
+
+    dm.logger.info('\n' + '='.repeat(60));
+    dm.logger.info('Synchronization summary:');
+    dm.logger.info(`  Users checked: ${checked}`);
+    dm.logger.info(`  Quotas ${dryRun ? 'needing sync' : 'synced'}: ${synced}`);
+    dm.logger.info(`  Errors: ${errors}`);
+    dm.logger.info('='.repeat(60));
+  } catch (err) {
+    dm.logger.error('Error during synchronization:', err);
+    process.exit(1);
+  } finally {
+    await dm.ldap.unbind();
+  }
+}
+
+// Run the sync
+syncJamesQuotas().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -184,7 +184,8 @@
   "main": "dist/bin/index.mjs",
   "bin": {
     "cleanup-external-users": "bin/cleanup-external-users.mjs",
-    "mini-dm": "bin/index.mjs"
+    "mini-dm": "bin/index.mjs",
+    "sync-james": "bin/sync-james.mjs"
   },
   "files": [
     "bin",

--- a/src/plugins/twake/james.ts
+++ b/src/plugins/twake/james.ts
@@ -2,6 +2,7 @@ import fetch from 'node-fetch';
 
 import DmPlugin, { type Role } from '../../abstract/plugin';
 import { Hooks } from '../../hooks';
+import type { AttributesList } from '../../lib/ldapActions';
 
 export default class James extends DmPlugin {
   name = 'james';
@@ -10,6 +11,41 @@ export default class James extends DmPlugin {
   dependencies = { onLdapChange: 'core/ldap/onChange' };
 
   hooks: Hooks = {
+    ldapadddone: async (args: [string, AttributesList]) => {
+      const [dn, attributes] = args;
+      // Initialize quota when user is created
+      const mailAttr = this.config.mail_attribute || 'mail';
+      const quotaAttr = this.config.quota_attribute || 'mailQuota';
+
+      const mail = attributes[mailAttr];
+      const quota = attributes[quotaAttr];
+
+      if (!mail || !quota) {
+        // Not a user with mail/quota, skip
+        return;
+      }
+
+      const mailStr = Array.isArray(mail) ? String(mail[0]) : String(mail);
+      // Handle both string and number values (LDAP stores as string, but accepts both)
+      const quotaNum = Array.isArray(quota) ? Number(quota[0]) : Number(quota);
+
+      if (isNaN(quotaNum) || quotaNum <= 0) {
+        // Invalid quota, skip
+        return;
+      }
+
+      // Wait a bit to ensure James has created the user
+      await new Promise(resolve => setTimeout(resolve, 1000));
+
+      return this._try(
+        'ldapadddone',
+        `${this.config.james_webadmin_url}/quota/users/${mailStr}/size`,
+        'PUT',
+        dn,
+        quotaNum.toString(),
+        { mail: mailStr, quota: quotaNum }
+      );
+    },
     onLdapMailChange: (dn: string, oldmail: string, newmail: string) => {
       return this._try(
         'onLdapMailChange',

--- a/src/plugins/twake/james.ts
+++ b/src/plugins/twake/james.ts
@@ -15,7 +15,7 @@ export default class James extends DmPlugin {
       const [dn, attributes] = args;
       // Initialize quota when user is created
       const mailAttr = this.config.mail_attribute || 'mail';
-      const quotaAttr = this.config.quota_attribute || 'mailQuota';
+      const quotaAttr = this.config.quota_attribute || 'mailQuotaSize';
 
       const mail = attributes[mailAttr];
       const quota = attributes[quotaAttr];
@@ -35,6 +35,7 @@ export default class James extends DmPlugin {
       }
 
       // Wait a bit to ensure James has created the user
+      // eslint-disable-next-line no-undef
       await new Promise(resolve => setTimeout(resolve, 1000));
 
       return this._try(

--- a/static/schemas/twake/users.json
+++ b/static/schemas/twake/users.json
@@ -76,6 +76,10 @@
       "type": "pointer",
       "branch": ["ou=twakeDeliveryMode,ou=nomenclature,__LDAP_BASE__"],
       "required": true
+    },
+    "mailQuotaSize": {
+      "type": "integer",
+      "required": false
     }
   }
 }

--- a/test/plugins/twake/james.test.ts
+++ b/test/plugins/twake/james.test.ts
@@ -82,17 +82,13 @@ describe('James Plugin', () => {
     expect(res).to.be.true;
   });
 
-  // Quota management tests require schema with mailQuota attribute
-  // These can be enabled when testing with appropriate LDAP schema
-  describe.skip('Quota management', () => {
+  describe('Quota management', () => {
     it('should initialize quota when user is created', async () => {
       const entry = {
-        objectClass: ['top', 'inetOrgPerson'],
-        cn: 'Quota User',
-        sn: 'User',
+        objectClass: ['top', 'twakeAccount'],
         uid: 'quotauser',
         mail: 'quotauser@test.org',
-        mailQuota: '75000000',
+        mailQuotaSize: '75000000',
       };
       const res = await dm.ldap.add(testDNQuota, entry);
       expect(res).to.be.true;
@@ -103,19 +99,17 @@ describe('James Plugin', () => {
 
     it('should update quota when modified in LDAP', async () => {
       const entry = {
-        objectClass: ['top', 'inetOrgPerson'],
-        cn: 'Test User',
-        sn: 'User',
+        objectClass: ['top', 'twakeAccount'],
         uid: 'testusermail',
         mail: 'testmail@test.org',
-        mailQuota: '50000000',
+        mailQuotaSize: '50000000',
       };
       let res = await dm.ldap.add(testDN, entry);
       expect(res).to.be.true;
 
       // Modify quota
       res = await dm.ldap.modify(testDN, {
-        replace: { mailQuota: '100000000' },
+        replace: { mailQuotaSize: '100000000' },
       });
       expect(res).to.be.true;
     });


### PR DESCRIPTION
Implements GitHub issue #2: James plugin quota management

Features:
- Initialize quota in James when user is created in LDAP (ldapadddone hook) - note that modifications were already checked
- Sync utility to verify and fix LDAP/James quota consistency
  - LDAP is the source of truth
  - Paginated search for large directories (1M+ users)
  - CLI options: `--quiet`, `--dry-run`, `--help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)