### PR TITLE
fix(cozyProvision): set ContextName on POST /instances

### DIFF
--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -184,6 +184,7 @@ export interface Config {
   cozy_org_id?: string;
   cozy_org_domain?: string;
   cozy_default_locale?: string;
+  cozy_context_name?: string;
   cozy_auth_exchange?: string;
   cozy_b2b_exchange?: string;
   rabbitmq_url?: string;
@@ -466,6 +467,7 @@ const configArgs: ConfigTemplate = [
   ['--cozy-org-id', 'DM_COZY_ORG_ID', ''],
   ['--cozy-org-domain', 'DM_COZY_ORG_DOMAIN', ''],
   ['--cozy-default-locale', 'DM_COZY_DEFAULT_LOCALE', 'fr'],
+  ['--cozy-context-name', 'DM_COZY_CONTEXT_NAME', 'default'],
   ['--cozy-auth-exchange', 'DM_COZY_AUTH_EXCHANGE', 'auth'],
   ['--cozy-b2b-exchange', 'DM_COZY_B2B_EXCHANGE', 'b2b'],
   ['--rabbitmq-url', 'DM_RABBITMQ_URL', ''],

--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -45,6 +45,7 @@ export default class CozyProvision extends DmPlugin {
   private readonly cozyOrgId: string;
   private readonly cozyOrgDomain: string;
   private readonly cozyDefaultLocale: string;
+  private readonly cozyContextName: string;
   private readonly rabbitmqUrl: string;
   private readonly authExchange: string;
   private readonly b2bExchange: string;
@@ -66,6 +67,8 @@ export default class CozyProvision extends DmPlugin {
     this.cozyOrgDomain = (this.config.cozy_org_domain as string) || '';
     this.cozyDefaultLocale =
       (this.config.cozy_default_locale as string) || 'fr';
+    this.cozyContextName =
+      (this.config.cozy_context_name as string) || 'default';
     this.rabbitmqUrl = (this.config.rabbitmq_url as string) || '';
     this.authExchange = (this.config.cozy_auth_exchange as string) || 'auth';
     this.b2bExchange = (this.config.cozy_b2b_exchange as string) || 'b2b';
@@ -135,6 +138,7 @@ export default class CozyProvision extends DmPlugin {
     if (email) params.set('Email', email);
     if (this.cozyOrgId) params.set('OrgID', this.cozyOrgId);
     if (this.cozyOrgDomain) params.set('OrgDomain', this.cozyOrgDomain);
+    if (this.cozyContextName) params.set('ContextName', this.cozyContextName);
 
     const url = `${this.cozyAdminUrl}/instances?${params.toString()}`;
     const auth = Buffer.from(

--- a/test/plugins/twake/cozyProvision.test.ts
+++ b/test/plugins/twake/cozyProvision.test.ts
@@ -78,6 +78,7 @@ describe('CozyProvision plugin', () => {
           Email: 'alice@twake.local',
           OrgID: 'twp-test',
           OrgDomain: 'twake.local',
+          ContextName: 'default',
         })
         .matchHeader('authorization', /^Basic /)
         .reply(201, { ok: true });


### PR DESCRIPTION
## What's broken

`cozyProvision` calls cozy-stack's `POST /instances` without a `ContextName` parameter, so the new instance lands in the no-context bucket. Any per-context configuration in `cozy.yaml` — most notably:

```yaml
authentication:
  default:
    disable_password_authentication: true
```

— never applies to it. Even on a recent cozy-stack carrying the forced-OIDC handler ([cozy/cozy-stack#4744](https://github.com/cozy/cozy-stack/pull/4744)), the `user.created` consumer falls through to `inst.HasForcedOIDC()` returning false and nacks every message with `missing passphrase hash`.

## The fix

Add a `cozy_context_name` config option (env `DM_COZY_CONTEXT_NAME`, CLI `--cozy-context-name`), defaulting to `default`. The default matches the most common `cozy.yaml` shape out of the box (cozy-stack ships an `authentication.default` block); operators with a different context name can override.

## Test plan

- [x] `npm test` — 740 passing, 0 failing
- [x] End-to-end on a real stack: instance lands in `context_name: default`, cozy-stack's `user.created` handler hits the forced-OIDC branch and acks the message; no DLQ growth.