### PR TITLE
fix(auth): accept bodyless POST in HMAC signature check

### DIFF
--- a/src/plugins/auth/hmac.ts
+++ b/src/plugins/auth/hmac.ts
@@ -175,15 +175,24 @@ export default class AuthHmac extends AuthBase {
 
   /**
    * Calculate SHA256 hash of request body
-   * Returns empty string for GET/DELETE/HEAD methods
+   *
+   * Returns empty string when no body was sent on the wire. bodyParser.json()
+   * populates `req.body` as `{}` for empty POSTs with a JSON content-type, so
+   * gating on `req.body` alone would hash `"{}"` for bodyless endpoints like
+   * `/users/:id/disable` — while the client, having sent no body, signs with
+   * an empty body hash. We key off Content-Length to match the wire exactly.
    */
   private calculateBodyHash(req: DmRequest): string {
     const method = req.method.toUpperCase();
 
-    // No body for these methods
     if (method === 'GET' || method === 'DELETE' || method === 'HEAD') return '';
 
-    // Hash the body if present
+    const contentLength = parseInt(
+      (req.headers['content-length'] as string | undefined) ?? '0',
+      10
+    );
+    if (!contentLength) return '';
+
     if (req.body) {
       const bodyString =
         typeof req.body === 'string' ? req.body : JSON.stringify(req.body);

--- a/test/plugins/auth/hmac.test.ts
+++ b/test/plugins/auth/hmac.test.ts
@@ -261,6 +261,24 @@ describe('AuthHmac', () => {
 
       expect(res.status).to.equal(401);
     });
+
+    it('should accept bodyless POST signed with empty body hash', async () => {
+      const timestamp = Date.now();
+      const signature = generateHmacSignature(
+        secret,
+        'POST',
+        '/api/hello',
+        timestamp,
+        undefined
+      );
+      const authHeader = createAuthHeader(serviceId, timestamp, signature);
+
+      const res = await request(app)
+        .post('/api/hello')
+        .set('Authorization', authHeader);
+
+      expect(res.status).to.not.equal(401);
+    });
   });
 
   describe('Multiple services', () => {


### PR DESCRIPTION
## Summary

- Account deletion from the registration service started returning 401 right after HMAC enforcement went live, on the `/users/:id/disable` call.
- Root cause is server side: `bodyParser.json()` populates `req.body` as `{}` for empty POSTs with a JSON content-type, so we were hashing `"{}"` while clients that sent no body signed against an empty body hash. Signing strings diverged only for bodyless POSTs, which is why GET and normal PATCH/POST stayed fine.
- Gating the body hash on `Content-Length` makes the server match what was actually on the wire. Also covers the B2B equivalent `/organizations/:id/users/:id/disable`, which was about to hit the same 401 as soon as a B2B user tried to delete their account.