### PR TITLE
fix(scim): pass hook payload as spread args, not wrapped array

### DIFF
--- a/src/plugins/scim/bulk.ts
+++ b/src/plugins/scim/bulk.ts
@@ -93,7 +93,7 @@ export class ScimBulk {
       schemas: [SCHEMA_BULK_RESPONSE],
       Operations: responses,
     };
-    void launchHooks(this.hooks.scimbulkdone, [bulkResp]);
+    void launchHooks(this.hooks.scimbulkdone, bulkResp);
     return bulkResp;
   }
 

--- a/src/plugins/scim/groups.ts
+++ b/src/plugins/scim/groups.ts
@@ -339,7 +339,7 @@ export class ScimGroups {
     }
 
     const created = await this.get(req, rdn);
-    void launchHooks(this.hooks.scimgroupcreatedone, [created]);
+    void launchHooks(this.hooks.scimgroupcreatedone, created);
     return created;
   }
 
@@ -386,7 +386,7 @@ export class ScimGroups {
     await this.ldap.modify(dn, changes);
 
     const updated = await this.get(req, id);
-    void launchHooks(this.hooks.scimgroupupdatedone, [id, updated]);
+    void launchHooks(this.hooks.scimgroupupdatedone, id, updated);
     return updated;
   }
 
@@ -442,7 +442,7 @@ export class ScimGroups {
 
     await this.ldap.modify(dn, changes);
     const updated = await this.get(req, id);
-    void launchHooks(this.hooks.scimgroupupdatedone, [id, updated]);
+    void launchHooks(this.hooks.scimgroupupdatedone, id, updated);
     return updated;
   }
 
@@ -455,7 +455,7 @@ export class ScimGroups {
     const finalId = hookInput[0];
     const dn = this.dnForId(finalId, req);
     await this.ldap.delete(dn);
-    void launchHooks(this.hooks.scimgroupdeletedone, [finalId]);
+    void launchHooks(this.hooks.scimgroupdeletedone, finalId);
   }
 
   /** Used internally and by Bulk to resolve a Group SCIM reference to a DN. */

--- a/src/plugins/scim/users.ts
+++ b/src/plugins/scim/users.ts
@@ -273,7 +273,7 @@ export class ScimUsers {
     }
 
     const created = await this.get(req, rdn);
-    void launchHooks(this.hooks.scimusercreatedone, [created]);
+    void launchHooks(this.hooks.scimusercreatedone, created);
     return created;
   }
 
@@ -345,7 +345,7 @@ export class ScimUsers {
     }
 
     const updated = await this.get(req, id);
-    void launchHooks(this.hooks.scimuserupdatedone, [id, updated]);
+    void launchHooks(this.hooks.scimuserupdatedone, id, updated);
     return updated;
   }
 
@@ -369,7 +369,7 @@ export class ScimUsers {
     const dn = this.dnForId(id, req);
     await this.ldap.modify(dn, changes);
     const updated = await this.get(req, id);
-    void launchHooks(this.hooks.scimuserupdatedone, [id, updated]);
+    void launchHooks(this.hooks.scimuserupdatedone, id, updated);
     return updated;
   }
 
@@ -382,7 +382,7 @@ export class ScimUsers {
     const finalId = hookInput[0];
     const dn = this.dnForId(finalId, req);
     await this.ldap.delete(dn);
-    void launchHooks(this.hooks.scimuserdeletedone, [finalId]);
+    void launchHooks(this.hooks.scimuserdeletedone, finalId);
   }
 
   /**


### PR DESCRIPTION
## What's broken

Plugins that hook into the SCIM lifecycle never see the actual SCIM resource — they receive an array wrapping it. Any plugin that reads `user.userName`, `group.id`, etc. silently no-ops.

Most visible casualty: `core/twake/cozyProvision`. `POST /scim/v2/Users` returns 201 with the right body, but the plugin logs `"user has no userName/id — skipping"` and never publishes `auth/user.created` to RabbitMQ. Cozy instances aren't created.

## Root cause

`launchHooks(hooks, ...args)` spreads `args` into `hook(...args)`. The SCIM resource handlers were calling it with the payload wrapped in an array — `launchHooks(hooks.scimusercreatedone, [created])` — so each hook received `[scimUser]` (an array) rather than `scimUser`.

The wrapping looks copied from `launchHooksChained`, which deliberately takes one packed argument because it threads the value back through the chain. `launchHooks` doesn't.

The hook contract in `src/hooks.ts` is variadic (`scimusercreatedone: VoidHook<[ScimUser]>`), so passing the args directly is what was intended.

## The fix

Drop the array wrapping at the 9 `launchHooks` call sites in `src/plugins/scim/{users,groups,bulk}.ts`. `launchHooksChained` callers are untouched — they correctly pass a single packed arg.

## Reproduction

Before, against a stack with `core/twake/cozyProvision` loaded:

```
POST /scim/v2/Users {"userName":"alice",...}   -> 201
  ldap-rest log: "user has no userName/id - skipping"
  auth/user.created queue: empty
  cozy instances: not created
```

After:

```
POST /scim/v2/Users {"userName":"alice",...}   -> 201
  ldap-rest log: "Published message exchange: auth, routingKey: user.created"
  auth/user.created queue:
    {"sub":"alice","organizationDomain":"...","workplaceFqdn":"alice....","email":"..."}
  cozy instances: alice.<domain>  (status: onboarding)
```

The `DELETE /Users/{id}` path coincidentally worked before because `cozyProvision` only used `id` inside a template literal, where a single-element array stringifies to its element. Symptom-free until you hit a hook that does property access — which is most of them.

## Test plan

- [x] `npm test` — 740 passing, 0 failing on this branch
- [x] `npm run check:ts` clean, `eslint` clean on edited files
- [x] End-to-end on a real stack with cozyProvision + RabbitMQ + cozy-stack: SCIM `POST /Users` triggers the cozy instance creation and lands `auth/user.created` on the consumer queue