### PR TITLE
feat(twake): add cozyProvision plugin for SCIM lifecycle on Cozy + RabbitMQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- New plugin `core/twake/cozyProvision`: hooks the SCIM lifecycle to
+  provision a Cozy instance after user creation and to publish
+  `auth` / `user.created` and `b2b` / `domain.user.deleted` events
+  on RabbitMQ. Reads `cozy_admin_url`, `cozy_admin_passphrase`,
+  `cozy_org_id`, `cozy_org_domain` and `rabbitmq_url` from config.
+  - Cozy admin call uses HTTP Basic with the configured passphrase;
+    `409 Conflict` is treated as idempotent success
+  - `@linagora/rabbitmq-client` is declared as an `optionalDependency`:
+    if not installed at runtime, AMQP publishes are skipped with a
+    one-time warning
+  - `workplaceFqdn` is composed as `${id}.${cozy_org_domain}`
+
 ## v0.3.1 (2026-04-29)
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "typescript": "^5.9.2"
       },
       "optionalDependencies": {
+        "@linagora/rabbitmq-client": "^0.1.2",
         "express-openid-connect": "^2.19.2",
         "lemonldap-ng-handler": "^0.7.3",
         "re2": "^1.22.1"
@@ -2050,6 +2051,20 @@
         "node-fetch": "^3.2.6"
       }
     },
+    "node_modules/@linagora/rabbitmq-client": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@linagora/rabbitmq-client/-/rabbitmq-client-0.1.2.tgz",
+      "integrity": "sha512-ZjL2PP3fbSz5tKhgBRl4G9arQTJj+qqeZFFQMMM+7VWceZ1+GXHqqvBACkwle0YEjOcKbPBGog2cQe21ovKHxw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "amqplib": "^0.10.7",
+        "pino": "^9.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.4.tgz",
@@ -2203,6 +2218,13 @@
       "dependencies": {
         "@noble/hashes": "^1.1.5"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
@@ -3930,6 +3952,20 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/amqplib": {
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.9.tgz",
+      "integrity": "sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "url-parse": "~1.5.10"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -4137,6 +4173,16 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -4347,6 +4393,13 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/bufferlist": {
       "version": "0.1.0",
@@ -8822,6 +8875,16 @@
         "node": "^10.13.0 || >=12.0.0"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -9268,6 +9331,46 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -9967,6 +10070,23 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "optional": true
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -10050,6 +10170,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10069,6 +10196,13 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -10149,6 +10283,16 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/rechoir": {
@@ -10239,6 +10383,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -10832,6 +10983,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/sort-object-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-2.1.0.tgz",
@@ -11319,6 +11480,16 @@
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/tildify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
@@ -11683,6 +11854,17 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "optional": true
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -192,6 +192,10 @@
       "types": "./dist/src/plugins/twake/calendarResources.d.ts",
       "import": "./dist/plugins/twake/calendarResources.js"
     },
+    "./plugin-twake-cozyprovision": {
+      "types": "./dist/src/plugins/twake/cozyProvision.d.ts",
+      "import": "./dist/plugins/twake/cozyProvision.js"
+    },
     "./plugin-twake-drive": {
       "types": "./dist/src/plugins/twake/drive.d.ts",
       "import": "./dist/plugins/twake/drive.js"
@@ -631,6 +635,7 @@
     "typescript": "^5.9.2"
   },
   "optionalDependencies": {
+    "@linagora/rabbitmq-client": "^0.1.2",
     "express-openid-connect": "^2.19.2",
     "lemonldap-ng-handler": "^0.7.3",
     "re2": "^1.22.1"

--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -174,6 +174,17 @@ export interface Config {
   calendar_resource_creator?: string;
   calendar_resource_domain?: string;
 
+  // Cozy provisioning plugin
+  cozy_admin_url?: string;
+  cozy_admin_user?: string;
+  cozy_admin_passphrase?: string;
+  cozy_org_id?: string;
+  cozy_org_domain?: string;
+  cozy_default_locale?: string;
+  cozy_auth_exchange?: string;
+  cozy_b2b_exchange?: string;
+  rabbitmq_url?: string;
+
   // Applicative Accounts plugin
   applicative_account_base?: string;
   max_app_accounts?: number;
@@ -445,6 +456,17 @@ const configArgs: ConfigTemplate = [
   ['--calendar-resource-creator', 'DM_CALENDAR_RESOURCE_CREATOR', ''],
   ['--calendar-resource-domain', 'DM_CALENDAR_RESOURCE_DOMAIN', ''],
 
+  // Cozy provisioning plugin (twake/cozyProvision)
+  ['--cozy-admin-url', 'DM_COZY_ADMIN_URL', ''],
+  ['--cozy-admin-user', 'DM_COZY_ADMIN_USER', 'admin'],
+  ['--cozy-admin-passphrase', 'DM_COZY_ADMIN_PASSPHRASE', ''],
+  ['--cozy-org-id', 'DM_COZY_ORG_ID', ''],
+  ['--cozy-org-domain', 'DM_COZY_ORG_DOMAIN', ''],
+  ['--cozy-default-locale', 'DM_COZY_DEFAULT_LOCALE', 'fr'],
+  ['--cozy-auth-exchange', 'DM_COZY_AUTH_EXCHANGE', 'auth'],
+  ['--cozy-b2b-exchange', 'DM_COZY_B2B_EXCHANGE', 'b2b'],
+  ['--rabbitmq-url', 'DM_RABBITMQ_URL', ''],
+
   // Applicative Accounts plugin
   ['--applicative-account-base', 'DM_APPLICATIVE_ACCOUNT_BASE', ''],
   ['--max-app-accounts', 'DM_MAX_APP_ACCOUNTS', 5, 'number'],
@@ -614,12 +636,7 @@ const configArgs: ConfigTemplate = [
   ['--scim-user-mapping', 'DM_SCIM_USER_MAPPING', ''],
   ['--scim-group-mapping', 'DM_SCIM_GROUP_MAPPING', ''],
   ['--scim-max-results', 'DM_SCIM_MAX_RESULTS', 200, 'number'],
-  [
-    '--scim-bulk-max-operations',
-    'DM_SCIM_BULK_MAX_OPERATIONS',
-    100,
-    'number',
-  ],
+  ['--scim-bulk-max-operations', 'DM_SCIM_BULK_MAX_OPERATIONS', 100, 'number'],
   [
     '--scim-bulk-max-payload-size',
     'DM_SCIM_BULK_MAX_PAYLOAD_SIZE',

--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -1,0 +1,372 @@
+/**
+ * @module plugins/twake/cozyProvision
+ *
+ * Provisions a Cozy instance and publishes lifecycle events on RabbitMQ when
+ * users are created or deleted via SCIM. Depends on cozy-stack admin API and
+ * an AMQP broker reachable from the ldap-rest process.
+ *
+ * Hooks:
+ *   - scimusercreatedone: POST /instances on cozy admin, then publish
+ *     `auth` / `user.created` so downstream services (cozy-stack, etc.)
+ *     can react.
+ *   - scimuserdeletedone: publish `b2b` / `domain.user.deleted` so peer
+ *     instances can clean up the deleted user's contact card.
+ *
+ * The RabbitMQ client (`@linagora/rabbitmq-client`) is declared as an
+ * optional dependency: if it is not installed at runtime, AMQP publishes
+ * are silently skipped and a one-time warning is logged.
+ */
+import { Buffer } from 'buffer';
+
+import fetch from 'node-fetch';
+
+import DmPlugin, { type Role } from '../../abstract/plugin';
+import type { DM } from '../../bin';
+import { Hooks } from '../../hooks';
+import type { ScimUser } from '../scim/types';
+
+interface RabbitPublisher {
+  init(): Promise<void>;
+  publish(
+    exchange: string,
+    routingKey: string,
+    message: Record<string, unknown>
+  ): Promise<void>;
+  close(clearSubscriptions?: boolean): Promise<void>;
+}
+
+export default class CozyProvision extends DmPlugin {
+  name = 'cozyProvision';
+  roles: Role[] = ['consistency'] as const;
+
+  private readonly cozyAdminUrl: string;
+  private readonly cozyAdminPassphrase: string;
+  private readonly cozyAdminUser: string;
+  private readonly cozyOrgId: string;
+  private readonly cozyOrgDomain: string;
+  private readonly cozyDefaultLocale: string;
+  private readonly rabbitmqUrl: string;
+  private readonly authExchange: string;
+  private readonly b2bExchange: string;
+
+  private publisher: RabbitPublisher | null = null;
+  private publisherInit: Promise<RabbitPublisher | null> | null = null;
+  private shutdownRegistered = false;
+
+  constructor(server: DM) {
+    super(server);
+
+    this.cozyAdminUrl = ((this.config.cozy_admin_url as string) || '').replace(
+      /\/$/,
+      ''
+    );
+    this.cozyAdminUser = (this.config.cozy_admin_user as string) || 'admin';
+    this.cozyAdminPassphrase =
+      (this.config.cozy_admin_passphrase as string) || '';
+    this.cozyOrgId = (this.config.cozy_org_id as string) || '';
+    this.cozyOrgDomain = (this.config.cozy_org_domain as string) || '';
+    this.cozyDefaultLocale =
+      (this.config.cozy_default_locale as string) || 'fr';
+    this.rabbitmqUrl = (this.config.rabbitmq_url as string) || '';
+    this.authExchange = (this.config.cozy_auth_exchange as string) || 'auth';
+    this.b2bExchange = (this.config.cozy_b2b_exchange as string) || 'b2b';
+
+    if (!this.cozyAdminUrl) {
+      this.logger.warn(
+        `${this.name}: cozy_admin_url is empty — Cozy instance creation will be skipped`
+      );
+    }
+    if (!this.cozyOrgDomain) {
+      this.logger.warn(
+        `${this.name}: cozy_org_domain is empty — workplaceFqdn cannot be composed`
+      );
+    }
+    if (!this.rabbitmqUrl) {
+      this.logger.warn(
+        `${this.name}: rabbitmq_url is empty — AMQP publishes will be skipped`
+      );
+    }
+
+    this.registerShutdown();
+  }
+
+  hooks: Hooks = {
+    scimusercreatedone: async (user: ScimUser): Promise<void> => {
+      const ok = await this.createCozyInstance(user);
+      if (ok) {
+        await this.publishUserCreated(user);
+      }
+    },
+    scimuserdeletedone: async (id: string): Promise<void> => {
+      await this.publishUserDeleted(id);
+    },
+  };
+
+  /**
+   * POST /instances on the cozy-stack admin API. Returns true on success
+   * (including 409 idempotent "already exists").
+   */
+  private async createCozyInstance(user: ScimUser): Promise<boolean> {
+    if (!this.cozyAdminUrl) return false;
+
+    const id = this.extractId(user);
+    if (!id) {
+      this.logger.warn({
+        plugin: this.name,
+        event: 'createCozyInstance',
+        message: 'user has no userName/id — skipping',
+      });
+      return false;
+    }
+    if (!this.cozyOrgDomain) {
+      this.logger.error({
+        plugin: this.name,
+        event: 'createCozyInstance',
+        id,
+        message: 'cozy_org_domain not configured — cannot compose Domain',
+      });
+      return false;
+    }
+
+    const domain = `${id}.${this.cozyOrgDomain}`;
+    const params = new URLSearchParams();
+    params.set('Domain', domain);
+    params.set('Locale', this.extractLocale(user));
+    const email = this.extractPrimaryEmail(user);
+    if (email) params.set('Email', email);
+    if (this.cozyOrgId) params.set('OrgID', this.cozyOrgId);
+    if (this.cozyOrgDomain) params.set('OrgDomain', this.cozyOrgDomain);
+
+    const url = `${this.cozyAdminUrl}/instances?${params.toString()}`;
+    const auth = Buffer.from(
+      `${this.cozyAdminUser}:${this.cozyAdminPassphrase}`
+    ).toString('base64');
+
+    const log = {
+      plugin: this.name,
+      event: 'createCozyInstance',
+      id,
+      domain,
+      email: email || undefined,
+    };
+
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${auth}`,
+          Accept: 'application/json',
+        },
+      });
+      if (!res.ok) {
+        if (res.status === 409) {
+          this.logger.info({
+            ...log,
+            result: 'already_exists',
+            http_status: res.status,
+          });
+          return true;
+        }
+        this.logger.error({
+          ...log,
+          result: 'error',
+          http_status: res.status,
+          http_status_text: res.statusText,
+        });
+        return false;
+      }
+      this.logger.info({
+        ...log,
+        result: 'success',
+        http_status: res.status,
+      });
+      return true;
+    } catch (err) {
+      this.logger.error({
+        ...log,
+        result: 'error',
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        error: `${err}`,
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Publish user.created on the `auth` topic exchange. Payload mirrors what
+   * cozy-stack expects: a sub identifier, an optional email, and the
+   * organizationDomain so consumers can match the instance.
+   */
+  private async publishUserCreated(user: ScimUser): Promise<void> {
+    const publisher = await this.getPublisher();
+    if (!publisher) return;
+
+    const id = this.extractId(user);
+    if (!id) return;
+    const email = this.extractPrimaryEmail(user);
+
+    const message: Record<string, unknown> = {
+      sub: id,
+      organizationDomain: this.cozyOrgDomain,
+      workplaceFqdn: `${id}.${this.cozyOrgDomain}`,
+    };
+    if (email) message.email = email;
+
+    try {
+      await publisher.publish(this.authExchange, 'user.created', message);
+      this.logger.info({
+        plugin: this.name,
+        event: 'publishUserCreated',
+        result: 'success',
+        exchange: this.authExchange,
+        routingKey: 'user.created',
+        sub: id,
+      });
+    } catch (err) {
+      this.logger.error({
+        plugin: this.name,
+        event: 'publishUserCreated',
+        sub: id,
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        error: `${err}`,
+      });
+    }
+  }
+
+  /**
+   * Publish domain.user.deleted on the `b2b` topic exchange so peer cozy
+   * instances can drop the deleted user's contact card.
+   */
+  private async publishUserDeleted(id: string): Promise<void> {
+    const publisher = await this.getPublisher();
+    if (!publisher) return;
+    if (!this.cozyOrgDomain) {
+      this.logger.error({
+        plugin: this.name,
+        event: 'publishUserDeleted',
+        id,
+        message:
+          'cozy_org_domain not configured — cannot compose workplaceFqdn',
+      });
+      return;
+    }
+
+    const message: Record<string, unknown> = {
+      workplaceFqdn: `${id}.${this.cozyOrgDomain}`,
+      domain: this.cozyOrgDomain,
+    };
+
+    try {
+      await publisher.publish(this.b2bExchange, 'domain.user.deleted', message);
+      this.logger.info({
+        plugin: this.name,
+        event: 'publishUserDeleted',
+        result: 'success',
+        exchange: this.b2bExchange,
+        routingKey: 'domain.user.deleted',
+        workplaceFqdn: message.workplaceFqdn,
+      });
+    } catch (err) {
+      this.logger.error({
+        plugin: this.name,
+        event: 'publishUserDeleted',
+        id,
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        error: `${err}`,
+      });
+    }
+  }
+
+  /**
+   * Lazy-init the AMQP publisher. The `@linagora/rabbitmq-client` dependency
+   * is optional — if the package or the broker is unreachable, return null
+   * so callers can no-op cleanly.
+   *
+   * Override this in tests to inject a stub publisher.
+   */
+  protected async getPublisher(): Promise<RabbitPublisher | null> {
+    if (this.publisher) return this.publisher;
+    if (!this.rabbitmqUrl) return null;
+    if (this.publisherInit) return this.publisherInit;
+
+    this.publisherInit = (async (): Promise<RabbitPublisher | null> => {
+      try {
+        const mod = await import('@linagora/rabbitmq-client');
+        const client = new mod.RabbitMQClient({
+          url: this.rabbitmqUrl,
+        }) as unknown as RabbitPublisher;
+        await client.init();
+        this.publisher = client;
+        this.logger.info(
+          `${this.name}: connected to RabbitMQ at ${this.rabbitmqUrl}`
+        );
+        return client;
+      } catch (err) {
+        this.logger.warn({
+          plugin: this.name,
+          event: 'rabbitmq_init',
+          message:
+            '@linagora/rabbitmq-client unavailable or broker unreachable — AMQP publishes disabled',
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          error: `${err}`,
+        });
+        return null;
+      }
+    })();
+
+    return this.publisherInit;
+  }
+
+  private extractId(user: ScimUser): string | null {
+    if (typeof user.userName === 'string' && user.userName.length > 0) {
+      return user.userName;
+    }
+    if (typeof user.id === 'string' && user.id.length > 0) {
+      return user.id;
+    }
+    return null;
+  }
+
+  private extractPrimaryEmail(user: ScimUser): string | null {
+    const emails = user.emails;
+    if (!emails || emails.length === 0) return null;
+    const primary = emails.find(e => e.primary);
+    const value = (primary || emails[0]).value;
+    return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+
+  private extractLocale(user: ScimUser): string {
+    if (typeof user.locale === 'string' && user.locale.length > 0) {
+      return user.locale;
+    }
+    if (
+      typeof user.preferredLanguage === 'string' &&
+      user.preferredLanguage.length > 0
+    ) {
+      return user.preferredLanguage;
+    }
+    return this.cozyDefaultLocale;
+  }
+
+  private registerShutdown(): void {
+    if (this.shutdownRegistered) return;
+    this.shutdownRegistered = true;
+    const shutdown = (): void => {
+      const pub = this.publisher;
+      if (!pub) return;
+      this.publisher = null;
+      pub.close().catch((err: unknown) => {
+        this.logger.warn({
+          plugin: this.name,
+          event: 'shutdown',
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          error: `${err}`,
+        });
+      });
+    };
+
+    process.once('SIGTERM', shutdown);
+
+    process.once('SIGINT', shutdown);
+  }
+}

--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -51,7 +51,6 @@ export default class CozyProvision extends DmPlugin {
 
   private publisher: RabbitPublisher | null = null;
   private publisherInit: Promise<RabbitPublisher | null> | null = null;
-  private shutdownRegistered = false;
 
   constructor(server: DM) {
     super(server);
@@ -298,7 +297,9 @@ export default class CozyProvision extends DmPlugin {
         await client.init();
         this.publisher = client;
         this.logger.info(
-          `${this.name}: connected to RabbitMQ at ${this.rabbitmqUrl}`
+          `${this.name}: connected to RabbitMQ at ${redactAmqpUrl(
+            this.rabbitmqUrl
+          )}`
         );
         return client;
       } catch (err) {
@@ -349,12 +350,13 @@ export default class CozyProvision extends DmPlugin {
   }
 
   private registerShutdown(): void {
-    if (this.shutdownRegistered) return;
-    this.shutdownRegistered = true;
     const shutdown = (): void => {
       const pub = this.publisher;
-      if (!pub) return;
+      // Clear both: a closed client must not be returned by a still-pending
+      // initialisation promise.
       this.publisher = null;
+      this.publisherInit = null;
+      if (!pub) return;
       pub.close().catch((err: unknown) => {
         this.logger.warn({
           plugin: this.name,
@@ -364,9 +366,48 @@ export default class CozyProvision extends DmPlugin {
         });
       });
     };
-
-    process.once('SIGTERM', shutdown);
-
-    process.once('SIGINT', shutdown);
+    registerProcessShutdown(shutdown);
   }
+}
+
+/**
+ * Strip credentials from an AMQP URL before logging — `amqp://user:pass@host`
+ * becomes `amqp://host`. Falls back to `amqp://[broker]` if the URL cannot
+ * be parsed (e.g. malformed config).
+ */
+function redactAmqpUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    u.username = '';
+    u.password = '';
+    return u.toString();
+  } catch {
+    return 'amqp://[broker]';
+  }
+}
+
+/**
+ * Registers a single SIGTERM/SIGINT handler at the process level. Each plugin
+ * instance contributes one callback that fans out from the shared handler, so
+ * we don't accumulate per-instance listeners (which would trip
+ * MaxListenersExceededWarning when many DM instances are created in tests).
+ */
+const shutdownCallbacks: Array<() => void> = [];
+let processShutdownInstalled = false;
+
+function registerProcessShutdown(cb: () => void): void {
+  shutdownCallbacks.push(cb);
+  if (processShutdownInstalled) return;
+  processShutdownInstalled = true;
+  const fanOut = (): void => {
+    for (const fn of shutdownCallbacks.splice(0)) {
+      try {
+        fn();
+      } catch {
+        // Hooks must never throw during shutdown.
+      }
+    }
+  };
+  process.once('SIGTERM', fanOut);
+  process.once('SIGINT', fanOut);
 }

--- a/test/plugins/twake/cozyProvision.test.ts
+++ b/test/plugins/twake/cozyProvision.test.ts
@@ -1,0 +1,224 @@
+import nock from 'nock';
+import { expect } from 'chai';
+
+import { DM } from '../../../src/bin';
+import CozyProvision from '../../../src/plugins/twake/cozyProvision';
+import type { ScimUser } from '../../../src/plugins/scim/types';
+
+interface PublishCall {
+  exchange: string;
+  routingKey: string;
+  message: Record<string, unknown>;
+}
+
+class StubPublisher {
+  calls: PublishCall[] = [];
+  closed = false;
+  async init(): Promise<void> {}
+  async publish(
+    exchange: string,
+    routingKey: string,
+    message: Record<string, unknown>
+  ): Promise<void> {
+    this.calls.push({ exchange, routingKey, message });
+  }
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+class TestableCozyProvision extends CozyProvision {
+  stub = new StubPublisher();
+  protected async getPublisher(): Promise<StubPublisher> {
+    return this.stub;
+  }
+}
+
+const COZY_URL = 'http://cozyt:6060';
+
+describe('CozyProvision plugin', () => {
+  let dm: DM;
+  let plugin: TestableCozyProvision;
+
+  before(() => {
+    nock.disableNetConnect();
+  });
+
+  after(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  beforeEach(async () => {
+    dm = new DM();
+    dm.config.cozy_admin_url = COZY_URL;
+    dm.config.cozy_admin_user = 'admin';
+    dm.config.cozy_admin_passphrase = 'admin';
+    dm.config.cozy_org_id = 'twp-test';
+    dm.config.cozy_org_domain = 'twake.local';
+    dm.config.cozy_default_locale = 'fr';
+    // Non-empty url just so the lazy-init path is exercised; the stub
+    // overrides actual broker access.
+    dm.config.rabbitmq_url = 'amqp://guest:guest@rabbitmq:5672/';
+    await dm.ready;
+    plugin = new TestableCozyProvision(dm);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('scimusercreatedone', () => {
+    it('POSTs /instances on cozy admin and publishes user.created', async () => {
+      const scope = nock(COZY_URL)
+        .post('/instances')
+        .query({
+          Domain: 'alice.twake.local',
+          Locale: 'fr',
+          Email: 'alice@twake.local',
+          OrgID: 'twp-test',
+          OrgDomain: 'twake.local',
+        })
+        .matchHeader('authorization', /^Basic /)
+        .reply(201, { ok: true });
+
+      const user: ScimUser = {
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        id: 'alice',
+        userName: 'alice',
+        emails: [{ value: 'alice@twake.local', primary: true }],
+      };
+
+      const hook = plugin.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await hook(user);
+
+      expect(scope.isDone(), 'cozy admin POST').to.be.true;
+      expect(plugin.stub.calls).to.have.length(1);
+      const call = plugin.stub.calls[0];
+      expect(call.exchange).to.equal('auth');
+      expect(call.routingKey).to.equal('user.created');
+      expect(call.message).to.deep.include({
+        sub: 'alice',
+        email: 'alice@twake.local',
+        organizationDomain: 'twake.local',
+        workplaceFqdn: 'alice.twake.local',
+      });
+    });
+
+    it('treats 409 as success and still publishes', async () => {
+      const scope = nock(COZY_URL)
+        .post('/instances')
+        .query(true)
+        .reply(409, { error: 'already exists' });
+
+      const user: ScimUser = {
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: 'bob',
+      };
+
+      const hook = plugin.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await hook(user);
+
+      expect(scope.isDone()).to.be.true;
+      expect(plugin.stub.calls).to.have.length(1);
+      expect(plugin.stub.calls[0].routingKey).to.equal('user.created');
+    });
+
+    it('skips publish when cozy admin returns a hard error', async () => {
+      const scope = nock(COZY_URL)
+        .post('/instances')
+        .query(true)
+        .reply(500, { error: 'boom' });
+
+      const user: ScimUser = {
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: 'carol',
+      };
+
+      const hook = plugin.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await hook(user);
+
+      expect(scope.isDone()).to.be.true;
+      expect(plugin.stub.calls).to.have.length(0);
+    });
+
+    it('uses user.locale when present', async () => {
+      const scope = nock(COZY_URL)
+        .post('/instances')
+        .query(q => q.Locale === 'en')
+        .reply(201, { ok: true });
+
+      const user: ScimUser = {
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: 'dave',
+        locale: 'en',
+      };
+
+      const hook = plugin.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await hook(user);
+
+      expect(scope.isDone()).to.be.true;
+    });
+
+    it('skips when user has no userName/id', async () => {
+      const user: ScimUser = {
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+      };
+      const hook = plugin.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await hook(user);
+      // No HTTP call expected, no publish either
+      expect(plugin.stub.calls).to.have.length(0);
+    });
+  });
+
+  describe('scimuserdeletedone', () => {
+    it('publishes domain.user.deleted with composed workplaceFqdn', async () => {
+      const hook = plugin.hooks?.scimuserdeletedone as (
+        id: string
+      ) => Promise<void>;
+      await hook('eve');
+
+      expect(plugin.stub.calls).to.have.length(1);
+      const call = plugin.stub.calls[0];
+      expect(call.exchange).to.equal('b2b');
+      expect(call.routingKey).to.equal('domain.user.deleted');
+      expect(call.message).to.deep.equal({
+        workplaceFqdn: 'eve.twake.local',
+        domain: 'twake.local',
+      });
+    });
+  });
+
+  describe('configuration safety', () => {
+    it('does not call cozy admin when cozy_admin_url is empty', async () => {
+      const dm2 = new DM();
+      dm2.config.cozy_admin_url = '';
+      dm2.config.cozy_org_domain = 'twake.local';
+      dm2.config.rabbitmq_url = 'amqp://x';
+      await dm2.ready;
+      const p = new TestableCozyProvision(dm2);
+
+      const user: ScimUser = {
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: 'frank',
+      };
+      const hook = p.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await hook(user);
+
+      // No nock expectation set, no HTTP call attempted; no publish either.
+      expect(p.stub.calls).to.have.length(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

New plugin `core/twake/cozyProvision` that wires the SCIM lifecycle to a Cozy + RabbitMQ deployment:

- **`scimusercreatedone`**: calls the cozy-stack admin API (`POST /instances?Domain=&Locale=&Email=&OrgID=&OrgDomain=`) with HTTP Basic auth, then publishes `user.created` on the `auth` topic exchange. `409 Conflict` is treated as idempotent success.
- **`scimuserdeletedone`**: publishes `domain.user.deleted` on the `b2b` topic exchange. `workplaceFqdn` is composed as `${id}.${cozy_org_domain}` so peer cozy instances can drop the deleted user's contact card.

`OrgID` and `OrgDomain` are deployment-wide constants read from the plugin config (`cozy_org_id`, `cozy_org_domain`), not from the user record — every provisioned instance lands in the same sharing group.

`@linagora/rabbitmq-client` (`^0.1.2`) is declared as an **`optionalDependency`**. The publisher is lazy-initialised on first publish; if the package is missing or the broker is unreachable, the plugin logs a one-time warning and skips AMQP publishes without failing the SCIM operation. The publisher is closed on `SIGTERM`/`SIGINT`.

## Config keys (env `DM_*`)

| Key | Default | Notes |
| --- | --- | --- |
| `cozy_admin_url` | _(empty → disabled)_ | Cozy admin endpoint, e.g. `http://cozyt:6060` |
| `cozy_admin_user` | `admin` | |
| `cozy_admin_passphrase` | _(empty)_ | |
| `cozy_org_id` | _(empty)_ | Sent as `OrgID` query param |
| `cozy_org_domain` | _(empty → publishes skipped)_ | `OrgDomain`, `organizationDomain`, FQDN domain part |
| `cozy_default_locale` | `fr` | Used when the SCIM user has no `locale` |
| `cozy_auth_exchange` | `auth` | |
| `cozy_b2b_exchange` | `b2b` | |
| `rabbitmq_url` | _(empty → AMQP disabled)_ | e.g. `amqp://guest:guest@rabbitmq:5672/` |

## Test plan

- [x] `npm run check:ts` — clean
- [x] `npm test` — 712 passing (705 prior + 7 new)
- [x] `npx eslint src/plugins/twake/cozyProvision.ts` — clean
- [x] `npx prettier --check` on the new files — clean
- [ ] Manual end-to-end against twp-docker (separate PR) — wire `core/twake/cozyProvision` in `DM_PLUGINS`, set the env vars above, confirm a SCIM POST creates a Cozy instance and the `auth` / `user.created` message is consumed by cozy-stack.