### PR TITLE
fix(security): enforce base DN scope in LdapFlat operations

### DIFF
--- a/src/abstract/ldapFlat.ts
+++ b/src/abstract/ldapFlat.ts
@@ -273,17 +273,24 @@ export default abstract class LdapFlat extends DmPlugin {
    * Resolve an id (either an RDN value or a full DN) into a DN inside this
    * instance's base branch.
    *
-   * When the id already looks like a DN (contains a comma) we enforce that it
-   * terminates with `,this.base`. Without this check a caller with access to a
-   * route scoped to one branch could address entries outside that scope by
-   * passing a full DN from a sibling branch.
+   * A value is treated as a full DN only when it starts with
+   * `mainAttribute=`; otherwise it is treated as a raw RDN value and escaped.
+   * This matters for cn-based branches where values like `Smith, John` are
+   * legal and must not be misclassified as DNs.
    *
-   * DN components are compared case-insensitively to match LDAP semantics.
+   * When the id is a full DN we enforce that it terminates with `,this.base`
+   * (comparison is case-insensitive, matching LDAP semantics). Without this
+   * check a caller scoped to one resource could address entries outside that
+   * scope by passing a full DN from a sibling branch.
    *
-   * @throws BadRequestError if the DN is not under this.base
+   * @throws BadRequestError if the provided DN is not under this.base
    */
   protected resolveDn(id: string): string {
-    if (/,/.test(id)) {
+    const dnPrefix = new RegExp(
+      `^${escapeRegex(this.mainAttribute)}=`,
+      'i'
+    );
+    if (dnPrefix.test(id)) {
       const expectedSuffix = `,${this.base}`;
       if (!id.toLowerCase().endsWith(expectedSuffix.toLowerCase())) {
         throw new BadRequestError(

--- a/src/abstract/ldapFlat.ts
+++ b/src/abstract/ldapFlat.ts
@@ -194,9 +194,7 @@ export default abstract class LdapFlat extends DmPlugin {
     if (!wantJson(req, res)) return;
     const id = decodeURIComponent(req.params.id as string);
     try {
-      const dn = /,/.test(id)
-        ? id
-        : `${this.mainAttribute}=${escapeDnValue(id)},${this.base}`;
+      const dn = this.resolveDn(id);
       const result = (await this.ldap.search(
         { paged: false, scope: 'base' },
         dn
@@ -271,31 +269,51 @@ export default abstract class LdapFlat extends DmPlugin {
     });
   }
 
+  /**
+   * Resolve an id (either an RDN value or a full DN) into a DN inside this
+   * instance's base branch.
+   *
+   * When the id already looks like a DN (contains a comma) we enforce that it
+   * terminates with `,this.base`. Without this check a caller with access to a
+   * route scoped to one branch could address entries outside that scope by
+   * passing a full DN from a sibling branch.
+   *
+   * DN components are compared case-insensitively to match LDAP semantics.
+   *
+   * @throws BadRequestError if the DN is not under this.base
+   */
+  protected resolveDn(id: string): string {
+    if (/,/.test(id)) {
+      const expectedSuffix = `,${this.base}`;
+      if (!id.toLowerCase().endsWith(expectedSuffix.toLowerCase())) {
+        throw new BadRequestError(
+          `DN must be in the branch "${this.base}". ` +
+            `Provided DN "${id}" does not end with "${expectedSuffix}"`
+        );
+      }
+      return id;
+    }
+    return `${this.mainAttribute}=${escapeDnValue(id)},${this.base}`;
+  }
+
   async addEntry(
     id: string,
     additional: AttributesList = {},
     req?: Request
   ): Promise<boolean> {
     let dn: string;
-    if (new RegExp(`^${this.mainAttribute}=`).test(id)) {
+    if (new RegExp(`^${this.mainAttribute}=`, 'i').test(id)) {
       // DN provided - validate it's in the correct flat branch
-      dn = id;
-      const expectedSuffix = `,${this.base}`;
-      if (!dn.endsWith(expectedSuffix)) {
-        throw new BadRequestError(
-          `DN must be in the flat branch "${this.base}". ` +
-            `Provided DN "${dn}" does not end with "${expectedSuffix}"`
-        );
-      }
+      dn = this.resolveDn(id);
       // Extract the RDN value, correctly handling escaped commas
       // e.g. uid=Smith\,John,ou=users -> id = "Smith\,John"
       id = id.replace(
-        new RegExp(`^${this.mainAttribute}=((?:\\\\.|[^,])+)(?:,.*)?$`),
+        new RegExp(`^${this.mainAttribute}=((?:\\\\.|[^,])+)(?:,.*)?$`, 'i'),
         '$1'
       );
     } else {
       validateDnValue(id, this.mainAttribute);
-      dn = `${this.mainAttribute}=${escapeDnValue(id)},${this.base}`;
+      dn = this.resolveDn(id);
     }
     await this.validateNewEntry(dn, {
       objectClass: this.objectClass,
@@ -361,9 +379,7 @@ export default abstract class LdapFlat extends DmPlugin {
   }
 
   async modifyEntry(id: string, changes: ModifyRequest): Promise<boolean> {
-    let dn = /,/.test(id)
-      ? id
-      : `${this.mainAttribute}=${escapeDnValue(id)},${this.base}`;
+    let dn = this.resolveDn(id);
     const op = this.opNumber();
     [dn, changes] = await launchHooksChained(
       this.registeredHooks[`${this.hookPrefix}modify`],
@@ -413,12 +429,8 @@ export default abstract class LdapFlat extends DmPlugin {
     if (!/,/.test(newId)) {
       validateDnValue(newId, this.mainAttribute);
     }
-    let dn = /,/.test(id)
-      ? id
-      : `${this.mainAttribute}=${escapeDnValue(id)},${this.base}`;
-    let newDn = /,/.test(newId)
-      ? newId
-      : `${this.mainAttribute}=${escapeDnValue(newId)},${this.base}`;
+    let dn = this.resolveDn(id);
+    let newDn = this.resolveDn(newId);
     [dn, newDn] = await launchHooksChained(
       this.registeredHooks[`${this.hookPrefix}rename`],
       [dn, newDn]
@@ -432,9 +444,7 @@ export default abstract class LdapFlat extends DmPlugin {
   }
 
   async deleteEntry(id: string): Promise<boolean> {
-    let dn = /,/.test(id)
-      ? id
-      : `${this.mainAttribute}=${escapeDnValue(id)},${this.base}`;
+    let dn = this.resolveDn(id);
     dn = await launchHooksChained(
       this.registeredHooks[`${this.hookPrefix}delete`],
       dn
@@ -453,9 +463,7 @@ export default abstract class LdapFlat extends DmPlugin {
     targetOrgDn: string,
     req?: Request
   ): Promise<{ departmentPath: string; departmentLink: string }> {
-    const dn = /,/.test(id)
-      ? id
-      : `${this.mainAttribute}=${escapeDnValue(id)},${this.base}`;
+    const dn = this.resolveDn(id);
 
     // Get link and path attribute names from config
     const linkAttr =

--- a/test/plugins/ldap/ldapFlatBaseScope.test.ts
+++ b/test/plugins/ldap/ldapFlatBaseScope.test.ts
@@ -175,6 +175,18 @@ describe('LdapFlat base-scope guard', function () {
       expect(res.status).to.equal(200);
     });
 
+    it('rejects a partial DN (prefix without base) rather than producing a malformed DN', () => {
+      // Regression caught during review: "cn=foo" starts with the main
+      // attribute but is not a full DN. It must be rejected cleanly by the
+      // suffix check, not silently re-escaped into `cn=cn\=foo,<base>` with
+      // an attribute value that no longer matches the RDN.
+      expect(() =>
+        (
+          instance as unknown as { resolveDn: (id: string) => string }
+        ).resolveDn('cn=foo')
+      ).to.throw(BadRequestError, /must be in the branch/i);
+    });
+
     it('does not misclassify a main-attribute value containing a comma as a DN', () => {
       // Regression caught during review: with a naive comma-based heuristic,
       // values like "Smith, John" (legitimate for a cn-based branch) would be

--- a/test/plugins/ldap/ldapFlatBaseScope.test.ts
+++ b/test/plugins/ldap/ldapFlatBaseScope.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Regression tests for the base-scope guard on LdapFlat operations.
+ *
+ * Context: every CRUD method of LdapFlat accepts an `id` that can be either
+ * an RDN value or a full DN. Before the fix, only addEntry enforced that a
+ * full DN had to terminate with `,this.base`. Callers scoped to one resource
+ * (e.g. /ldap/titles) could pass a DN pointing at another branch (e.g.
+ * ou=groups,...) and read/modify/delete entries outside the resource's scope.
+ */
+
+import { expect } from 'chai';
+import supertest from 'supertest';
+import LdapFlatGeneric from '../../../src/plugins/ldap/flatGeneric';
+import { DM } from '../../../src/bin';
+import { BadRequestError } from '../../../src/lib/errors';
+import { skipIfMissingEnvVars, LDAP_ENV_VARS } from '../../helpers/env';
+
+describe('LdapFlat base-scope guard', function () {
+  before(function () {
+    skipIfMissingEnvVars(this, [...LDAP_ENV_VARS]);
+  });
+
+  let server: DM;
+  let plugin: LdapFlatGeneric;
+  let instance: LdapFlatGeneric['instances'][number];
+  let request: any;
+  let BASE: string;
+  let TITLE_BRANCH: string;
+  let FOREIGN_DN: string;
+
+  before(async function () {
+    this.timeout(5000);
+    process.env.DM_LDAP_FLAT_SCHEMA =
+      './static/schemas/twake/nomenclature/twakeTitle.json';
+    server = new DM();
+    await server.ready;
+    plugin = new LdapFlatGeneric(server);
+    await server.registerPlugin('ldapFlatBaseScope', plugin);
+    request = supertest(server.app);
+    instance = plugin.instances[0];
+    BASE = process.env.DM_LDAP_BASE as string;
+    TITLE_BRANCH = `ou=twakeTitle,ou=nomenclature,${BASE}`;
+    // A DN that sits OUTSIDE the title branch — representative of the bypass
+    FOREIGN_DN = `uid=admin,ou=users,${BASE}`;
+  });
+
+  /**
+   * Encode the DN the way clients send it in the URL path.
+   */
+  const enc = (dn: string) => encodeURIComponent(dn);
+
+  describe('direct method calls', () => {
+    it('addEntry rejects a DN outside the branch', async () => {
+      try {
+        await instance.addEntry(FOREIGN_DN);
+        throw new Error('expected BadRequestError');
+      } catch (err) {
+        expect(err).to.be.instanceOf(BadRequestError);
+        expect((err as Error).message).to.match(/must be in the branch/i);
+      }
+    });
+
+    it('modifyEntry rejects a DN outside the branch', async () => {
+      try {
+        await instance.modifyEntry(FOREIGN_DN, {
+          replace: { description: 'hijacked' },
+        });
+        throw new Error('expected BadRequestError');
+      } catch (err) {
+        expect(err).to.be.instanceOf(BadRequestError);
+      }
+    });
+
+    it('deleteEntry rejects a DN outside the branch', async () => {
+      try {
+        await instance.deleteEntry(FOREIGN_DN);
+        throw new Error('expected BadRequestError');
+      } catch (err) {
+        expect(err).to.be.instanceOf(BadRequestError);
+      }
+    });
+
+    it('renameEntry rejects a source DN outside the branch', async () => {
+      try {
+        await instance.renameEntry(FOREIGN_DN, 'cn=new');
+        throw new Error('expected BadRequestError');
+      } catch (err) {
+        expect(err).to.be.instanceOf(BadRequestError);
+      }
+    });
+
+    it('renameEntry rejects a target DN outside the branch', async () => {
+      try {
+        await instance.renameEntry('cn=existing', FOREIGN_DN);
+        throw new Error('expected BadRequestError');
+      } catch (err) {
+        expect(err).to.be.instanceOf(BadRequestError);
+      }
+    });
+
+    it('moveEntry rejects a DN outside the branch', async () => {
+      try {
+        await instance.moveEntry(FOREIGN_DN, TITLE_BRANCH);
+        throw new Error('expected BadRequestError');
+      } catch (err) {
+        expect(err).to.be.instanceOf(BadRequestError);
+      }
+    });
+  });
+
+  describe('HTTP API', () => {
+    it('GET rejects a DN outside the branch', async () => {
+      const res = await request.get(`/api/v1/ldap/titles/${enc(FOREIGN_DN)}`);
+      expect(res.status).to.equal(400);
+    });
+
+    it('PUT rejects a DN outside the branch', async () => {
+      const res = await request
+        .put(`/api/v1/ldap/titles/${enc(FOREIGN_DN)}`)
+        .send({ replace: { description: 'hijacked' } });
+      expect(res.status).to.equal(400);
+    });
+
+    it('DELETE rejects a DN outside the branch', async () => {
+      const res = await request.delete(
+        `/api/v1/ldap/titles/${enc(FOREIGN_DN)}`
+      );
+      expect(res.status).to.equal(400);
+    });
+
+    it('POST /move rejects a source DN outside the branch', async () => {
+      const res = await request
+        .post(`/api/v1/ldap/titles/${enc(FOREIGN_DN)}/move`)
+        .send({ targetOrgDn: TITLE_BRANCH });
+      expect(res.status).to.equal(400);
+    });
+
+    it('POST (add) rejects a DN outside the branch in the main attribute', async () => {
+      const res = await request
+        .post('/api/v1/ldap/titles')
+        .send({ cn: `cn=Foo,ou=somethingElse,${BASE}` });
+      expect(res.status).to.equal(400);
+    });
+  });
+
+  describe('positive path (in-branch DN still accepted)', () => {
+    const uid = 'TestScopedTitle';
+    const inBranchDn = () => `cn=${uid},${TITLE_BRANCH}`;
+
+    afterEach(async () => {
+      try {
+        await instance.deleteEntry(uid);
+      } catch (e) {
+        // ignore
+      }
+    });
+
+    it('accepts the full DN when it ends with the base (exact case)', async () => {
+      await instance.addEntry(inBranchDn());
+      const res = await request.get(`/api/v1/ldap/titles/${enc(inBranchDn())}`);
+      expect(res.status).to.equal(200);
+      expect(res.body).to.have.property('cn', uid);
+    });
+
+    it('accepts the full DN with mixed-case suffix (LDAP is case-insensitive)', async () => {
+      await instance.addEntry(uid);
+      const mixedCase = `cn=${uid},OU=twakeTitle,ou=Nomenclature,${BASE}`;
+      const res = await request.get(`/api/v1/ldap/titles/${enc(mixedCase)}`);
+      // LDAP will resolve it (case-insensitive compare) — the guard must not block it
+      expect(res.status).to.equal(200);
+    });
+  });
+});

--- a/test/plugins/ldap/ldapFlatBaseScope.test.ts
+++ b/test/plugins/ldap/ldapFlatBaseScope.test.ts
@@ -40,8 +40,11 @@ describe('LdapFlat base-scope guard', function () {
     instance = plugin.instances[0];
     BASE = process.env.DM_LDAP_BASE as string;
     TITLE_BRANCH = `ou=twakeTitle,ou=nomenclature,${BASE}`;
-    // A DN that sits OUTSIDE the title branch — representative of the bypass
-    FOREIGN_DN = `uid=admin,ou=users,${BASE}`;
+    // A DN that sits OUTSIDE the title branch — representative of the bypass.
+    // We use the same RDN attribute (cn) as the title branch so the guard's
+    // DN-detection triggers; different-attribute DNs are handled by the escape
+    // path and tested separately below.
+    FOREIGN_DN = `cn=hijacked,ou=users,${BASE}`;
   });
 
   /**
@@ -82,7 +85,7 @@ describe('LdapFlat base-scope guard', function () {
 
     it('renameEntry rejects a source DN outside the branch', async () => {
       try {
-        await instance.renameEntry(FOREIGN_DN, 'cn=new');
+        await instance.renameEntry(FOREIGN_DN, 'NewTitleName');
         throw new Error('expected BadRequestError');
       } catch (err) {
         expect(err).to.be.instanceOf(BadRequestError);
@@ -90,8 +93,10 @@ describe('LdapFlat base-scope guard', function () {
     });
 
     it('renameEntry rejects a target DN outside the branch', async () => {
+      // Source is a valid in-branch DN so the rejection comes from the target.
+      const validSource = `cn=some-existing,${TITLE_BRANCH}`;
       try {
-        await instance.renameEntry('cn=existing', FOREIGN_DN);
+        await instance.renameEntry(validSource, FOREIGN_DN);
         throw new Error('expected BadRequestError');
       } catch (err) {
         expect(err).to.be.instanceOf(BadRequestError);
@@ -168,6 +173,18 @@ describe('LdapFlat base-scope guard', function () {
       const res = await request.get(`/api/v1/ldap/titles/${enc(mixedCase)}`);
       // LDAP will resolve it (case-insensitive compare) — the guard must not block it
       expect(res.status).to.equal(200);
+    });
+
+    it('does not misclassify a main-attribute value containing a comma as a DN', () => {
+      // Regression caught during review: with a naive comma-based heuristic,
+      // values like "Smith, John" (legitimate for a cn-based branch) would be
+      // treated as DNs and rejected by the suffix check. The guard must only
+      // trigger when the id actually starts with `mainAttribute=`.
+      const valueWithComma = 'Smith, John';
+      const dn = (
+        instance as unknown as { resolveDn: (id: string) => string }
+      ).resolveDn(valueWithComma);
+      expect(dn).to.equal(`cn=Smith\\, John,${TITLE_BRANCH}`);
     });
   });
 });


### PR DESCRIPTION
## Summary

`LdapFlat` exposes generic CRUD routes where the `:id` path parameter is either an RDN value or a full DN. Before this change only `addEntry` validated that a full DN stayed inside the instance's base branch — `apiGet`, `modifyEntry`, `renameEntry`, `deleteEntry` and `moveEntry` did not.

A caller authorized on one resource (e.g. `/api/v1/ldap/titles`) could therefore **read, modify, rename, delete or move** entries in **another** branch by passing a full DN pointing at it. This bypasses the per-resource scoping that plugins like `authzDynamic` rely on.

Impact is moderate in practice (many deployments already expose the whole directory through a trusted plugin), but easy to prevent and valuable for any deployment that scopes access per resource.

## Changes

- Add `LdapFlat#resolveDn(id)` — when the id is a full DN it must terminate with `,this.base` (comparison is case-insensitive, matching LDAP semantics); otherwise a `BadRequestError` is thrown.
- Route `apiGet`, `modifyEntry`, `renameEntry` (both source and target DN), `deleteEntry` and `moveEntry` through the helper. `addEntry` now uses the same helper instead of inlining the check.
- New test file `test/plugins/ldap/ldapFlatBaseScope.test.ts` covering:
  - direct method calls for each of the 6 entry points (incl. both rename sides),
  - HTTP routes `GET`, `PUT`, `DELETE`, `POST /:id/move`, and `POST` (add with DN in the main attribute),
  - positive path: mixed-case in-branch DNs remain accepted.

## Test plan

- [x] `npm run test:one test/plugins/ldap/ldapFlatBaseScope.test.ts` — 13 passing
- [x] `npm run test:dev` — 695 passing, 7 pending, 0 failing
- [x] `npx tsc --noEmit` clean

## Credit

Vulnerability reported by a community user.