### PR TITLE
fix(cozyProvision): publish twakeId on user.created so cozy-stack accepts it

### DIFF
--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -192,9 +192,11 @@ export default class CozyProvision extends DmPlugin {
   }
 
   /**
-   * Publish user.created on the `auth` topic exchange. Payload mirrors what
-   * cozy-stack expects: a sub identifier, an optional email, and the
-   * organizationDomain so consumers can match the instance.
+   * Publish user.created on the `auth` topic exchange. Payload matches what
+   * cozy-stack's stack.user.created consumer expects: a `twakeId` identifier,
+   * an optional email, and the organizationDomain so the consumer can match
+   * the instance. Sending `sub` instead causes cozy-stack to nack the message
+   * with "missing twakeId".
    */
   private async publishUserCreated(user: ScimUser): Promise<void> {
     const publisher = await this.getPublisher();
@@ -205,7 +207,7 @@ export default class CozyProvision extends DmPlugin {
     const email = this.extractPrimaryEmail(user);
 
     const message: Record<string, unknown> = {
-      sub: id,
+      twakeId: id,
       organizationDomain: this.cozyOrgDomain,
       workplaceFqdn: `${id}.${this.cozyOrgDomain}`,
     };
@@ -219,13 +221,13 @@ export default class CozyProvision extends DmPlugin {
         result: 'success',
         exchange: this.authExchange,
         routingKey: 'user.created',
-        sub: id,
+        twakeId: id,
       });
     } catch (err) {
       this.logger.error({
         plugin: this.name,
         event: 'publishUserCreated',
-        sub: id,
+        twakeId: id,
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         error: `${err}`,
       });

--- a/test/plugins/twake/cozyProvision.test.ts
+++ b/test/plugins/twake/cozyProvision.test.ts
@@ -100,7 +100,7 @@ describe('CozyProvision plugin', () => {
       expect(call.exchange).to.equal('auth');
       expect(call.routingKey).to.equal('user.created');
       expect(call.message).to.deep.include({
-        sub: 'alice',
+        twakeId: 'alice',
         email: 'alice@twake.local',
         organizationDomain: 'twake.local',
         workplaceFqdn: 'alice.twake.local',


### PR DESCRIPTION
## What's broken

`cozyProvision` lands a message on `auth/user.created`, and cozy-stack's `stack.user.created` consumer immediately nacks it:

```
level=error msg="Message processing failed for queue stack.user.created: user.created: missing twakeId, nacking message"
```

Messages pile up in the dead-letter queue and the per-user cozy instance never completes onboarding.

## Root cause

The published payload uses `sub` for the user identifier — an OIDC convention — but cozy-stack reads `twakeId`. There's no other consumer of this exchange/routing key today, so `sub` was effectively dead.

## The fix

Rename the field to `twakeId` in the message body and the matching log lines. The plugin's existing test (`test/plugins/twake/cozyProvision.test.ts`) is updated to assert the new field name.

## Test plan

- [x] `npm test` — 740 passing
- [x] End-to-end on a real stack: `auth/user.created` now lands on `stack.user.created` and is acked, no DLQ entries; cozy instance reaches `onboarded` state.