### PR TITLE
feat(auth): add authzPerRoute plugin for HTTP route-level ACL

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -27,6 +27,7 @@ All LDAP-Rest configuration options.
     - [core/auth/openidconnect](#coreauthopenidconnect)
   - [Authorization Plugins](#authorization-plugins)
     - [core/auth/authzPerBranch](#coreauthauthzperbranch)
+    - [core/auth/authzPerRoute](#coreauthauthzperroute)
     - [core/auth/authzLinid1](#coreauthauthzlinid1)
   - [Security Plugins](#security-plugins)
     - [core/auth/rateLimit](#coreauthratelimit)
@@ -235,6 +236,12 @@ Maintains consistency of department links when organizations are renamed/moved. 
 | ------------------------------ | ------------------------------- | ------------------------------------------------ | --------------------------- |
 | `--authz-per-branch-config`    | `DM_AUTHZ_PER_BRANCH_CONFIG`    | `{default:{read:true,write:false,delete:false}}` | Authorization config (JSON) |
 | `--authz-per-branch-cache-ttl` | `DM_AUTHZ_PER_BRANCH_CACHE_TTL` | `60`                                             | Cache TTL (seconds)         |
+
+#### `core/auth/authzPerRoute`
+
+| CLI                  | Env                   | Default | Description                                                      |
+| -------------------- | --------------------- | ------- | ---------------------------------------------------------------- |
+| `--authz-per-route`  | `DM_AUTHZ_PER_ROUTE`  | `[]`    | Per-user route ACL rules (see [docs](plugins/auth/authz-per-route.md)) |
 
 #### `core/auth/authzLinid1`
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -239,9 +239,9 @@ Maintains consistency of department links when organizations are renamed/moved. 
 
 #### `core/auth/authzPerRoute`
 
-| CLI                  | Env                   | Default | Description                                                      |
-| -------------------- | --------------------- | ------- | ---------------------------------------------------------------- |
-| `--authz-per-route`  | `DM_AUTHZ_PER_ROUTE`  | `[]`    | Per-user route ACL rules (see [docs](plugins/auth/authz-per-route.md)) |
+| CLI                 | Env                   | Default | Description                                                            |
+| ------------------- | --------------------- | ------- | ---------------------------------------------------------------------- |
+| `--authz-per-route` | `DM_AUTHZ_PER_ROUTES` | `[]`    | Per-user route ACL rules (see [docs](plugins/auth/authz-per-route.md)) |
 
 #### `core/auth/authzLinid1`
 

--- a/docs/usage/plugins/auth/README.md
+++ b/docs/usage/plugins/auth/README.md
@@ -17,6 +17,7 @@ LDAP-Rest provides multiple authentication plugins to secure API access. These p
 | Method                                          | Plugin                     | Description                 |
 | ----------------------------------------------- | -------------------------- | --------------------------- |
 | [Authorization Per Branch](authz-per-branch.md) | `core/auth/authzPerBranch` | Branch-level access control |
+| [Authorization Per Route](authz-per-route.md)   | `core/auth/authzPerRoute`  | HTTP route-level ACL        |
 | [Authorization LinID 1.x](authz-linid1.md)      | `core/auth/authzLinid1`    | LinID 1.x integration       |
 
 ## Security Plugins

--- a/docs/usage/plugins/auth/authz-per-route.md
+++ b/docs/usage/plugins/auth/authz-per-route.md
@@ -7,10 +7,18 @@ This plugin complements `authzPerBranch` (LDAP-branch ACL) and `authzDynamic`
 (LDAP-backed tokens): whereas those operate at the LDAP-branch level,
 `authzPerRoute` works at the HTTP route level and needs no LDAP connection.
 
-## Loading Order
+## Plugin loading order
 
-**`authzPerRoute` must be loaded _after_ the auth plugin** (e.g. `core/auth/token`),
-because it reads `req.user` which is set by the auth middleware.
+`authzPerRoute` MUST run **after** the authentication plugin (so `req.user` is set)
+AND **before** any API route plugin (so its Express middleware is registered before
+the routes it protects).
+
+When loaded via the CLI plugin loader, plugins not listed in
+`src/plugins/priority.json` are loaded in parallel — this can race with API route
+registration and result in an authorization bypass. To guarantee correct ordering,
+`core/auth/authzPerRoute` is included in the priority list and loads sequentially
+after the other auth plugins. If you build a custom loader, ensure equivalent
+sequencing.
 
 ```bash
 --plugin core/auth/token \

--- a/docs/usage/plugins/auth/authz-per-route.md
+++ b/docs/usage/plugins/auth/authz-per-route.md
@@ -24,13 +24,13 @@ because it reads `req.user` which is set by the auth middleware.
 ```bash
 --authz-per-route "full-access:*" \
 --authz-per-route "updt-only:POST:/api/v1/ldap/updt" \
---authz-per-route "updt-only:GET:/api/v1/ldap/updt(/.*)?"
+--authz-per-route "updt-only:GET:/api/v1/ldap/updt/**"
 ```
 
 ### Environment Variable
 
 ```bash
-DM_AUTHZ_PER_ROUTE="full-access:*,updt-only:POST:/api/v1/ldap/updt,updt-only:GET:/api/v1/ldap/updt(/.*)?
+DM_AUTHZ_PER_ROUTE="full-access:*,updt-only:POST:/api/v1/ldap/updt,updt-only:GET:/api/v1/ldap/updt/**"
 ```
 
 Multiple values are comma-separated. Repeating `--authz-per-route` on the CLI
@@ -40,17 +40,20 @@ is equivalent.
 
 Each entry has one of two forms:
 
-| Form                          | Meaning                                                      |
-| ----------------------------- | ------------------------------------------------------------ |
-| `<user>:*`                    | Full wildcard — allow any method on any path                 |
-| `<user>:<METHOD>:<pathRegex>` | Allow only the given HTTP method on paths matching the regex |
+| Form                         | Meaning                                                     |
+| ---------------------------- | ----------------------------------------------------------- |
+| `<user>:*`                   | Full wildcard — allow any method on any path                |
+| `<user>:<METHOD>:<pathGlob>` | Allow only the given HTTP method on paths matching the glob |
 
 - `<user>` — the value of `req.user` as set by the auth plugin.
 - `<METHOD>` — an HTTP verb (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`,
   `OPTIONS`) or `*` (any verb).
-- `<pathRegex>` — a JavaScript regular expression. The plugin auto-anchors it
-  with `^…$`, so `/api/hello` matches exactly `/api/hello`, while
-  `/api/hello(/.*)?` also matches sub-paths.
+- `<pathGlob>` — a glob pattern (not a regex). Patterns are implicitly
+  anchored start-to-end. Rules:
+  - `*` matches any sequence of characters **except** `/` (one path segment).
+  - `**` matches any sequence of characters **including** `/` (multiple segments).
+  - All other characters are matched literally — regex special characters (`.`, `+`,
+    `?`, etc.) have no special meaning.
 
 A user may have multiple entries; access is granted if **any** rule matches
 (logical OR).
@@ -61,16 +64,29 @@ A user may have multiple entries; access is granted if **any** rule matches
 # admin token: full access
 full-access:*
 
-# read-only token: GET only on /api/hello
+# read-only token: GET only on exactly /api/hello
 reader:GET:/api/hello
 
-# update token: POST or GET on a specific path and its sub-paths
+# update token: POST on exact path, GET on that path and all sub-paths
 updt:POST:/api/v1/ldap/updt
-updt:GET:/api/v1/ldap/updt(/.*)?
+updt:GET:/api/v1/ldap/updt**
 
-# any method on a path
-any-method:*:/api/v1/ldap/users
+# any method on a path and all sub-paths
+any-method:*:/api/v1/ldap/users**
+
+# match one level deep only (not /api/v1/ldap/users/uid=bob/sub)
+one-level:GET:/api/v1/ldap/users/*
 ```
+
+### Glob pattern quick reference
+
+| Pattern              | Matches                                       | Does NOT match                          |
+| -------------------- | --------------------------------------------- | --------------------------------------- |
+| `/api/hello`         | `/api/hello`                                  | `/api/hello/sub`                        |
+| `/api/hello**`       | `/api/hello`, `/api/hello/sub`, `/api/hello/sub/deep` | `/api/hell`                   |
+| `/api/hello/**`      | `/api/hello/sub`, `/api/hello/sub/deep`       | `/api/hello`                            |
+| `/api/hello/*`       | `/api/hello/sub`                              | `/api/hello`, `/api/hello/sub/deep`     |
+| `/api/hello.bak`     | `/api/hello.bak`                              | `/api/helloXbak` (`.` is literal)       |
 
 ## Behavior
 
@@ -85,7 +101,7 @@ any-method:*:/api/v1/ldap/users
 
 ```bash
 DM_AUTH_TOKENS="tok-admin:admin,tok-ro:reader"
-DM_AUTHZ_PER_ROUTE="admin:*,reader:GET:/api/v1/ldap/users,reader:GET:/api/v1/ldap/groups"
+DM_AUTHZ_PER_ROUTE="admin:*,reader:GET:/api/v1/ldap/users**,reader:GET:/api/v1/ldap/groups**"
 
 npx ldap-rest \
   --plugin core/auth/token \

--- a/docs/usage/plugins/auth/authz-per-route.md
+++ b/docs/usage/plugins/auth/authz-per-route.md
@@ -54,6 +54,9 @@ Each entry has one of two forms:
   - `**` matches any sequence of characters **including** `/` (multiple segments).
   - All other characters are matched literally — regex special characters (`.`, `+`,
     `?`, etc.) have no special meaning.
+  - **Allowed characters:** alphanumerics (`a-z`, `A-Z`, `0-9`), `/`, `_`, `-`,
+    `.`, `+`, and `*`. Globs containing any other character (e.g. `;`, space,
+    `?`) are rejected at startup with a warning and the rule is skipped.
 
 A user may have multiple entries; access is granted if **any** rule matches
 (logical OR).

--- a/docs/usage/plugins/auth/authz-per-route.md
+++ b/docs/usage/plugins/auth/authz-per-route.md
@@ -1,0 +1,117 @@
+# Route-Level Authorization (`authzPerRoute`)
+
+Restricts access to specific HTTP routes based on the authenticated user's name
+(`req.user`), which is set by an auth plugin such as `core/auth/token`.
+
+This plugin complements `authzPerBranch` (LDAP-branch ACL) and `authzDynamic`
+(LDAP-backed tokens): whereas those operate at the LDAP-branch level,
+`authzPerRoute` works at the HTTP route level and needs no LDAP connection.
+
+## Loading Order
+
+**`authzPerRoute` must be loaded _after_ the auth plugin** (e.g. `core/auth/token`),
+because it reads `req.user` which is set by the auth middleware.
+
+```bash
+--plugin core/auth/token \
+--plugin core/auth/authzPerRoute
+```
+
+## Configuration
+
+### CLI
+
+```bash
+--authz-per-route "full-access:*" \
+--authz-per-route "updt-only:POST:/api/v1/ldap/updt" \
+--authz-per-route "updt-only:GET:/api/v1/ldap/updt(/.*)?"
+```
+
+### Environment Variable
+
+```bash
+DM_AUTHZ_PER_ROUTE="full-access:*,updt-only:POST:/api/v1/ldap/updt,updt-only:GET:/api/v1/ldap/updt(/.*)?
+```
+
+Multiple values are comma-separated. Repeating `--authz-per-route` on the CLI
+is equivalent.
+
+## Rule Syntax
+
+Each entry has one of two forms:
+
+| Form                          | Meaning                                                      |
+| ----------------------------- | ------------------------------------------------------------ |
+| `<user>:*`                    | Full wildcard — allow any method on any path                 |
+| `<user>:<METHOD>:<pathRegex>` | Allow only the given HTTP method on paths matching the regex |
+
+- `<user>` — the value of `req.user` as set by the auth plugin.
+- `<METHOD>` — an HTTP verb (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`,
+  `OPTIONS`) or `*` (any verb).
+- `<pathRegex>` — a JavaScript regular expression. The plugin auto-anchors it
+  with `^…$`, so `/api/hello` matches exactly `/api/hello`, while
+  `/api/hello(/.*)?` also matches sub-paths.
+
+A user may have multiple entries; access is granted if **any** rule matches
+(logical OR).
+
+### Examples
+
+```bash
+# admin token: full access
+full-access:*
+
+# read-only token: GET only on /api/hello
+reader:GET:/api/hello
+
+# update token: POST or GET on a specific path and its sub-paths
+updt:POST:/api/v1/ldap/updt
+updt:GET:/api/v1/ldap/updt(/.*)?
+
+# any method on a path
+any-method:*:/api/v1/ldap/users
+```
+
+## Behavior
+
+| Situation                                             | Result                                                 |
+| ----------------------------------------------------- | ------------------------------------------------------ |
+| `req.user` is unset (no auth plugin ran)              | Pass through (`next()`) — let upstream auth return 401 |
+| User authenticated but has no rules configured        | 403 Forbidden                                          |
+| User has at least one matching rule                   | 200 / pass through                                     |
+| User has rules but none match the current method+path | 403 Forbidden                                          |
+
+## Full Example
+
+```bash
+DM_AUTH_TOKENS="tok-admin:admin,tok-ro:reader"
+DM_AUTHZ_PER_ROUTE="admin:*,reader:GET:/api/v1/ldap/users,reader:GET:/api/v1/ldap/groups"
+
+npx ldap-rest \
+  --plugin core/auth/token \
+  --plugin core/auth/authzPerRoute \
+  --plugin core/ldap/users \
+  --plugin core/ldap/groups \
+  --ldap-url ldap://localhost:389 \
+  ...
+```
+
+```bash
+# admin: any request allowed
+curl -H "Authorization: Bearer tok-admin" http://api/v1/ldap/users
+curl -H "Authorization: Bearer tok-admin" -X DELETE http://api/v1/ldap/users/uid=bob,ou=users,dc=example,dc=org
+
+# reader: GET allowed
+curl -H "Authorization: Bearer tok-ro" http://api/v1/ldap/users   # 200
+
+# reader: write denied
+curl -H "Authorization: Bearer tok-ro" -X POST http://api/v1/ldap/users  # 403
+```
+
+## Difference vs. Other Authz Plugins
+
+| Plugin           | Scope                          | Requires LDAP      |
+| ---------------- | ------------------------------ | ------------------ |
+| `authzPerRoute`  | HTTP method + path             | No                 |
+| `authzPerBranch` | LDAP branch read/write/delete  | No (static config) |
+| `authzDynamic`   | LDAP branch ACL stored in LDAP | Yes                |

--- a/docs/usage/plugins/auth/authz-per-route.md
+++ b/docs/usage/plugins/auth/authz-per-route.md
@@ -38,7 +38,7 @@ sequencing.
 ### Environment Variable
 
 ```bash
-DM_AUTHZ_PER_ROUTE="full-access:*,updt-only:POST:/api/v1/ldap/updt,updt-only:GET:/api/v1/ldap/updt/**"
+DM_AUTHZ_PER_ROUTES="full-access:*,updt-only:POST:/api/v1/ldap/updt,updt-only:GET:/api/v1/ldap/updt/**"
 ```
 
 Multiple values are comma-separated. Repeating `--authz-per-route` on the CLI
@@ -91,13 +91,13 @@ one-level:GET:/api/v1/ldap/users/*
 
 ### Glob pattern quick reference
 
-| Pattern              | Matches                                       | Does NOT match                          |
-| -------------------- | --------------------------------------------- | --------------------------------------- |
-| `/api/hello`         | `/api/hello`                                  | `/api/hello/sub`                        |
-| `/api/hello**`       | `/api/hello`, `/api/hello/sub`, `/api/hello/sub/deep` | `/api/hell`                   |
-| `/api/hello/**`      | `/api/hello/sub`, `/api/hello/sub/deep`       | `/api/hello`                            |
-| `/api/hello/*`       | `/api/hello/sub`                              | `/api/hello`, `/api/hello/sub/deep`     |
-| `/api/hello.bak`     | `/api/hello.bak`                              | `/api/helloXbak` (`.` is literal)       |
+| Pattern          | Matches                                               | Does NOT match                      |
+| ---------------- | ----------------------------------------------------- | ----------------------------------- |
+| `/api/hello`     | `/api/hello`                                          | `/api/hello/sub`                    |
+| `/api/hello**`   | `/api/hello`, `/api/hello/sub`, `/api/hello/sub/deep` | `/api/hell`                         |
+| `/api/hello/**`  | `/api/hello/sub`, `/api/hello/sub/deep`               | `/api/hello`                        |
+| `/api/hello/*`   | `/api/hello/sub`                                      | `/api/hello`, `/api/hello/sub/deep` |
+| `/api/hello.bak` | `/api/hello.bak`                                      | `/api/helloXbak` (`.` is literal)   |
 
 ## Behavior
 
@@ -112,7 +112,7 @@ one-level:GET:/api/v1/ldap/users/*
 
 ```bash
 DM_AUTH_TOKENS="tok-admin:admin,tok-ro:reader"
-DM_AUTHZ_PER_ROUTE="admin:*,reader:GET:/api/v1/ldap/users**,reader:GET:/api/v1/ldap/groups**"
+DM_AUTHZ_PER_ROUTES="admin:*,reader:GET:/api/v1/ldap/users**,reader:GET:/api/v1/ldap/groups**"
 
 npx ldap-rest \
   --plugin core/auth/token \

--- a/package.json
+++ b/package.json
@@ -52,6 +52,10 @@
       "types": "./dist/src/plugins/auth/authzPerBranch.d.ts",
       "import": "./dist/plugins/auth/authzPerBranch.js"
     },
+    "./plugin-auth-authzperroute": {
+      "types": "./dist/src/plugins/auth/authzPerRoute.d.ts",
+      "import": "./dist/plugins/auth/authzPerRoute.js"
+    },
     "./plugin-auth-crowdsec": {
       "types": "./dist/src/plugins/auth/crowdsec.d.ts",
       "import": "./dist/plugins/auth/crowdsec.js"

--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -111,6 +111,9 @@ export interface Config {
   oidc_client_secret?: string;
   base_url?: string;
 
+  // auth/authzPerRoute
+  authz_per_route?: string[];
+
   // auth/authzPerBranch
   authz_per_branch_config?: AuthConfig;
   authz_per_branch_cache_ttl?: number;
@@ -490,6 +493,9 @@ const configArgs: ConfigTemplate = [
   // Auth HMAC plugin
   ['--auth-hmac', 'DM_AUTH_HMAC', [], 'array', '--auth-hmacs'],
   ['--auth-hmac-window', 'DM_AUTH_HMAC_WINDOW', 120000, 'number'],
+
+  // Auth authzPerRoute plugin
+  ['--authz-per-route', 'DM_AUTHZ_PER_ROUTE', [], 'array', '--authz-per-routes'],
 
   // Auth authzPerBranch plugin
   [

--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -495,7 +495,7 @@ const configArgs: ConfigTemplate = [
   ['--auth-hmac-window', 'DM_AUTH_HMAC_WINDOW', 120000, 'number'],
 
   // Auth authzPerRoute plugin
-  ['--authz-per-route', 'DM_AUTHZ_PER_ROUTE', [], 'array', '--authz-per-routes'],
+  ['--authz-per-route', 'DM_AUTHZ_PER_ROUTES', [], 'array', '--authz-per-routes'],
 
   // Auth authzPerBranch plugin
   [

--- a/src/plugins/auth/authzPerRoute.ts
+++ b/src/plugins/auth/authzPerRoute.ts
@@ -80,7 +80,7 @@ export default class AuthzPerRoute extends DmPlugin {
   }
 
   private parseEntry(entry: string): void {
-    const parts = entry.split(':');
+    const parts = entry.split(':').map((p) => p.trim());
 
     if (parts.length < 2) {
       this.logger.warn(`authzPerRoute: ignoring invalid rule entry: ${entry}`);
@@ -88,6 +88,11 @@ export default class AuthzPerRoute extends DmPlugin {
     }
 
     const user = parts[0];
+
+    if (!user) {
+      this.logger.warn(`authzPerRoute: ignoring rule with empty user: ${entry}`);
+      return;
+    }
 
     // "<user>:*" — full wildcard
     if (parts.length === 2 && parts[1] === '*') {
@@ -98,8 +103,17 @@ export default class AuthzPerRoute extends DmPlugin {
     // "<user>:<METHOD>:<pathGlob>"
     if (parts.length >= 3) {
       const method = parts[1].toUpperCase();
-      // Rejoin in case the glob itself contains colons
-      const pathPattern = parts.slice(2).join(':');
+      const VALID_METHODS = new Set(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', '*']);
+      if (!method || !VALID_METHODS.has(method)) {
+        this.logger.warn(`authzPerRoute: ignoring rule with invalid method "${parts[1]}" in entry: ${entry}`);
+        return;
+      }
+      // Rejoin in case the glob itself contains colons, then trim
+      const pathPattern = parts.slice(2).join(':').trim();
+      if (!pathPattern) {
+        this.logger.warn(`authzPerRoute: ignoring rule with empty path pattern in entry: ${entry}`);
+        return;
+      }
       let pathRe: RegExp;
       try {
         pathRe = globToRegex(pathPattern);

--- a/src/plugins/auth/authzPerRoute.ts
+++ b/src/plugins/auth/authzPerRoute.ts
@@ -13,25 +13,33 @@ import DmPlugin, { type Role } from '../../abstract/plugin';
 import { forbidden } from '../../lib/expressFormatedResponses';
 import type { DmRequest } from '../../lib/auth/base';
 
+// Whitelist of characters permitted in a glob pattern.
+// Covers all characters needed for typical REST paths: alphanumerics, slash,
+// underscore, hyphen, dot, plus, and the glob wildcards (*).
+// Any pattern containing characters outside this set is rejected.
+const ALLOWED_GLOB_CHARS = /^[\w/.\-+*]*$/;
+
 // Convert a glob pattern to a RegExp. '*' matches one path segment ([^/]*),
 // '**' matches any sequence including '/' (.*). All other characters are escaped.
+//
+// Security: the pattern is validated against ALLOWED_GLOB_CHARS before any
+// regex construction, providing a whitelist guard recognised by CodeQL's
+// js/regex-injection query. Only the sanitised, escaped string flows into
+// new RegExp.
+//
+// Throws if the glob contains characters outside the allowed set.
 export function globToRegex(glob: string): RegExp {
-  let out = '';
-  let i = 0;
-  while (i < glob.length) {
-    if (glob[i] === '*' && glob[i + 1] === '*') {
-      out += '.*';
-      i += 2;
-    } else if (glob[i] === '*') {
-      out += '[^/]*';
-      i += 1;
-    } else {
-      const c = glob[i];
-      out += /[.+?^${}()|[\]\\]/.test(c) ? `\\${c}` : c;
-      i += 1;
-    }
+  if (!ALLOWED_GLOB_CHARS.test(glob)) {
+    throw new Error(`Invalid glob pattern: "${glob}" — only [a-zA-Z0-9_/.\-+*] are allowed`);
   }
-  return new RegExp(`^${out}$`);
+  // Escape every regex-significant character first (producing a safe string).
+  // Among the whitelisted chars only `.` and `+` are regex metacharacters;
+  // `*` is also flagged by the broad escape set and will be escaped too.
+  const escaped = glob.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+  // After escaping: `**` → `\*\*`, `*` → `\*`.
+  // Restore glob semantics on the already-sanitised string.
+  const pattern = escaped.replace(/\\\*\\\*/g, '.*').replace(/\\\*/g, '[^/]*');
+  return new RegExp(`^${pattern}$`);
 }
 
 interface WildcardRule {

--- a/src/plugins/auth/authzPerRoute.ts
+++ b/src/plugins/auth/authzPerRoute.ts
@@ -1,0 +1,139 @@
+/**
+ * @module core/auth/authzPerRoute
+ * Route-level authorization plugin.
+ *
+ * Restricts access by HTTP method + path based on the authenticated user name
+ * (req.user, set by an auth plugin loaded before this one).
+ *
+ * @author Xavier Guimard <xguimard@linagora.com>
+ */
+import type { Express, Request, Response, NextFunction } from 'express';
+
+import DmPlugin, { type Role } from '../../abstract/plugin';
+import { forbidden } from '../../lib/expressFormatedResponses';
+import type { DmRequest } from '../../lib/auth/base';
+
+interface WildcardRule {
+  kind: 'wildcard';
+}
+
+interface MethodPathRule {
+  kind: 'method-path';
+  method: string; // uppercase HTTP verb or '*'
+  pathRe: RegExp;
+}
+
+type AuthzRule = WildcardRule | MethodPathRule;
+
+export default class AuthzPerRoute extends DmPlugin {
+  name = 'authzPerRoute';
+  roles: Role[] = ['authz'] as const;
+  private rules: Map<string, AuthzRule[]> = new Map();
+
+  constructor(...args: ConstructorParameters<typeof DmPlugin>) {
+    super(...args);
+
+    const entries = (this.config.authz_per_route as string[] | undefined) ?? [];
+    for (const entry of entries) {
+      this.parseEntry(entry);
+    }
+
+    const summary = [...this.rules.entries()]
+      .map(([user, rules]) => {
+        const hasWildcard = rules.some((r) => r.kind === 'wildcard');
+        return `${user}: ${hasWildcard ? 'full access' : `${rules.length} rule${rules.length !== 1 ? 's' : ''}`}`;
+      })
+      .join(', ');
+
+    this.logger.info(
+      `authzPerRoute: ${this.rules.size} user${this.rules.size !== 1 ? 's' : ''} configured${this.rules.size > 0 ? ` (${summary})` : ''}`
+    );
+  }
+
+  private parseEntry(entry: string): void {
+    const parts = entry.split(':');
+
+    if (parts.length < 2) {
+      this.logger.warn(`authzPerRoute: ignoring invalid rule entry: ${entry}`);
+      return;
+    }
+
+    const user = parts[0];
+
+    // "<user>:*" — full wildcard
+    if (parts.length === 2 && parts[1] === '*') {
+      this.addRule(user, { kind: 'wildcard' });
+      return;
+    }
+
+    // "<user>:<METHOD>:<pathRegex>"
+    if (parts.length >= 3) {
+      const method = parts[1].toUpperCase();
+      // Rejoin in case the regex itself contains colons
+      const pathRegexStr = parts.slice(2).join(':');
+      let pathRe: RegExp;
+      try {
+        pathRe = new RegExp(`^${pathRegexStr}$`);
+      } catch {
+        this.logger.warn(
+          `authzPerRoute: ignoring entry with invalid regex "${pathRegexStr}" in rule: ${entry}`
+        );
+        return;
+      }
+      this.addRule(user, { kind: 'method-path', method, pathRe });
+      return;
+    }
+
+    this.logger.warn(`authzPerRoute: ignoring invalid rule entry: ${entry}`);
+  }
+
+  private addRule(user: string, rule: AuthzRule): void {
+    const existing = this.rules.get(user);
+    if (existing) {
+      existing.push(rule);
+    } else {
+      this.rules.set(user, [rule]);
+    }
+  }
+
+  private matches(rules: AuthzRule[], method: string, path: string): boolean {
+    for (const rule of rules) {
+      if (rule.kind === 'wildcard') return true;
+      if (
+        (rule.method === '*' || rule.method === method.toUpperCase()) &&
+        rule.pathRe.test(path)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  api(app: Express): void {
+    app.use((req: Request, res: Response, next: NextFunction) => {
+      const user = (req as DmRequest).user;
+
+      // No authenticated user yet — let upstream auth plugin handle 401
+      if (!user) {
+        return next();
+      }
+
+      const rules = this.rules.get(user);
+      if (!rules) {
+        this.logger.warn(
+          `authzPerRoute: user '${user}' denied for ${req.method} ${req.path} (no rules configured)`
+        );
+        return forbidden(res);
+      }
+
+      if (this.matches(rules, req.method, req.path)) {
+        return next();
+      }
+
+      this.logger.warn(
+        `authzPerRoute: user '${user}' denied for ${req.method} ${req.path}`
+      );
+      return forbidden(res);
+    });
+  }
+}

--- a/src/plugins/auth/authzPerRoute.ts
+++ b/src/plugins/auth/authzPerRoute.ts
@@ -13,6 +13,27 @@ import DmPlugin, { type Role } from '../../abstract/plugin';
 import { forbidden } from '../../lib/expressFormatedResponses';
 import type { DmRequest } from '../../lib/auth/base';
 
+// Convert a glob pattern to a RegExp. '*' matches one path segment ([^/]*),
+// '**' matches any sequence including '/' (.*). All other characters are escaped.
+export function globToRegex(glob: string): RegExp {
+  let out = '';
+  let i = 0;
+  while (i < glob.length) {
+    if (glob[i] === '*' && glob[i + 1] === '*') {
+      out += '.*';
+      i += 2;
+    } else if (glob[i] === '*') {
+      out += '[^/]*';
+      i += 1;
+    } else {
+      const c = glob[i];
+      out += /[.+?^${}()|[\]\\]/.test(c) ? `\\${c}` : c;
+      i += 1;
+    }
+  }
+  return new RegExp(`^${out}$`);
+}
+
 interface WildcardRule {
   kind: 'wildcard';
 }
@@ -66,17 +87,17 @@ export default class AuthzPerRoute extends DmPlugin {
       return;
     }
 
-    // "<user>:<METHOD>:<pathRegex>"
+    // "<user>:<METHOD>:<pathGlob>"
     if (parts.length >= 3) {
       const method = parts[1].toUpperCase();
-      // Rejoin in case the regex itself contains colons
-      const pathRegexStr = parts.slice(2).join(':');
+      // Rejoin in case the glob itself contains colons
+      const pathPattern = parts.slice(2).join(':');
       let pathRe: RegExp;
       try {
-        pathRe = new RegExp(`^${pathRegexStr}$`);
+        pathRe = globToRegex(pathPattern);
       } catch {
         this.logger.warn(
-          `authzPerRoute: ignoring entry with invalid regex "${pathRegexStr}" in rule: ${entry}`
+          `authzPerRoute: ignoring entry with invalid glob "${pathPattern}" in rule: ${entry}`
         );
         return;
       }

--- a/src/plugins/priority.json
+++ b/src/plugins/priority.json
@@ -5,5 +5,6 @@
   "core/auth/rateLimit",
   "core/auth/token",
   "core/auth/llng",
-  "core/auth/openidconnect"
+  "core/auth/openidconnect",
+  "core/auth/authzPerRoute"
 ]

--- a/test/plugins/auth/authzPerRoute.test.ts
+++ b/test/plugins/auth/authzPerRoute.test.ts
@@ -233,5 +233,52 @@ describe('AuthzPerRoute', () => {
         expect(re.test('/pathextra')).to.equal(false);
       });
     });
+
+    describe('whitelist validation', () => {
+      it('throws on semicolon in glob', () => {
+        expect(() => globToRegex('foo;bar')).to.throw(/Invalid glob pattern/);
+      });
+
+      it('throws on space in glob', () => {
+        expect(() => globToRegex('foo bar')).to.throw(/Invalid glob pattern/);
+      });
+    });
+  });
+
+  describe('Malformed glob in rule is ignored (no crash)', () => {
+    let app: Express;
+
+    before(async () => {
+      process.env.DM_AUTH_TOKENS = 'tok-valid:validuser';
+      // "foo?bar" contains a question-mark — invalid glob, rule must be skipped.
+      // Deliberately avoid ';' here because the config parser uses ';' as array
+      // separator when present in the env-var value, which would mangle the entry.
+      process.env.DM_AUTHZ_PER_ROUTE = 'validuser:GET:foo?bar,validuser:GET:/api/hello';
+      const dm = new DM();
+      await dm.ready;
+      await dm.registerPlugin('authToken', new AuthToken(dm));
+      await dm.registerPlugin('authzPerRoute', new AuthzPerRoute(dm));
+      await dm.registerPlugin('helloWorld', new HelloWorld(dm));
+      app = dm.app;
+    });
+
+    after(() => {
+      delete process.env.DM_AUTH_TOKENS;
+      delete process.env.DM_AUTHZ_PER_ROUTE;
+    });
+
+    it('plugin starts and valid rule still works', async () => {
+      const res = await request(app)
+        .get('/api/hello')
+        .set('Authorization', 'Bearer tok-valid');
+      expect(res.status).to.equal(200);
+    });
+
+    it('malformed-glob rule does not grant access (returns 403 on unmatched path)', async () => {
+      const res = await request(app)
+        .get('/some/other/path')
+        .set('Authorization', 'Bearer tok-valid');
+      expect(res.status).to.equal(403);
+    });
   });
 });

--- a/test/plugins/auth/authzPerRoute.test.ts
+++ b/test/plugins/auth/authzPerRoute.test.ts
@@ -1,0 +1,169 @@
+import { DM } from '../../../src/bin';
+import type { Express } from 'express';
+import request from 'supertest';
+import AuthToken from '../../../src/plugins/auth/token';
+import AuthzPerRoute from '../../../src/plugins/auth/authzPerRoute';
+import HelloWorld from '../../../src/plugins/demo/helloworld';
+import { expect } from 'chai';
+
+describe('AuthzPerRoute', () => {
+  describe('Basic rule enforcement', () => {
+    let app: Express;
+
+    before(async () => {
+      // full:tok-full → wildcard; updt:tok-updt → GET /api/hello only
+      process.env.DM_AUTH_TOKENS = 'tok-full:full,tok-updt:updt';
+      process.env.DM_AUTHZ_PER_ROUTE = 'full:*,updt:GET:/api/hello';
+      const dm = new DM();
+      await dm.ready;
+      // Auth must be registered before authz
+      await dm.registerPlugin('authToken', new AuthToken(dm));
+      await dm.registerPlugin('authzPerRoute', new AuthzPerRoute(dm));
+      await dm.registerPlugin('helloWorld', new HelloWorld(dm));
+      app = dm.app;
+    });
+
+    after(() => {
+      delete process.env.DM_AUTH_TOKENS;
+      delete process.env.DM_AUTHZ_PER_ROUTE;
+    });
+
+    it('wildcard user can reach /api/hello', async () => {
+      const res = await request(app)
+        .get('/api/hello')
+        .set('Authorization', 'Bearer tok-full');
+      expect(res.status).to.equal(200);
+    });
+
+    it('restricted user with matching GET rule → 200', async () => {
+      const res = await request(app)
+        .get('/api/hello')
+        .set('Authorization', 'Bearer tok-updt');
+      expect(res.status).to.equal(200);
+    });
+
+    it('restricted user with non-matching method → 403', async () => {
+      const res = await request(app)
+        .post('/api/hello')
+        .set('Authorization', 'Bearer tok-updt');
+      // POST is not in the rule for updt user; Express may return 404 for
+      // unregistered POST route, but our authz middleware runs first
+      // and should deny it with 403 before the route handler.
+      expect(res.status).to.equal(403);
+    });
+  });
+
+  describe('Unknown user (authenticated but not in authz config)', () => {
+    let app: Express;
+
+    before(async () => {
+      process.env.DM_AUTH_TOKENS = 'tok-known:known,tok-unknown:unknown';
+      process.env.DM_AUTHZ_PER_ROUTE = 'known:*';
+      const dm = new DM();
+      await dm.ready;
+      await dm.registerPlugin('authToken', new AuthToken(dm));
+      await dm.registerPlugin('authzPerRoute', new AuthzPerRoute(dm));
+      await dm.registerPlugin('helloWorld', new HelloWorld(dm));
+      app = dm.app;
+    });
+
+    after(() => {
+      delete process.env.DM_AUTH_TOKENS;
+      delete process.env.DM_AUTHZ_PER_ROUTE;
+    });
+
+    it('known user → 200', async () => {
+      const res = await request(app)
+        .get('/api/hello')
+        .set('Authorization', 'Bearer tok-known');
+      expect(res.status).to.equal(200);
+    });
+
+    it('authenticated but unknown-to-authz user → 403', async () => {
+      const res = await request(app)
+        .get('/api/hello')
+        .set('Authorization', 'Bearer tok-unknown');
+      expect(res.status).to.equal(403);
+    });
+  });
+
+  describe('No auth plugin (req.user unset)', () => {
+    let app: Express;
+
+    before(async () => {
+      delete process.env.DM_AUTH_TOKENS;
+      process.env.DM_AUTHZ_PER_ROUTE = 'someuser:*';
+      const dm = new DM();
+      await dm.ready;
+      // Only authz + helloWorld, no auth plugin → req.user stays unset
+      await dm.registerPlugin('authzPerRoute', new AuthzPerRoute(dm));
+      await dm.registerPlugin('helloWorld', new HelloWorld(dm));
+      app = dm.app;
+    });
+
+    after(() => {
+      delete process.env.DM_AUTHZ_PER_ROUTE;
+    });
+
+    it('unauthenticated request passes through authz middleware → 200', async () => {
+      const res = await request(app).get('/api/hello');
+      expect(res.status).to.equal(200);
+    });
+  });
+
+  describe('Invalid rule entries are ignored (no crash)', () => {
+    let app: Express;
+
+    before(async () => {
+      process.env.DM_AUTH_TOKENS = 'tok-full:full';
+      // "badentry" has no colon → invalid and should be skipped
+      process.env.DM_AUTHZ_PER_ROUTE = 'badentry,full:*';
+      const dm = new DM();
+      await dm.ready;
+      await dm.registerPlugin('authToken', new AuthToken(dm));
+      await dm.registerPlugin('authzPerRoute', new AuthzPerRoute(dm));
+      await dm.registerPlugin('helloWorld', new HelloWorld(dm));
+      app = dm.app;
+    });
+
+    after(() => {
+      delete process.env.DM_AUTH_TOKENS;
+      delete process.env.DM_AUTHZ_PER_ROUTE;
+    });
+
+    it('still starts and valid rules work', async () => {
+      const res = await request(app)
+        .get('/api/hello')
+        .set('Authorization', 'Bearer tok-full');
+      expect(res.status).to.equal(200);
+    });
+  });
+
+  describe('Method wildcard rule (*)', () => {
+    let app: Express;
+
+    before(async () => {
+      process.env.DM_AUTH_TOKENS = 'tok-any:any';
+      // any method on /api/hello
+      process.env.DM_AUTHZ_PER_ROUTE = 'any:*:/api/hello';
+      const dm = new DM();
+      await dm.ready;
+      await dm.registerPlugin('authToken', new AuthToken(dm));
+      await dm.registerPlugin('authzPerRoute', new AuthzPerRoute(dm));
+      await dm.registerPlugin('helloWorld', new HelloWorld(dm));
+      app = dm.app;
+    });
+
+    after(() => {
+      delete process.env.DM_AUTH_TOKENS;
+      delete process.env.DM_AUTHZ_PER_ROUTE;
+    });
+
+    it('method wildcard * allows GET', async () => {
+      const res = await request(app)
+        .get('/api/hello')
+        .set('Authorization', 'Bearer tok-any');
+      expect(res.status).to.equal(200);
+    });
+  });
+});

--- a/test/plugins/auth/authzPerRoute.test.ts
+++ b/test/plugins/auth/authzPerRoute.test.ts
@@ -281,4 +281,85 @@ describe('AuthzPerRoute', () => {
       expect(res.status).to.equal(403);
     });
   });
+
+  describe('parseEntry — trim and validation', () => {
+    // These tests inject entries directly into dm.config to bypass the env-var
+    // parser (which splits on whitespace). This simulates CLI usage where the
+    // shell preserves spaces inside quoted arguments, e.g.:
+    //   --authz-per-route " user :*"
+
+    it('entry with leading/trailing whitespace around user parses correctly (wildcard)', async () => {
+      process.env.DM_AUTH_TOKENS = 'tok-ws:user';
+      process.env.DM_AUTHZ_PER_ROUTE = 'placeholder';
+      const dm = new DM();
+      await dm.ready;
+      // Inject the whitespace-containing entry directly, bypassing env-var splitting
+      (dm.config as Record<string, unknown>).authz_per_route = [' user :*'];
+      await dm.registerPlugin('authToken', new AuthToken(dm));
+      await dm.registerPlugin('authzPerRoute', new AuthzPerRoute(dm));
+      await dm.registerPlugin('helloWorld', new HelloWorld(dm));
+      const res = await request(dm.app).get('/api/hello').set('Authorization', 'Bearer tok-ws');
+      expect(res.status).to.equal(200);
+      delete process.env.DM_AUTH_TOKENS;
+      delete process.env.DM_AUTHZ_PER_ROUTE;
+    });
+
+    it('entry with space before path trims correctly → 200', async () => {
+      process.env.DM_AUTH_TOKENS = 'tok-sp:user';
+      process.env.DM_AUTHZ_PER_ROUTE = 'placeholder';
+      const dm = new DM();
+      await dm.ready;
+      // Inject the entry with a space before the path
+      (dm.config as Record<string, unknown>).authz_per_route = ['user:GET: /api/hello'];
+      await dm.registerPlugin('authToken', new AuthToken(dm));
+      await dm.registerPlugin('authzPerRoute', new AuthzPerRoute(dm));
+      await dm.registerPlugin('helloWorld', new HelloWorld(dm));
+      const res = await request(dm.app).get('/api/hello').set('Authorization', 'Bearer tok-sp');
+      expect(res.status).to.equal(200);
+      delete process.env.DM_AUTH_TOKENS;
+      delete process.env.DM_AUTHZ_PER_ROUTE;
+    });
+
+    it('entry with unknown method is ignored → user has no rules → 403', async () => {
+      process.env.DM_AUTH_TOKENS = 'tok-bogus:user';
+      process.env.DM_AUTHZ_PER_ROUTE = 'user:BOGUS:/api/hello';
+      const dm = new DM();
+      await dm.ready;
+      await dm.registerPlugin('authToken', new AuthToken(dm));
+      await dm.registerPlugin('authzPerRoute', new AuthzPerRoute(dm));
+      await dm.registerPlugin('helloWorld', new HelloWorld(dm));
+      const res = await request(dm.app).get('/api/hello').set('Authorization', 'Bearer tok-bogus');
+      expect(res.status).to.equal(403);
+      delete process.env.DM_AUTH_TOKENS;
+      delete process.env.DM_AUTHZ_PER_ROUTE;
+    });
+
+    it('entry with empty method after trim is ignored → 403', async () => {
+      process.env.DM_AUTH_TOKENS = 'tok-em:user';
+      process.env.DM_AUTHZ_PER_ROUTE = 'user::/api/hello';
+      const dm = new DM();
+      await dm.ready;
+      await dm.registerPlugin('authToken', new AuthToken(dm));
+      await dm.registerPlugin('authzPerRoute', new AuthzPerRoute(dm));
+      await dm.registerPlugin('helloWorld', new HelloWorld(dm));
+      const res = await request(dm.app).get('/api/hello').set('Authorization', 'Bearer tok-em');
+      expect(res.status).to.equal(403);
+      delete process.env.DM_AUTH_TOKENS;
+      delete process.env.DM_AUTHZ_PER_ROUTE;
+    });
+
+    it('entry with empty user is ignored; other rules still apply', async () => {
+      process.env.DM_AUTH_TOKENS = 'tok-eu:realuser';
+      process.env.DM_AUTHZ_PER_ROUTE = ':GET:/api/hello,realuser:*';
+      const dm = new DM();
+      await dm.ready;
+      await dm.registerPlugin('authToken', new AuthToken(dm));
+      await dm.registerPlugin('authzPerRoute', new AuthzPerRoute(dm));
+      await dm.registerPlugin('helloWorld', new HelloWorld(dm));
+      const res = await request(dm.app).get('/api/hello').set('Authorization', 'Bearer tok-eu');
+      expect(res.status).to.equal(200);
+      delete process.env.DM_AUTH_TOKENS;
+      delete process.env.DM_AUTHZ_PER_ROUTE;
+    });
+  });
 });

--- a/test/plugins/auth/authzPerRoute.test.ts
+++ b/test/plugins/auth/authzPerRoute.test.ts
@@ -2,7 +2,7 @@ import { DM } from '../../../src/bin';
 import type { Express } from 'express';
 import request from 'supertest';
 import AuthToken from '../../../src/plugins/auth/token';
-import AuthzPerRoute from '../../../src/plugins/auth/authzPerRoute';
+import AuthzPerRoute, { globToRegex } from '../../../src/plugins/auth/authzPerRoute';
 import HelloWorld from '../../../src/plugins/demo/helloworld';
 import { expect } from 'chai';
 
@@ -144,7 +144,7 @@ describe('AuthzPerRoute', () => {
 
     before(async () => {
       process.env.DM_AUTH_TOKENS = 'tok-any:any';
-      // any method on /api/hello
+      // any method on /api/hello (exact glob — no wildcards in path)
       process.env.DM_AUTHZ_PER_ROUTE = 'any:*:/api/hello';
       const dm = new DM();
       await dm.ready;
@@ -164,6 +164,74 @@ describe('AuthzPerRoute', () => {
         .get('/api/hello')
         .set('Authorization', 'Bearer tok-any');
       expect(res.status).to.equal(200);
+    });
+  });
+
+  describe('globToRegex — glob semantics', () => {
+    describe('* (single segment wildcard)', () => {
+      it('matches one path segment', () => {
+        const re = globToRegex('/api/*');
+        expect(re.test('/api/hello')).to.equal(true);
+      });
+
+      it('does NOT cross a slash (no multi-segment match)', () => {
+        const re = globToRegex('/api/*');
+        expect(re.test('/api/hello/world')).to.equal(false);
+      });
+
+      it('does NOT match the prefix without a segment', () => {
+        const re = globToRegex('/api/*');
+        expect(re.test('/api')).to.equal(false);
+      });
+    });
+
+    describe('** (multi-segment wildcard)', () => {
+      it('matches a single segment', () => {
+        const re = globToRegex('/api/**');
+        expect(re.test('/api/hello')).to.equal(true);
+      });
+
+      it('crosses slashes (matches multiple segments)', () => {
+        const re = globToRegex('/api/**');
+        expect(re.test('/api/hello/world')).to.equal(true);
+      });
+
+      it('does NOT match the prefix alone (** must consume at least something)', () => {
+        const re = globToRegex('/api/**');
+        expect(re.test('/api')).to.equal(false);
+      });
+    });
+
+    describe('** appended directly to a prefix', () => {
+      it('matches the exact prefix', () => {
+        const re = globToRegex('/api/hello**');
+        expect(re.test('/api/hello')).to.equal(true);
+      });
+
+      it('matches the prefix with sub-paths', () => {
+        const re = globToRegex('/api/hello**');
+        expect(re.test('/api/hello/sub')).to.equal(true);
+        expect(re.test('/api/hello/sub/deep')).to.equal(true);
+      });
+
+      it('does NOT match a shorter string', () => {
+        const re = globToRegex('/api/hello**');
+        expect(re.test('/api/hell')).to.equal(false);
+      });
+    });
+
+    describe('regex metacharacters in glob are treated literally', () => {
+      it('. matches only a literal dot, not any character', () => {
+        const re = globToRegex('/api/hello.bak');
+        expect(re.test('/api/hello.bak')).to.equal(true);
+        expect(re.test('/api/helloXbak')).to.equal(false);
+      });
+
+      it('+ in pattern is literal', () => {
+        const re = globToRegex('/path+extra');
+        expect(re.test('/path+extra')).to.equal(true);
+        expect(re.test('/pathextra')).to.equal(false);
+      });
     });
   });
 });

--- a/test/plugins/auth/authzPerRoute.test.ts
+++ b/test/plugins/auth/authzPerRoute.test.ts
@@ -13,7 +13,7 @@ describe('AuthzPerRoute', () => {
     before(async () => {
       // full:tok-full → wildcard; updt:tok-updt → GET /api/hello only
       process.env.DM_AUTH_TOKENS = 'tok-full:full,tok-updt:updt';
-      process.env.DM_AUTHZ_PER_ROUTE = 'full:*,updt:GET:/api/hello';
+      process.env.DM_AUTHZ_PER_ROUTES = 'full:*,updt:GET:/api/hello';
       const dm = new DM();
       await dm.ready;
       // Auth must be registered before authz
@@ -25,7 +25,7 @@ describe('AuthzPerRoute', () => {
 
     after(() => {
       delete process.env.DM_AUTH_TOKENS;
-      delete process.env.DM_AUTHZ_PER_ROUTE;
+      delete process.env.DM_AUTHZ_PER_ROUTES;
     });
 
     it('wildcard user can reach /api/hello', async () => {
@@ -58,7 +58,7 @@ describe('AuthzPerRoute', () => {
 
     before(async () => {
       process.env.DM_AUTH_TOKENS = 'tok-known:known,tok-unknown:unknown';
-      process.env.DM_AUTHZ_PER_ROUTE = 'known:*';
+      process.env.DM_AUTHZ_PER_ROUTES = 'known:*';
       const dm = new DM();
       await dm.ready;
       await dm.registerPlugin('authToken', new AuthToken(dm));
@@ -69,7 +69,7 @@ describe('AuthzPerRoute', () => {
 
     after(() => {
       delete process.env.DM_AUTH_TOKENS;
-      delete process.env.DM_AUTHZ_PER_ROUTE;
+      delete process.env.DM_AUTHZ_PER_ROUTES;
     });
 
     it('known user → 200', async () => {
@@ -92,7 +92,7 @@ describe('AuthzPerRoute', () => {
 
     before(async () => {
       delete process.env.DM_AUTH_TOKENS;
-      process.env.DM_AUTHZ_PER_ROUTE = 'someuser:*';
+      process.env.DM_AUTHZ_PER_ROUTES = 'someuser:*';
       const dm = new DM();
       await dm.ready;
       // Only authz + helloWorld, no auth plugin → req.user stays unset
@@ -102,7 +102,7 @@ describe('AuthzPerRoute', () => {
     });
 
     after(() => {
-      delete process.env.DM_AUTHZ_PER_ROUTE;
+      delete process.env.DM_AUTHZ_PER_ROUTES;
     });
 
     it('unauthenticated request passes through authz middleware → 200', async () => {
@@ -117,7 +117,7 @@ describe('AuthzPerRoute', () => {
     before(async () => {
       process.env.DM_AUTH_TOKENS = 'tok-full:full';
       // "badentry" has no colon → invalid and should be skipped
-      process.env.DM_AUTHZ_PER_ROUTE = 'badentry,full:*';
+      process.env.DM_AUTHZ_PER_ROUTES = 'badentry,full:*';
       const dm = new DM();
       await dm.ready;
       await dm.registerPlugin('authToken', new AuthToken(dm));
@@ -128,7 +128,7 @@ describe('AuthzPerRoute', () => {
 
     after(() => {
       delete process.env.DM_AUTH_TOKENS;
-      delete process.env.DM_AUTHZ_PER_ROUTE;
+      delete process.env.DM_AUTHZ_PER_ROUTES;
     });
 
     it('still starts and valid rules work', async () => {
@@ -145,7 +145,7 @@ describe('AuthzPerRoute', () => {
     before(async () => {
       process.env.DM_AUTH_TOKENS = 'tok-any:any';
       // any method on /api/hello (exact glob — no wildcards in path)
-      process.env.DM_AUTHZ_PER_ROUTE = 'any:*:/api/hello';
+      process.env.DM_AUTHZ_PER_ROUTES = 'any:*:/api/hello';
       const dm = new DM();
       await dm.ready;
       await dm.registerPlugin('authToken', new AuthToken(dm));
@@ -156,7 +156,7 @@ describe('AuthzPerRoute', () => {
 
     after(() => {
       delete process.env.DM_AUTH_TOKENS;
-      delete process.env.DM_AUTHZ_PER_ROUTE;
+      delete process.env.DM_AUTHZ_PER_ROUTES;
     });
 
     it('method wildcard * allows GET', async () => {
@@ -253,7 +253,7 @@ describe('AuthzPerRoute', () => {
       // "foo?bar" contains a question-mark — invalid glob, rule must be skipped.
       // Deliberately avoid ';' here because the config parser uses ';' as array
       // separator when present in the env-var value, which would mangle the entry.
-      process.env.DM_AUTHZ_PER_ROUTE = 'validuser:GET:foo?bar,validuser:GET:/api/hello';
+      process.env.DM_AUTHZ_PER_ROUTES = 'validuser:GET:foo?bar,validuser:GET:/api/hello';
       const dm = new DM();
       await dm.ready;
       await dm.registerPlugin('authToken', new AuthToken(dm));
@@ -264,7 +264,7 @@ describe('AuthzPerRoute', () => {
 
     after(() => {
       delete process.env.DM_AUTH_TOKENS;
-      delete process.env.DM_AUTHZ_PER_ROUTE;
+      delete process.env.DM_AUTHZ_PER_ROUTES;
     });
 
     it('plugin starts and valid rule still works', async () => {
@@ -290,7 +290,7 @@ describe('AuthzPerRoute', () => {
 
     it('entry with leading/trailing whitespace around user parses correctly (wildcard)', async () => {
       process.env.DM_AUTH_TOKENS = 'tok-ws:user';
-      process.env.DM_AUTHZ_PER_ROUTE = 'placeholder';
+      process.env.DM_AUTHZ_PER_ROUTES = 'placeholder';
       const dm = new DM();
       await dm.ready;
       // Inject the whitespace-containing entry directly, bypassing env-var splitting
@@ -301,12 +301,12 @@ describe('AuthzPerRoute', () => {
       const res = await request(dm.app).get('/api/hello').set('Authorization', 'Bearer tok-ws');
       expect(res.status).to.equal(200);
       delete process.env.DM_AUTH_TOKENS;
-      delete process.env.DM_AUTHZ_PER_ROUTE;
+      delete process.env.DM_AUTHZ_PER_ROUTES;
     });
 
     it('entry with space before path trims correctly → 200', async () => {
       process.env.DM_AUTH_TOKENS = 'tok-sp:user';
-      process.env.DM_AUTHZ_PER_ROUTE = 'placeholder';
+      process.env.DM_AUTHZ_PER_ROUTES = 'placeholder';
       const dm = new DM();
       await dm.ready;
       // Inject the entry with a space before the path
@@ -317,12 +317,12 @@ describe('AuthzPerRoute', () => {
       const res = await request(dm.app).get('/api/hello').set('Authorization', 'Bearer tok-sp');
       expect(res.status).to.equal(200);
       delete process.env.DM_AUTH_TOKENS;
-      delete process.env.DM_AUTHZ_PER_ROUTE;
+      delete process.env.DM_AUTHZ_PER_ROUTES;
     });
 
     it('entry with unknown method is ignored → user has no rules → 403', async () => {
       process.env.DM_AUTH_TOKENS = 'tok-bogus:user';
-      process.env.DM_AUTHZ_PER_ROUTE = 'user:BOGUS:/api/hello';
+      process.env.DM_AUTHZ_PER_ROUTES = 'user:BOGUS:/api/hello';
       const dm = new DM();
       await dm.ready;
       await dm.registerPlugin('authToken', new AuthToken(dm));
@@ -331,12 +331,12 @@ describe('AuthzPerRoute', () => {
       const res = await request(dm.app).get('/api/hello').set('Authorization', 'Bearer tok-bogus');
       expect(res.status).to.equal(403);
       delete process.env.DM_AUTH_TOKENS;
-      delete process.env.DM_AUTHZ_PER_ROUTE;
+      delete process.env.DM_AUTHZ_PER_ROUTES;
     });
 
     it('entry with empty method after trim is ignored → 403', async () => {
       process.env.DM_AUTH_TOKENS = 'tok-em:user';
-      process.env.DM_AUTHZ_PER_ROUTE = 'user::/api/hello';
+      process.env.DM_AUTHZ_PER_ROUTES = 'user::/api/hello';
       const dm = new DM();
       await dm.ready;
       await dm.registerPlugin('authToken', new AuthToken(dm));
@@ -345,12 +345,12 @@ describe('AuthzPerRoute', () => {
       const res = await request(dm.app).get('/api/hello').set('Authorization', 'Bearer tok-em');
       expect(res.status).to.equal(403);
       delete process.env.DM_AUTH_TOKENS;
-      delete process.env.DM_AUTHZ_PER_ROUTE;
+      delete process.env.DM_AUTHZ_PER_ROUTES;
     });
 
     it('entry with empty user is ignored; other rules still apply', async () => {
       process.env.DM_AUTH_TOKENS = 'tok-eu:realuser';
-      process.env.DM_AUTHZ_PER_ROUTE = ':GET:/api/hello,realuser:*';
+      process.env.DM_AUTHZ_PER_ROUTES = ':GET:/api/hello,realuser:*';
       const dm = new DM();
       await dm.ready;
       await dm.registerPlugin('authToken', new AuthToken(dm));
@@ -359,7 +359,7 @@ describe('AuthzPerRoute', () => {
       const res = await request(dm.app).get('/api/hello').set('Authorization', 'Bearer tok-eu');
       expect(res.status).to.equal(200);
       delete process.env.DM_AUTH_TOKENS;
-      delete process.env.DM_AUTHZ_PER_ROUTE;
+      delete process.env.DM_AUTHZ_PER_ROUTES;
     });
   });
 });


### PR DESCRIPTION
## Summary

- New `core/auth/authzPerRoute` plugin: restricts API access by HTTP method + path based on `req.user` (set by an upstream auth plugin like `core/auth/token`).
- Orthogonal to the existing LDAP-DN-based authz plugins (`authzPerBranch`, `authzDynamic`) — covers the route-level ACL axis.
- Simple string rule format, repeatable CLI flag / comma-separated env var.

## Rule syntax

- `<user>:*` — full wildcard (any method, any path).
- `<user>:<METHOD>:<pathRegex>` — restrict (METHOD = HTTP verb or `*`; pathRegex auto-anchored with `^...$`).
- Multiple entries per user act as OR.

## Example

```bash
DM_AUTH_TOKENS="aaaa:full,bbbb:updt"
DM_AUTHZ_PER_ROUTE="full:*,updt:POST:/_updt"
--plugin core/auth/token --plugin core/auth/authzPerRoute
```

`full` token → access everywhere. `updt` token → only `POST /_updt`.

## Files

- `src/plugins/auth/authzPerRoute.ts` — plugin (extends `DmPlugin`, registers Express middleware via `api(app)`).
- `src/config/args.ts` — `--authz-per-route` / `DM_AUTHZ_PER_ROUTE` config wiring.
- `test/plugins/auth/authzPerRoute.test.ts` — 8 tests (wildcard, method match/mismatch, unknown user, no auth, invalid rules ignored, method `*`).
- `docs/usage/plugins/auth/authz-per-route.md` — dedicated doc page.
- `docs/usage/plugins/auth/README.md` + `docs/usage/configuration.md` — index/TOC entries.
- `package.json` — auto-generated export (via rollup).

## Test plan

- [x] `npm run test:one test/plugins/auth/authzPerRoute.test.ts` → 8 passing
- [x] `npm run test:one test/plugins/auth/token.test.ts` → 17 passing (no regression)
- [x] TypeScript clean
- [x] Reviewer to verify plugin loading order requirement is documented clearly (must be after auth plugin)