### PR TITLE
feat: add James delegation support (#7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ ENV NODE_ENV=production \
  DM_SCHEMAS_PATH="/app/node_modules/mini-dm/static/schemas" \
  DM_MAIL_ATTRIBUTE="mail" \
  DM_QUOTA_ATTRIBUTE="mailQuota" \
+ DM_DELEGATION_ATTRIBUTE="twakeDelegatedUsers" \
  DM_USER_CLASSES=top,twakeAccount,twakeWhitePages \
  DM_LDAP_TOP_ORGANIZATION= \
  DM_LDAP_ORGANIZATION_CLASSES=top,organizationalUnit,twakeDepartment \

--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -108,6 +108,7 @@ export interface Config {
   // Special attributes
   mail_attribute?: string;
   quota_attribute?: string;
+  delegation_attribute?: string;
 
   // James plugin
   james_webadmin_url?: string;
@@ -172,6 +173,7 @@ const configArgs: ConfigTemplate = [
   // Special attributes
   ['--mail-attribute', 'DM_MAIL_ATTRIBUTE', 'mail'],
   ['--quota-attribute', 'DM_QUOTA_ATTRIBUTE', 'mailQuota'],
+  ['--delegation-attribute', 'DM_DELEGATION_ATTRIBUTE', 'twakeDelegatedUsers'],
 
   // Default classes to insert into LDAP
   [

--- a/src/plugins/twake/james.ts
+++ b/src/plugins/twake/james.ts
@@ -2,6 +2,8 @@ import fetch from 'node-fetch';
 
 import DmPlugin, { type Role } from '../../abstract/plugin';
 import { Hooks } from '../../hooks';
+import type { ChangesToNotify } from '../ldap/onChange';
+import type { AttributeValue, SearchResult } from '../../lib/ldapActions';
 
 export default class James extends DmPlugin {
   name = 'james';
@@ -35,7 +37,121 @@ export default class James extends DmPlugin {
         { oldQuota, newQuota }
       );
     },
+    onLdapChange: async (dn: string, changes: ChangesToNotify) => {
+      if (
+        this.config.delegation_attribute &&
+        changes[this.config.delegation_attribute]
+      ) {
+        await this._handleDelegationChange(dn, changes);
+      }
+    },
   };
+
+  async _handleDelegationChange(
+    dn: string,
+    changes: ChangesToNotify
+  ): Promise<void> {
+    // Get the user's mail attribute from LDAP
+    const entry = (await this.server.ldap.search(
+      { paged: false },
+      dn
+    )) as SearchResult;
+    if (!entry.searchEntries || entry.searchEntries.length !== 1) {
+      this.logger.warn({
+        plugin: this.name,
+        event: 'onLdapChange',
+        dn,
+        message: 'Could not find user entry to get mail attribute',
+      });
+      return;
+    }
+
+    const userMail = entry.searchEntries[0].mail;
+    if (!userMail || typeof userMail !== 'string') {
+      this.logger.warn({
+        plugin: this.name,
+        event: 'onLdapChange',
+        dn,
+        message: 'User has no mail attribute, cannot manage delegation',
+      });
+      return;
+    }
+
+    const delegationAttr = this.config.delegation_attribute;
+    if (!delegationAttr) return;
+
+    const [oldDelegated, newDelegated] = changes[delegationAttr] || [];
+
+    // Normalize values to arrays of DNs
+    const oldDNs = this._normalizeToArray(oldDelegated);
+    const newDNs = this._normalizeToArray(newDelegated);
+
+    // Find added and removed delegations
+    const addedDNs = newDNs.filter(delegateDN => !oldDNs.includes(delegateDN));
+    const removedDNs = oldDNs.filter(
+      delegateDN => !newDNs.includes(delegateDN)
+    );
+
+    // Process additions
+    for (const delegateDN of addedDNs) {
+      const delegateEmail = await this._getDelegateEmail(delegateDN);
+      if (delegateEmail) {
+        await this._try(
+          'onLdapChange:addDelegation',
+          `${this.config.james_webadmin_url}/users/${userMail}/authorizedUsers/${delegateEmail}`,
+          'PUT',
+          dn,
+          null,
+          { userMail, delegateEmail, delegateDN, action: 'add' }
+        );
+      }
+    }
+
+    // Process removals
+    for (const delegateDN of removedDNs) {
+      const delegateEmail = await this._getDelegateEmail(delegateDN);
+      if (delegateEmail) {
+        await this._try(
+          'onLdapChange:removeDelegation',
+          `${this.config.james_webadmin_url}/users/${userMail}/authorizedUsers/${delegateEmail}`,
+          'DELETE',
+          dn,
+          null,
+          { userMail, delegateEmail, delegateDN, action: 'remove' }
+        );
+      }
+    }
+  }
+
+  async _getDelegateEmail(dn: string): Promise<string | null> {
+    try {
+      const result = (await this.server.ldap.search(
+        { paged: false },
+        dn
+      )) as SearchResult;
+      if (result.searchEntries && result.searchEntries.length === 1) {
+        const mail = result.searchEntries[0].mail;
+        if (mail && typeof mail === 'string') {
+          return mail;
+        }
+      }
+    } catch (err) {
+      this.logger.warn({
+        plugin: this.name,
+        event: 'getDelegateEmail',
+        dn,
+        message: 'Could not resolve delegate DN to email',
+        error: err,
+      });
+    }
+    return null;
+  }
+
+  _normalizeToArray(value: AttributeValue | null): string[] {
+    if (!value) return [];
+    if (Array.isArray(value)) return value as string[];
+    return [value as string];
+  }
 
   async _try(
     hookname: string,

--- a/static/schemas/twake/users.json
+++ b/static/schemas/twake/users.json
@@ -76,6 +76,14 @@
       "type": "pointer",
       "branch": ["ou=twakeDeliveryMode,ou=nomenclature,__LDAP_BASE__"],
       "required": true
+    },
+    "twakeDelegatedUsers": {
+      "type": "array",
+      "items": {
+        "type": "pointer",
+        "branch": ["ou=users,__LDAP_BASE__"]
+      },
+      "required": false
     }
   }
 }

--- a/test/plugins/twake/james.test.ts
+++ b/test/plugins/twake/james.test.ts
@@ -69,4 +69,186 @@ describe('James Plugin', () => {
     });
     expect(res).to.be.true;
   });
+
+  describe('Delegation', () => {
+    const userDN = `uid=testdelegate,${process.env.DM_LDAP_BASE}`;
+    const assistantDN = `uid=assistant,${process.env.DM_LDAP_BASE}`;
+    const assistant1DN = `uid=assistant1,${process.env.DM_LDAP_BASE}`;
+    const assistant2DN = `uid=assistant2,${process.env.DM_LDAP_BASE}`;
+    let delegateAddScope: nock.Scope;
+    let delegateRemoveScope: nock.Scope;
+
+    beforeEach(async () => {
+      // Create assistant user
+      try {
+        await dm.ldap.add(assistantDN, {
+          objectClass: ['top', 'twakeAccount', 'twakeWhitePages'],
+          cn: 'Assistant',
+          sn: 'Assistant',
+          uid: 'assistant',
+          mail: 'assistant@test.org',
+        });
+      } catch (err) {
+        // Ignore if already exists
+      }
+    });
+
+    afterEach(async () => {
+      try {
+        await dm.ldap.delete(userDN);
+      } catch (err) {
+        // Ignore
+      }
+      try {
+        await dm.ldap.delete(assistantDN);
+      } catch (err) {
+        // Ignore
+      }
+      try {
+        await dm.ldap.delete(assistant1DN);
+      } catch (err) {
+        // Ignore
+      }
+      try {
+        await dm.ldap.delete(assistant2DN);
+      } catch (err) {
+        // Ignore
+      }
+    });
+
+    it('should add delegation when twakeDelegatedUsers is added', async () => {
+      let apiCalled = false;
+      const addScope = nock(
+        process.env.DM_JAMES_WEBADMIN_URL || 'http://localhost:8000'
+      )
+        .put('/users/delegate@test.org/authorizedUsers/assistant@test.org')
+        .reply(200);
+
+      addScope.on('request', () => {
+        apiCalled = true;
+      });
+
+      const entry = {
+        objectClass: ['top', 'twakeAccount', 'twakeWhitePages'],
+        cn: 'Test Delegate',
+        sn: 'Delegate',
+        uid: 'testdelegate',
+        mail: 'delegate@test.org',
+      };
+      await dm.ldap.add(userDN, entry);
+
+      await dm.ldap.modify(userDN, {
+        add: { twakeDelegatedUsers: assistantDN },
+      });
+
+      // Wait for hooks
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      expect(apiCalled).to.be.true;
+    });
+
+    it('should remove delegation when twakeDelegatedUsers is removed', async () => {
+      let addApiCalled = false;
+      let removeApiCalled = false;
+
+      const addScope = nock(
+        process.env.DM_JAMES_WEBADMIN_URL || 'http://localhost:8000'
+      )
+        .put('/users/delegate@test.org/authorizedUsers/assistant@test.org')
+        .reply(200);
+
+      const removeScope = nock(
+        process.env.DM_JAMES_WEBADMIN_URL || 'http://localhost:8000'
+      )
+        .delete('/users/delegate@test.org/authorizedUsers/assistant@test.org')
+        .reply(200);
+
+      addScope.on('request', () => {
+        addApiCalled = true;
+      });
+
+      removeScope.on('request', () => {
+        removeApiCalled = true;
+      });
+
+      // First create user without delegation
+      const entry = {
+        objectClass: ['top', 'twakeAccount', 'twakeWhitePages'],
+        cn: 'Test Delegate',
+        sn: 'Delegate',
+        uid: 'testdelegate',
+        mail: 'delegate@test.org',
+      };
+      await dm.ldap.add(userDN, entry);
+
+      // Add delegation
+      await dm.ldap.modify(userDN, {
+        add: { twakeDelegatedUsers: assistantDN },
+      });
+
+      // Wait for add hook
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      // Now remove delegation
+      await dm.ldap.modify(userDN, {
+        delete: { twakeDelegatedUsers: assistantDN },
+      });
+
+      // Wait for remove hook
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      expect(removeApiCalled).to.be.true;
+    });
+
+    it('should handle multiple delegated users', async () => {
+      // Create additional assistants
+      await dm.ldap.add(assistant1DN, {
+        objectClass: ['top', 'twakeAccount', 'twakeWhitePages'],
+        cn: 'Assistant 1',
+        sn: 'Assistant',
+        uid: 'assistant1',
+        mail: 'assistant1@test.org',
+      });
+      await dm.ldap.add(assistant2DN, {
+        objectClass: ['top', 'twakeAccount', 'twakeWhitePages'],
+        cn: 'Assistant 2',
+        sn: 'Assistant',
+        uid: 'assistant2',
+        mail: 'assistant2@test.org',
+      });
+
+      const multiAddScope1 = nock(
+        process.env.DM_JAMES_WEBADMIN_URL || 'http://localhost:8000'
+      )
+        .put('/users/delegate@test.org/authorizedUsers/assistant1@test.org')
+        .reply(200);
+
+      const multiAddScope2 = nock(
+        process.env.DM_JAMES_WEBADMIN_URL || 'http://localhost:8000'
+      )
+        .put('/users/delegate@test.org/authorizedUsers/assistant2@test.org')
+        .reply(200);
+
+      const entry = {
+        objectClass: ['top', 'twakeAccount', 'twakeWhitePages'],
+        cn: 'Test Delegate',
+        sn: 'Delegate',
+        uid: 'testdelegate',
+        mail: 'delegate@test.org',
+      };
+      await dm.ldap.add(userDN, entry);
+
+      await dm.ldap.modify(userDN, {
+        add: {
+          twakeDelegatedUsers: [assistant1DN, assistant2DN],
+        },
+      });
+
+      // Wait for hooks
+      await new Promise(resolve => setTimeout(resolve, 400));
+
+      expect(multiAddScope1.isDone()).to.be.true;
+      expect(multiAddScope2.isDone()).to.be.true;
+    });
+  });
 });

--- a/test/plugins/twake/james.test.ts
+++ b/test/plugins/twake/james.test.ts
@@ -75,8 +75,7 @@ describe('James Plugin', () => {
     const assistantDN = `uid=assistant,${process.env.DM_LDAP_BASE}`;
     const assistant1DN = `uid=assistant1,${process.env.DM_LDAP_BASE}`;
     const assistant2DN = `uid=assistant2,${process.env.DM_LDAP_BASE}`;
-    let delegateAddScope: nock.Scope;
-
+  
     beforeEach(async () => {
       // Create assistant user
       try {

--- a/test/plugins/twake/james.test.ts
+++ b/test/plugins/twake/james.test.ts
@@ -76,7 +76,6 @@ describe('James Plugin', () => {
     const assistant1DN = `uid=assistant1,${process.env.DM_LDAP_BASE}`;
     const assistant2DN = `uid=assistant2,${process.env.DM_LDAP_BASE}`;
     let delegateAddScope: nock.Scope;
-    let delegateRemoveScope: nock.Scope;
 
     beforeEach(async () => {
       // Create assistant user


### PR DESCRIPTION
Implement user delegation feature for James mail server, allowing users to authorize other users to act on their behalf (#7).

Changes:
- Add twakeDelegatedUsers attribute to Twake user schema (pointer array to user DNs)
- Extend James plugin to sync delegations with James WebAdmin API
- Add configurable delegation_attribute (default: twakeDelegatedUsers)
- Resolve DNs to email addresses for James API calls
- Add comprehensive tests for delegation add/remove/multiple users

API integration:
- PUT /users/{user}/authorizedUsers/{delegate} to add delegation
- DELETE /users/{user}/authorizedUsers/{delegate} to remove delegation

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)