### PR TITLE
fix(security): reject escaped-comma DN injection in LdapFlat

### DIFF
--- a/docs/usage/plugins/auth/authz-dynamic.md
+++ b/docs/usage/plugins/auth/authz-dynamic.md
@@ -17,7 +17,7 @@ each SCIM client (or REST API consumer) is scoped to its own subtree.
 3. On a match, the plugin sets `req.user` to the tenant name and records the
    token's ACL in an `AsyncLocalStorage` context.
 4. Downstream LDAP operations (via `ldapActions.search / add / modify /
-   delete / rename`) trigger authz hooks that read the active token from the
+delete / rename`) trigger authz hooks that read the active token from the
    async context and throw if the requested DN is outside the allowed
    branches.
 5. The cache refreshes on a TTL (default 60 s) or on demand via a protected
@@ -39,14 +39,14 @@ node lib/bin/index.js \
 
 ### CLI / environment
 
-| Argument | Environment | Default | Purpose |
-|---|---|---|---|
-| `--authz-dynamic-base` | `DM_AUTHZ_DYNAMIC_BASE` | — (required) | LDAP branch that contains the token entries |
-| `--authz-dynamic-cache-ttl` | `DM_AUTHZ_DYNAMIC_CACHE_TTL` | `60` | Cache refresh interval in seconds |
-| `--authz-dynamic-token-attribute` | `DM_AUTHZ_DYNAMIC_TOKEN_ATTRIBUTE` | `userPassword` | Attribute holding the hashed bearer token |
-| `--authz-dynamic-config-attribute` | `DM_AUTHZ_DYNAMIC_CONFIG_ATTRIBUTE` | `description` | Attribute holding the JSON ACL document |
-| `--authz-dynamic-tenant-attribute` | `DM_AUTHZ_DYNAMIC_TENANT_ATTRIBUTE` | `cn` | Attribute from which `req.user` is read |
-| `--authz-dynamic-reload-endpoint` | `DM_AUTHZ_DYNAMIC_RELOAD_ENDPOINT` | `false` | Register `POST /api/v1/authz-dynamic/reload` for manual cache refresh |
+| Argument                           | Environment                         | Default        | Purpose                                                               |
+| ---------------------------------- | ----------------------------------- | -------------- | --------------------------------------------------------------------- |
+| `--authz-dynamic-base`             | `DM_AUTHZ_DYNAMIC_BASE`             | — (required)   | LDAP branch that contains the token entries                           |
+| `--authz-dynamic-cache-ttl`        | `DM_AUTHZ_DYNAMIC_CACHE_TTL`        | `60`           | Cache refresh interval in seconds                                     |
+| `--authz-dynamic-token-attribute`  | `DM_AUTHZ_DYNAMIC_TOKEN_ATTRIBUTE`  | `userPassword` | Attribute holding the hashed bearer token                             |
+| `--authz-dynamic-config-attribute` | `DM_AUTHZ_DYNAMIC_CONFIG_ATTRIBUTE` | `description`  | Attribute holding the JSON ACL document                               |
+| `--authz-dynamic-tenant-attribute` | `DM_AUTHZ_DYNAMIC_TENANT_ATTRIBUTE` | `cn`           | Attribute from which `req.user` is read                               |
+| `--authz-dynamic-reload-endpoint`  | `DM_AUTHZ_DYNAMIC_RELOAD_ENDPOINT`  | `false`        | Register `POST /api/v1/authz-dynamic/reload` for manual cache refresh |
 
 ## Token entry shape
 
@@ -92,14 +92,14 @@ description: {
 
 Handled by a constant-time verifier (`authzDynamicHash.ts`):
 
-| Scheme | Notes |
-|---|---|
-| `{SSHA}` | salted SHA-1 — OpenLDAP default, recommended minimum |
-| `{SHA}` | unsalted SHA-1 — legacy |
-| `{SSHA256}` / `{SHA256}` | salted / unsalted SHA-256 |
-| `{SSHA512}` / `{SHA512}` | salted / unsalted SHA-512 |
-| `{SMD5}` / `{MD5}` | salted / unsalted MD5 — legacy, avoid |
-| `{CLEARTEXT}` / `{PLAIN}` / no prefix | cleartext — test environments only |
+| Scheme                                | Notes                                                |
+| ------------------------------------- | ---------------------------------------------------- |
+| `{SSHA}`                              | salted SHA-1 — OpenLDAP default, recommended minimum |
+| `{SHA}`                               | unsalted SHA-1 — legacy                              |
+| `{SSHA256}` / `{SHA256}`              | salted / unsalted SHA-256                            |
+| `{SSHA512}` / `{SHA512}`              | salted / unsalted SHA-512                            |
+| `{SMD5}` / `{MD5}`                    | salted / unsalted MD5 — legacy, avoid                |
+| `{CLEARTEXT}` / `{PLAIN}` / no prefix | cleartext — test environments only                   |
 
 To generate an `{SSHA}` hash with OpenLDAP tools: `slappasswd -h '{SSHA}'`.
 To generate programmatically, `ssha(token)` is also exported from

--- a/docs/usage/plugins/auth/authz-dynamic.md
+++ b/docs/usage/plugins/auth/authz-dynamic.md
@@ -16,10 +16,7 @@ each SCIM client (or REST API consumer) is scoped to its own subtree.
    (timing-safe comparison).
 3. On a match, the plugin sets `req.user` to the tenant name and records the
    token's ACL in an `AsyncLocalStorage` context.
-4. Downstream LDAP operations (via `ldapActions.search / add / modify /
-delete / rename`) trigger authz hooks that read the active token from the
-   async context and throw if the requested DN is outside the allowed
-   branches.
+4. Downstream LDAP operations (via `ldapActions.search / add / modify / delete / rename`) trigger authz hooks that read the active token from the async context and throw if the requested DN is outside the allowed branches.
 5. The cache refreshes on a TTL (default 60 s) or on demand via a protected
    reload endpoint.
 

--- a/docs/usage/plugins/integrations/scim.md
+++ b/docs/usage/plugins/integrations/scim.md
@@ -41,26 +41,26 @@ All SCIM endpoints sit behind the auth middleware registered before the plugin
 
 ### CLI / environment
 
-| Argument | Environment | Default | Description |
-|---|---|---|---|
-| `--scim-prefix` | `DM_SCIM_PREFIX` | `/scim/v2` | Base URL path for all SCIM endpoints |
-| `--scim-user-base` | `DM_SCIM_USER_BASE` | `{ldap_base}` | LDAP branch containing users |
-| `--scim-group-base` | `DM_SCIM_GROUP_BASE` | `{ldap_base}` | LDAP branch containing groups |
-| `--scim-user-base-template` | `DM_SCIM_USER_BASE_TEMPLATE` | — | DN template with `{user}` placeholder (see *multi-tenant*) |
-| `--scim-group-base-template` | `DM_SCIM_GROUP_BASE_TEMPLATE` | — | Same for groups |
-| `--scim-base-map` | `DM_SCIM_BASE_MAP` | — | Path to JSON file mapping authenticated user → `{userBase, groupBase}` |
-| `--scim-user-object-class` | `DM_SCIM_USER_OBJECT_CLASSES` | `top, inetOrgPerson, organizationalPerson, person` | Object classes for created Users |
-| `--scim-user-rdn-attribute` | `DM_SCIM_USER_RDN_ATTRIBUTE` | `uid` | RDN attribute for Users |
-| `--scim-group-object-class` | `DM_SCIM_GROUP_OBJECT_CLASSES` | `top, groupOfNames` | Object classes for created Groups |
-| `--scim-group-rdn-attribute` | `DM_SCIM_GROUP_RDN_ATTRIBUTE` | `cn` | RDN attribute for Groups |
-| `--scim-id-attribute` | `DM_SCIM_ID_ATTRIBUTE` | `rdn` | `rdn` (default) or `entryUUID` for SCIM `id` |
-| `--scim-user-mapping` | `DM_SCIM_USER_MAPPING` | — | Path to JSON mapping override |
-| `--scim-group-mapping` | `DM_SCIM_GROUP_MAPPING` | — | Same for Groups |
-| `--scim-max-results` | `DM_SCIM_MAX_RESULTS` | `200` | Hard cap on list results |
-| `--scim-bulk-max-operations` | `DM_SCIM_BULK_MAX_OPERATIONS` | `100` | Max `/Bulk` operations per request |
-| `--scim-bulk-max-payload-size` | `DM_SCIM_BULK_MAX_PAYLOAD_SIZE` | `1048576` | Max `/Bulk` payload size in bytes |
-| `--scim-etag` | `DM_SCIM_ETAG` | `false` | Advertise ETag support in discovery (not yet implemented) |
-| `--scim-base-url` | `DM_SCIM_BASE_URL` | auto from request | Override external base URL for `meta.location` values |
+| Argument                       | Environment                     | Default                                            | Description                                                            |
+| ------------------------------ | ------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------- |
+| `--scim-prefix`                | `DM_SCIM_PREFIX`                | `/scim/v2`                                         | Base URL path for all SCIM endpoints                                   |
+| `--scim-user-base`             | `DM_SCIM_USER_BASE`             | `{ldap_base}`                                      | LDAP branch containing users                                           |
+| `--scim-group-base`            | `DM_SCIM_GROUP_BASE`            | `{ldap_base}`                                      | LDAP branch containing groups                                          |
+| `--scim-user-base-template`    | `DM_SCIM_USER_BASE_TEMPLATE`    | —                                                  | DN template with `{user}` placeholder (see _multi-tenant_)             |
+| `--scim-group-base-template`   | `DM_SCIM_GROUP_BASE_TEMPLATE`   | —                                                  | Same for groups                                                        |
+| `--scim-base-map`              | `DM_SCIM_BASE_MAP`              | —                                                  | Path to JSON file mapping authenticated user → `{userBase, groupBase}` |
+| `--scim-user-object-class`     | `DM_SCIM_USER_OBJECT_CLASSES`   | `top, inetOrgPerson, organizationalPerson, person` | Object classes for created Users                                       |
+| `--scim-user-rdn-attribute`    | `DM_SCIM_USER_RDN_ATTRIBUTE`    | `uid`                                              | RDN attribute for Users                                                |
+| `--scim-group-object-class`    | `DM_SCIM_GROUP_OBJECT_CLASSES`  | `top, groupOfNames`                                | Object classes for created Groups                                      |
+| `--scim-group-rdn-attribute`   | `DM_SCIM_GROUP_RDN_ATTRIBUTE`   | `cn`                                               | RDN attribute for Groups                                               |
+| `--scim-id-attribute`          | `DM_SCIM_ID_ATTRIBUTE`          | `rdn`                                              | `rdn` (default) or `entryUUID` for SCIM `id`                           |
+| `--scim-user-mapping`          | `DM_SCIM_USER_MAPPING`          | —                                                  | Path to JSON mapping override                                          |
+| `--scim-group-mapping`         | `DM_SCIM_GROUP_MAPPING`         | —                                                  | Same for Groups                                                        |
+| `--scim-max-results`           | `DM_SCIM_MAX_RESULTS`           | `200`                                              | Hard cap on list results                                               |
+| `--scim-bulk-max-operations`   | `DM_SCIM_BULK_MAX_OPERATIONS`   | `100`                                              | Max `/Bulk` operations per request                                     |
+| `--scim-bulk-max-payload-size` | `DM_SCIM_BULK_MAX_PAYLOAD_SIZE` | `1048576`                                          | Max `/Bulk` payload size in bytes                                      |
+| `--scim-etag`                  | `DM_SCIM_ETAG`                  | `false`                                            | Advertise ETag support in discovery (not yet implemented)              |
+| `--scim-base-url`              | `DM_SCIM_BASE_URL`              | auto from request                                  | Override external base URL for `meta.location` values                  |
 
 ### Authentication
 
@@ -77,39 +77,39 @@ For Okta / Entra, load `core/auth/token` with a provisioning token.
 
 All responses have `Content-Type: application/scim+json`.
 
-| Method | Path | Description |
-|---|---|---|
-| GET  | `/Users` | List Users (filter, pagination, sort) |
-| GET  | `/Users/{id}` | Get a User |
-| POST | `/Users` | Create a User |
-| PUT  | `/Users/{id}` | Replace a User |
-| PATCH| `/Users/{id}` | Partial update (add/remove/replace) |
-| DELETE | `/Users/{id}` | Delete a User |
-| GET/POST/PUT/PATCH/DELETE | `/Groups[/{id}]` | Same operations on Groups |
-| POST | `/Bulk` | Batch operations with `bulkId` refs |
-| GET  | `/ServiceProviderConfig` | Capabilities |
-| GET  | `/ResourceTypes` / `/ResourceTypes/{name}` | Resource metadata |
-| GET  | `/Schemas` / `/Schemas/{urn}` | Schema definitions |
+| Method                    | Path                                       | Description                           |
+| ------------------------- | ------------------------------------------ | ------------------------------------- |
+| GET                       | `/Users`                                   | List Users (filter, pagination, sort) |
+| GET                       | `/Users/{id}`                              | Get a User                            |
+| POST                      | `/Users`                                   | Create a User                         |
+| PUT                       | `/Users/{id}`                              | Replace a User                        |
+| PATCH                     | `/Users/{id}`                              | Partial update (add/remove/replace)   |
+| DELETE                    | `/Users/{id}`                              | Delete a User                         |
+| GET/POST/PUT/PATCH/DELETE | `/Groups[/{id}]`                           | Same operations on Groups             |
+| POST                      | `/Bulk`                                    | Batch operations with `bulkId` refs   |
+| GET                       | `/ServiceProviderConfig`                   | Capabilities                          |
+| GET                       | `/ResourceTypes` / `/ResourceTypes/{name}` | Resource metadata                     |
+| GET                       | `/Schemas` / `/Schemas/{urn}`              | Schema definitions                    |
 
 ### Default mapping (LDAP ⇄ SCIM User)
 
-| SCIM | LDAP |
-|---|---|
-| `id` | `uid` (or `entryUUID`) |
-| `userName` | `uid` |
-| `externalId` | `employeeNumber` |
-| `name.familyName` | `sn` |
-| `name.givenName` | `givenName` |
-| `name.formatted` | `cn` |
-| `displayName` | `displayName` |
-| `title` | `title` |
-| `preferredLanguage` | `preferredLanguage` |
-| `emails[primary=true].value` | `mail` |
-| `emails[primary=false].value` | `mailAlternateAddress` |
-| `phoneNumbers[primary=true].value` | `telephoneNumber` |
-| `phoneNumbers[primary=false].value` | `mobile` |
-| `active` | pseudo (false if `pwdAccountLockedTime` is set) |
-| `meta.created` / `meta.lastModified` | `createTimestamp` / `modifyTimestamp` |
+| SCIM                                 | LDAP                                            |
+| ------------------------------------ | ----------------------------------------------- |
+| `id`                                 | `uid` (or `entryUUID`)                          |
+| `userName`                           | `uid`                                           |
+| `externalId`                         | `employeeNumber`                                |
+| `name.familyName`                    | `sn`                                            |
+| `name.givenName`                     | `givenName`                                     |
+| `name.formatted`                     | `cn`                                            |
+| `displayName`                        | `displayName`                                   |
+| `title`                              | `title`                                         |
+| `preferredLanguage`                  | `preferredLanguage`                             |
+| `emails[primary=true].value`         | `mail`                                          |
+| `emails[primary=false].value`        | `mailAlternateAddress`                          |
+| `phoneNumbers[primary=true].value`   | `telephoneNumber`                               |
+| `phoneNumbers[primary=false].value`  | `mobile`                                        |
+| `active`                             | pseudo (false if `pwdAccountLockedTime` is set) |
+| `meta.created` / `meta.lastModified` | `createTimestamp` / `modifyTimestamp`           |
 
 Override with `--scim-user-mapping /path/to/user-mapping.json` (same schema as
 `static/schemas/scim/default-mapping.json`).
@@ -135,16 +135,16 @@ and `--scim-group-mapping`.
 
 Each element of `entries` is a `MappingEntry` with the following optional fields:
 
-| Field | Purpose |
-|---|---|
-| `scim` | **Required.** Top-level SCIM attribute name (`userName`, `displayName`, `emails`, …). |
-| `ldap` | Simple 1:1 mapping to an LDAP attribute. |
-| `ldapPrimary` | For multi-valued SCIM attributes (`emails`, `phoneNumbers`, …), the LDAP attribute that stores the *primary* value. |
-| `ldapSecondary` | LDAP attribute that stores the *non-primary* values of the same SCIM attribute (array). |
-| `sub` | Object that maps SCIM sub-attributes to LDAP attributes. Used for complex SCIM values like `name.familyName` → `sn`. |
-| `multi` | `"array"` or `"single"` (default) — hints array serialization for `ldap`. |
-| `readOnly` | `true` to skip this attribute on write (create/update ignore it). |
-| `operational` | `true` for LDAP operational attributes (e.g. `entryUUID`) — loaded on read only. |
+| Field           | Purpose                                                                                                              |
+| --------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `scim`          | **Required.** Top-level SCIM attribute name (`userName`, `displayName`, `emails`, …).                                |
+| `ldap`          | Simple 1:1 mapping to an LDAP attribute.                                                                             |
+| `ldapPrimary`   | For multi-valued SCIM attributes (`emails`, `phoneNumbers`, …), the LDAP attribute that stores the _primary_ value.  |
+| `ldapSecondary` | LDAP attribute that stores the _non-primary_ values of the same SCIM attribute (array).                              |
+| `sub`           | Object that maps SCIM sub-attributes to LDAP attributes. Used for complex SCIM values like `name.familyName` → `sn`. |
+| `multi`         | `"array"` or `"single"` (default) — hints array serialization for `ldap`.                                            |
+| `readOnly`      | `true` to skip this attribute on write (create/update ignore it).                                                    |
+| `operational`   | `true` for LDAP operational attributes (e.g. `entryUUID`) — loaded on read only.                                     |
 
 ### Merging
 
@@ -235,15 +235,15 @@ mapping file describes the internal translation.
 SCIM filters are translated to LDAP filters (RFC 4515). Values are always escaped
 via `escapeLdapFilter()` — no LDAP injection is possible.
 
-| SCIM | LDAP |
-|---|---|
-| `userName eq "alice"` | `(uid=alice)` |
-| `name.familyName sw "Du"` | `(sn=Du*)` |
-| `emails.value co "@example.com"` | `(mail=*@example.com*)` |
-| `displayName pr` | `(displayName=*)` |
-| `active eq true` | `(!(pwdAccountLockedTime=*))` |
-| `a eq "x" and b eq "y"` | `(&(a=x)(b=y))` |
-| `not (a eq "x")` | `(!(a=x))` |
+| SCIM                             | LDAP                          |
+| -------------------------------- | ----------------------------- |
+| `userName eq "alice"`            | `(uid=alice)`                 |
+| `name.familyName sw "Du"`        | `(sn=Du*)`                    |
+| `emails.value co "@example.com"` | `(mail=*@example.com*)`       |
+| `displayName pr`                 | `(displayName=*)`             |
+| `active eq true`                 | `(!(pwdAccountLockedTime=*))` |
+| `a eq "x" and b eq "y"`          | `(&(a=x)(b=y))`               |
+| `not (a eq "x")`                 | `(!(a=x))`                    |
 
 Unknown SCIM attributes raise `400 invalidFilter`.
 
@@ -259,13 +259,13 @@ without any client-visible distinction.
 Whichever auth plugin runs before SCIM must set `req.user` to a string that
 identifies the caller. Supported out of the box:
 
-| Auth plugin | `req.user` value |
-|---|---|
-| `core/auth/token` | the `name` field of `--auth-token "id:secret:name"` |
-| `core/auth/openidconnect` | the subject / preferred_username from the OIDC token |
-| `core/auth/hmac` | the HMAC key id |
-| `core/auth/trustedProxy` | the value of `--trusted-proxy-auth-header` (default `Auth-User`) |
-| `core/auth/llng` | the LemonLDAP::NG user id |
+| Auth plugin               | `req.user` value                                                 |
+| ------------------------- | ---------------------------------------------------------------- |
+| `core/auth/token`         | the `name` field of `--auth-token "id:secret:name"`              |
+| `core/auth/openidconnect` | the subject / preferred_username from the OIDC token             |
+| `core/auth/hmac`          | the HMAC key id                                                  |
+| `core/auth/trustedProxy`  | the value of `--trusted-proxy-auth-header` (default `Auth-User`) |
+| `core/auth/llng`          | the LemonLDAP::NG user id                                        |
 
 In the examples below we use `core/auth/token`, but any of the above works the
 same way — the SCIM plugin only reads `req.user`.
@@ -292,15 +292,15 @@ Create `/etc/ldap-rest/scim-tenants.json`:
 ```json
 {
   "okta-acme": {
-    "userBase":  "ou=users,ou=acme,dc=example,dc=com",
+    "userBase": "ou=users,ou=acme,dc=example,dc=com",
     "groupBase": "ou=groups,ou=acme,dc=example,dc=com"
   },
   "entra-globex": {
-    "userBase":  "ou=users,ou=globex,dc=example,dc=com",
+    "userBase": "ou=users,ou=globex,dc=example,dc=com",
     "groupBase": "ou=groups,ou=globex,dc=example,dc=com"
   },
   "*": {
-    "userBase":  "ou=users,dc=example,dc=com",
+    "userBase": "ou=users,dc=example,dc=com",
     "groupBase": "ou=groups,dc=example,dc=com"
   }
 }
@@ -486,9 +486,14 @@ Response shape (truncated):
         "defaultMapping": "/static/schemas/scim/default-mapping.json"
       },
       "capabilities": {
-        "patch": true, "bulk": true, "filter": true, "sort": true,
-        "etag": false, "changePassword": false,
-        "maxResults": 200, "bulkMaxOperations": 100,
+        "patch": true,
+        "bulk": true,
+        "filter": true,
+        "sort": true,
+        "etag": false,
+        "changePassword": false,
+        "maxResults": 200,
+        "bulkMaxOperations": 100,
         "bulkMaxPayloadSize": 1048576
       },
       "resourceTypes": [
@@ -497,16 +502,33 @@ Response shape (truncated):
           "endpoint": "/scim/v2/Users",
           "schema": "urn:ietf:params:scim:schemas:core:2.0:User",
           "rdnAttribute": "uid",
-          "objectClass": ["top", "inetOrgPerson", "organizationalPerson", "person"],
-          "filterableAttributes": ["userName", "externalId", "name", "displayName", "...", "id", "active"],
-          "mapping": [ /* same shape as default-mapping.json */ ]
+          "objectClass": [
+            "top",
+            "inetOrgPerson",
+            "organizationalPerson",
+            "person"
+          ],
+          "filterableAttributes": [
+            "userName",
+            "externalId",
+            "name",
+            "displayName",
+            "...",
+            "id",
+            "active"
+          ],
+          "mapping": [
+            /* same shape as default-mapping.json */
+          ]
         },
         {
           "id": "Group",
           "endpoint": "/scim/v2/Groups",
           "schema": "urn:ietf:params:scim:schemas:core:2.0:Group",
           "rdnAttribute": "cn",
-          "mapping": [ /* ... */ ]
+          "mapping": [
+            /* ... */
+          ]
         }
       ],
       "idStrategy": "rdn",

--- a/src/abstract/ldapFlat.ts
+++ b/src/abstract/ldapFlat.ts
@@ -32,6 +32,7 @@ import {
   escapeLdapFilter,
   escapeRegex,
   getCompiledRegex,
+  getParentDn,
   launchHooks,
   launchHooksChained,
   transformSchemas,
@@ -278,12 +279,15 @@ export default abstract class LdapFlat extends DmPlugin {
    * This matters for cn-based branches where values like `Smith, John` are
    * legal and must not be misclassified as DNs.
    *
-   * When the id is a full DN we enforce that it terminates with `,this.base`
-   * (comparison is case-insensitive, matching LDAP semantics). Without this
-   * check a caller scoped to one resource could address entries outside that
-   * scope by passing a full DN from a sibling branch.
+   * When the id is a full DN we enforce that its parent equals this.base
+   * (LdapFlat entries are, by definition, direct children of the base).
+   * The comparison is done on the parsed RDN components so escape-aware
+   * payloads like `cn=pwn\,ou=titles,ou=nomenclature,dc=example,dc=com`
+   * cannot sneak past a naive textual suffix check: `\,` is a literal comma
+   * inside the first RDN's value, so the actual parent of that DN is
+   * `ou=nomenclature,dc=example,dc=com` — one level above the expected base.
    *
-   * @throws BadRequestError if the provided DN is not under this.base
+   * @throws BadRequestError if the provided DN is not a direct child of this.base
    */
   protected resolveDn(id: string): string {
     const dnPrefix = new RegExp(
@@ -291,11 +295,14 @@ export default abstract class LdapFlat extends DmPlugin {
       'i'
     );
     if (dnPrefix.test(id)) {
-      const expectedSuffix = `,${this.base}`;
-      if (!id.toLowerCase().endsWith(expectedSuffix.toLowerCase())) {
+      const parent = getParentDn(id);
+      // If the DN has a single RDN, getParentDn returns the DN itself; treat
+      // that as "missing parent" rather than "parent equals base".
+      const hasParent = parent !== id;
+      if (!hasParent || parent.toLowerCase() !== this.base.toLowerCase()) {
         throw new BadRequestError(
-          `DN must be in the branch "${this.base}". ` +
-            `Provided DN "${id}" does not end with "${expectedSuffix}"`
+          `DN must be a direct child of "${this.base}". ` +
+            `Provided DN "${id}" has parent "${hasParent ? parent : ''}"`
         );
       }
       return id;

--- a/src/abstract/ldapFlat.ts
+++ b/src/abstract/ldapFlat.ts
@@ -302,7 +302,7 @@ export default abstract class LdapFlat extends DmPlugin {
       if (!hasParent || parent.toLowerCase() !== this.base.toLowerCase()) {
         throw new BadRequestError(
           `DN must be a direct child of "${this.base}". ` +
-            `Provided DN "${id}" has parent "${hasParent ? parent : ''}"`
+            `Provided DN "${id}" has parent "${hasParent ? parent : '<none>'}"`
         );
       }
       return id;

--- a/test/plugins/ldap/ldapFlatBaseScope.test.ts
+++ b/test/plugins/ldap/ldapFlatBaseScope.test.ts
@@ -59,7 +59,9 @@ describe('LdapFlat base-scope guard', function () {
         throw new Error('expected BadRequestError');
       } catch (err) {
         expect(err).to.be.instanceOf(BadRequestError);
-        expect((err as Error).message).to.match(/must be in the branch/i);
+        expect((err as Error).message).to.match(
+          /must be a direct child of/i
+        );
       }
     });
 
@@ -178,13 +180,13 @@ describe('LdapFlat base-scope guard', function () {
     it('rejects a partial DN (prefix without base) rather than producing a malformed DN', () => {
       // Regression caught during review: "cn=foo" starts with the main
       // attribute but is not a full DN. It must be rejected cleanly by the
-      // suffix check, not silently re-escaped into `cn=cn\=foo,<base>` with
-      // an attribute value that no longer matches the RDN.
+      // guard, not silently re-escaped into `cn=cn\=foo,<base>` with an
+      // attribute value that no longer matches the RDN.
       expect(() =>
         (
           instance as unknown as { resolveDn: (id: string) => string }
         ).resolveDn('cn=foo')
-      ).to.throw(BadRequestError, /must be in the branch/i);
+      ).to.throw(BadRequestError, /must be a direct child of/i);
     });
 
     it('does not misclassify a main-attribute value containing a comma as a DN', () => {
@@ -197,6 +199,70 @@ describe('LdapFlat base-scope guard', function () {
         instance as unknown as { resolveDn: (id: string) => string }
       ).resolveDn(valueWithComma);
       expect(dn).to.equal(`cn=Smith\\, John,${TITLE_BRANCH}`);
+    });
+  });
+
+  describe('escape-aware DN parsing (guards against RFC 4514 tricks)', () => {
+    const callResolve = (dn: string) =>
+      (
+        instance as unknown as { resolveDn: (id: string) => string }
+      ).resolveDn(dn);
+
+    it('rejects a DN whose textual tail matches the base via an escaped comma in the first RDN', () => {
+      // Attack: `cn=pwn\,ou=twakeTitle,ou=nomenclature,<BASE>` textually
+      // ends with `,ou=twakeTitle,ou=nomenclature,<BASE>`, so a naive
+      // `endsWith` check would accept it. But per RFC 4514 `\,` is a
+      // literal comma inside the first RDN value, so the entry's real
+      // parent is `ou=nomenclature,<BASE>` — a sibling of the titles
+      // branch. Passing this DN through to ldapts would let a titles-API
+      // caller create/read/modify/delete entries outside the titles
+      // branch.
+      const malicious = `cn=pwn\\,ou=twakeTitle,ou=nomenclature,${BASE}`;
+      expect(() => callResolve(malicious)).to.throw(
+        BadRequestError,
+        /must be a direct child of/i
+      );
+    });
+
+    it('rejects a DN whose tail matches via a deeply nested escaped comma', () => {
+      // Same trick, one RDN deeper: the entry's real parent would be
+      // `ou=other,<BASE>`, still outside the titles branch.
+      const malicious = `cn=pwn\\,deep,ou=other,ou=twakeTitle,ou=nomenclature,${BASE}`;
+      expect(() => callResolve(malicious)).to.throw(
+        BadRequestError,
+        /must be a direct child of/i
+      );
+    });
+
+    it('rejects an HTTP DELETE with an escaped-comma bypass payload', async () => {
+      // End-to-end: the decodeURIComponent'd path parameter must not reach
+      // ldap.delete with a DN whose real parent is outside the branch.
+      const malicious = `cn=pwn\\,ou=twakeTitle,ou=nomenclature,${BASE}`;
+      const res = await request.delete(
+        `/api/v1/ldap/titles/${enc(malicious)}`
+      );
+      expect(res.status).to.equal(400);
+    });
+
+    it('rejects an HTTP POST add with an escaped-comma bypass payload', async () => {
+      const malicious = `cn=pwn\\,ou=twakeTitle,ou=nomenclature,${BASE}`;
+      const res = await request
+        .post('/api/v1/ldap/titles')
+        .send({ cn: malicious });
+      expect(res.status).to.equal(400);
+    });
+
+    it('still accepts a legitimate direct child of the base', () => {
+      const dn = `cn=ValidTitle,${TITLE_BRANCH}`;
+      expect(callResolve(dn)).to.equal(dn);
+    });
+
+    it('still accepts a direct child with an escaped comma in the RDN value', () => {
+      // `cn=Smith\, John,<TITLE_BRANCH>` is a legitimate in-branch DN with a
+      // literal comma inside the cn value. The parent is the branch, not a
+      // sibling, so the guard must NOT reject it.
+      const dn = `cn=Smith\\, John,${TITLE_BRANCH}`;
+      expect(callResolve(dn)).to.equal(dn);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes a bypass of the per-branch scope guard introduced in #59.

`LdapFlat.resolveDn` was comparing user-supplied DNs to the plugin's base branch with a **raw, non-RFC-4514-aware string match** (`id.toLowerCase().endsWith(",<base>".toLowerCase())`). An attacker could embed an escaped comma inside the first RDN value so that the textual tail still matched the expected suffix, while the LDAP server — parsing the same string per RFC 4514 — treated \`\,\` as a literal comma inside the value and placed the entry's real parent one level above \`this.base\`.

## Exploit (pre-patch)

Plugin mounted on `/api/v1/ldap/titles` with `base=ou=titles,ou=nomenclature,dc=example,dc=com`, `mainAttribute=cn`.

```http
POST /api/v1/ldap/titles
Content-Type: application/json

{ "cn": "cn=pwn\\,ou=titles,ou=nomenclature,dc=example,dc=com" }
```

- `endsWith(",ou=titles,ou=nomenclature,dc=example,dc=com")` → `true`, guard accepts.
- `ldapts` is configured with `strictDN:false` (see `src/lib/ldapActions.ts`), so the DN is forwarded unchanged.
- OpenLDAP parses the first RDN as `cn=pwn\,ou=titles` with value `pwn,ou=titles`, placing the new entry under `ou=nomenclature,dc=example,dc=com` — **outside the titles branch**.

The identical payload URL-encoded into `GET|PUT|DELETE /api/v1/ldap/titles/:id`, `POST /api/v1/ldap/titles/:id/move`, and either DN of `renameEntry` gives the same cross-branch read / modify / delete / rename / move primitive, since all now route through `resolveDn`.

Without a per-branch authz plugin loaded (neither `authzDynamic` nor `authzPerBranch` are in the default plugin set), `resolveDn` is the only scope enforcement, so a titles-scoped caller could in principle touch any sibling branch whose name happens to align with the suffix check.

## Fix

Replace the textual `endsWith` with escape-aware structural parsing. `LdapFlat` entries are by definition **direct children** of the base, so the invariant the guard enforces is

```
getParentDn(id).toLowerCase() === this.base.toLowerCase()
```

`getParentDn` uses `parseDn`, which tokenises escaped commas correctly — `cn=pwn\,ou=titles,ou=nomenclature,...` is seen as a single RDN whose parent is `ou=nomenclature,...`, and rejected.

The error message also becomes more informative: it now reports the actual computed parent, which helps legitimate callers diagnose mis-scoped requests.

## Changes

- `src/abstract/ldapFlat.ts`: `resolveDn` switches from `endsWith` to `getParentDn(id) === this.base` (case-insensitive).
- `test/plugins/ldap/ldapFlatBaseScope.test.ts`:
  - Adds a new `describe('escape-aware DN parsing ...')` block with six tests: rejection of the classic escape-comma payload, of a deeper variant, of the HTTP `DELETE` and `POST` forms end-to-end, plus positive tests for a legitimate direct child and for a direct child whose RDN value legitimately contains `\,`.
  - Updates the existing assertions to the new error-message wording.

## Test plan

- [x] `npm run test:one test/plugins/ldap/ldapFlatBaseScope.test.ts` → 21 passing
- [x] `npm run test:dev` → 703 passing, 7 pending, 0 failing
- [x] `npx tsc --noEmit` clean

## Credit

Bypass identified by the `/security-review` pass on #59 after the merge.