### PR TITLE
refactor: remove dead code from ldapActions and ldapFlat

### DIFF
--- a/src/abstract/ldapFlat.ts
+++ b/src/abstract/ldapFlat.ts
@@ -749,38 +749,4 @@ export default abstract class LdapFlat extends DmPlugin {
     return true;
   }
 
-  /**
-   * Escape special characters in DN values for LDAP attributes
-   * Escape spaces and special characters with backslashes
-   */
-  private escapeDnValue(dn: string): string {
-    if (!dn) return dn;
-
-    // Split DN into RDN components
-    const parts = dn.split(',').map(part => {
-      const trimmed = part.trim();
-      const eqIndex = trimmed.indexOf('=');
-      if (eqIndex === -1) return trimmed;
-
-      const key = trimmed.substring(0, eqIndex);
-      let value = trimmed.substring(eqIndex + 1);
-
-      // Escape special characters according to RFC 4514
-      // Characters that must be escaped: space, #, +, ,, ;, <, >, \
-      // Also escape leading # and space
-      value = value
-        .replace(/\\/g, '\\\\') // Backslash first
-        .replace(/ /g, '\\ ') // Spaces (all of them, not just leading/trailing)
-        .replace(/#/g, '\\#')
-        .replace(/\+/g, '\\+')
-        .replace(/,/g, '\\,')
-        .replace(/;/g, '\\;')
-        .replace(/</g, '\\<')
-        .replace(/>/g, '\\>');
-
-      return `${key}=${value}`;
-    });
-
-    return parts.join(',');
-  }
 }

--- a/src/lib/ldapActions.ts
+++ b/src/lib/ldapActions.ts
@@ -230,14 +230,6 @@ class ldapActions {
   }
 
   /**
-   * Legacy connect method for backward compatibility
-   * @deprecated Use acquireConnection/releaseConnection instead
-   */
-  async connect(): Promise<Client> {
-    return await this.createConnection();
-  }
-
-  /**
    * Generate cache key for LDAP search
    */
   private getCacheKey(base: string, opts: SearchOptions): string {

--- a/test/lib/ldapActions.test.ts
+++ b/test/lib/ldapActions.test.ts
@@ -17,14 +17,6 @@ describe('ldapActions', function () {
     ldapActions = new LdapActions(new DM());
   });
 
-  describe('connect', () => {
-    it('should connect to LDAP server successfully', async () => {
-      const result = await ldapActions.connect();
-      expect(result).to.be.instanceOf(Client);
-      await result?.unbind();
-    });
-  });
-
   describe('search', () => {
     it('should perform a search and return results', async () => {
       const options = {


### PR DESCRIPTION
Remove unused methods that are no longer called anywhere in the codebase:

- ldapActions.connect(): Deprecated method replaced by connection pool (acquireConnection/releaseConnection)
- ldapFlat.escapeDnValue(): Unused private method, DN escaping handled by ldapts library automatically
- Remove obsolete test for connect() method