### PR TITLE
fix(cozyProvision): rename email to internalEmail, forward phone as mobile

### DIFF
--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -184,6 +184,7 @@ export interface Config {
   cozy_org_id?: string;
   cozy_org_domain?: string;
   cozy_default_locale?: string;
+  cozy_context_name?: string;
   cozy_auth_exchange?: string;
   cozy_b2b_exchange?: string;
   rabbitmq_url?: string;
@@ -466,6 +467,7 @@ const configArgs: ConfigTemplate = [
   ['--cozy-org-id', 'DM_COZY_ORG_ID', ''],
   ['--cozy-org-domain', 'DM_COZY_ORG_DOMAIN', ''],
   ['--cozy-default-locale', 'DM_COZY_DEFAULT_LOCALE', 'fr'],
+  ['--cozy-context-name', 'DM_COZY_CONTEXT_NAME', 'default'],
   ['--cozy-auth-exchange', 'DM_COZY_AUTH_EXCHANGE', 'auth'],
   ['--cozy-b2b-exchange', 'DM_COZY_B2B_EXCHANGE', 'b2b'],
   ['--rabbitmq-url', 'DM_RABBITMQ_URL', ''],

--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -168,6 +168,7 @@ export default class CozyProvision extends DmPlugin {
             result: 'already_exists',
             http_status: res.status,
           });
+          await this.markInstanceOnboarded(domain);
           return true;
         }
         this.logger.error({
@@ -183,6 +184,7 @@ export default class CozyProvision extends DmPlugin {
         result: 'success',
         http_status: res.status,
       });
+      await this.markInstanceOnboarded(domain);
       return true;
     } catch (err) {
       this.logger.error({
@@ -192,6 +194,58 @@ export default class CozyProvision extends DmPlugin {
         error: `${err}`,
       });
       return false;
+    }
+  }
+
+  /**
+   * PATCH /instances/<domain>?OnboardingFinished=true on the cozy admin API.
+   *
+   * SCIM-provisioned users have no signup flow to complete (the admin already
+   * provisioned them), so the per-user instance should land directly in the
+   * onboarded state. Without this PATCH the instance stays in onboarding and
+   * the user gets dropped onto a setup wizard at first OIDC login.
+   */
+  private async markInstanceOnboarded(domain: string): Promise<void> {
+    const url = `${this.cozyAdminUrl}/instances/${encodeURIComponent(
+      domain
+    )}?OnboardingFinished=true`;
+    const auth = Buffer.from(
+      `${this.cozyAdminUser}:${this.cozyAdminPassphrase}`
+    ).toString('base64');
+    const log = {
+      plugin: this.name,
+      event: 'markInstanceOnboarded',
+      domain,
+    };
+    try {
+      const res = await fetch(url, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Basic ${auth}`,
+          Accept: 'application/json',
+        },
+      });
+      if (!res.ok) {
+        this.logger.error({
+          ...log,
+          result: 'error',
+          http_status: res.status,
+          http_status_text: res.statusText,
+        });
+        return;
+      }
+      this.logger.info({
+        ...log,
+        result: 'success',
+        http_status: res.status,
+      });
+    } catch (err) {
+      this.logger.error({
+        ...log,
+        result: 'error',
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        error: `${err}`,
+      });
     }
   }
 

--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -45,6 +45,7 @@ export default class CozyProvision extends DmPlugin {
   private readonly cozyOrgId: string;
   private readonly cozyOrgDomain: string;
   private readonly cozyDefaultLocale: string;
+  private readonly cozyContextName: string;
   private readonly rabbitmqUrl: string;
   private readonly authExchange: string;
   private readonly b2bExchange: string;
@@ -66,6 +67,8 @@ export default class CozyProvision extends DmPlugin {
     this.cozyOrgDomain = (this.config.cozy_org_domain as string) || '';
     this.cozyDefaultLocale =
       (this.config.cozy_default_locale as string) || 'fr';
+    this.cozyContextName =
+      (this.config.cozy_context_name as string) || 'default';
     this.rabbitmqUrl = (this.config.rabbitmq_url as string) || '';
     this.authExchange = (this.config.cozy_auth_exchange as string) || 'auth';
     this.b2bExchange = (this.config.cozy_b2b_exchange as string) || 'b2b';
@@ -135,6 +138,7 @@ export default class CozyProvision extends DmPlugin {
     if (email) params.set('Email', email);
     if (this.cozyOrgId) params.set('OrgID', this.cozyOrgId);
     if (this.cozyOrgDomain) params.set('OrgDomain', this.cozyOrgDomain);
+    if (this.cozyContextName) params.set('ContextName', this.cozyContextName);
 
     const url = `${this.cozyAdminUrl}/instances?${params.toString()}`;
     const auth = Buffer.from(

--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -263,13 +263,15 @@ export default class CozyProvision extends DmPlugin {
     const id = this.extractId(user);
     if (!id) return;
     const email = this.extractPrimaryEmail(user);
+    const mobile = this.extractPrimaryPhone(user);
 
     const message: Record<string, unknown> = {
       twakeId: id,
       organizationDomain: this.cozyOrgDomain,
       workplaceFqdn: `${id}.${this.cozyOrgDomain}`,
     };
-    if (email) message.email = email;
+    if (email) message.internalEmail = email;
+    if (mobile) message.mobile = mobile;
 
     try {
       await publisher.publish(this.authExchange, 'user.created', message);
@@ -393,6 +395,14 @@ export default class CozyProvision extends DmPlugin {
     if (!emails || emails.length === 0) return null;
     const primary = emails.find(e => e.primary);
     const value = (primary || emails[0]).value;
+    return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+
+  private extractPrimaryPhone(user: ScimUser): string | null {
+    const phones = user.phoneNumbers;
+    if (!phones || phones.length === 0) return null;
+    const primary = phones.find(p => p.primary);
+    const value = (primary || phones[0]).value;
     return typeof value === 'string' && value.length > 0 ? value : null;
   }
 

--- a/test/plugins/twake/cozyProvision.test.ts
+++ b/test/plugins/twake/cozyProvision.test.ts
@@ -81,7 +81,10 @@ describe('CozyProvision plugin', () => {
           ContextName: 'default',
         })
         .matchHeader('authorization', /^Basic /)
-        .reply(201, { ok: true });
+        .reply(201, { ok: true })
+        .patch('/instances/alice.twake.local')
+        .query({ OnboardingFinished: 'true' })
+        .reply(200, { ok: true });
 
       const user: ScimUser = {
         schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
@@ -95,7 +98,7 @@ describe('CozyProvision plugin', () => {
       ) => Promise<void>;
       await hook(user);
 
-      expect(scope.isDone(), 'cozy admin POST').to.be.true;
+      expect(scope.isDone(), 'cozy admin POST + PATCH').to.be.true;
       expect(plugin.stub.calls).to.have.length(1);
       const call = plugin.stub.calls[0];
       expect(call.exchange).to.equal('auth');
@@ -112,7 +115,10 @@ describe('CozyProvision plugin', () => {
       const scope = nock(COZY_URL)
         .post('/instances')
         .query(true)
-        .reply(409, { error: 'already exists' });
+        .reply(409, { error: 'already exists' })
+        .patch('/instances/bob.twake.local')
+        .query({ OnboardingFinished: 'true' })
+        .reply(200, { ok: true });
 
       const user: ScimUser = {
         schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
@@ -153,7 +159,10 @@ describe('CozyProvision plugin', () => {
       const scope = nock(COZY_URL)
         .post('/instances')
         .query(q => q.Locale === 'en')
-        .reply(201, { ok: true });
+        .reply(201, { ok: true })
+        .patch('/instances/dave.twake.local')
+        .query({ OnboardingFinished: 'true' })
+        .reply(200, { ok: true });
 
       const user: ScimUser = {
         schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],

--- a/test/plugins/twake/cozyProvision.test.ts
+++ b/test/plugins/twake/cozyProvision.test.ts
@@ -78,6 +78,7 @@ describe('CozyProvision plugin', () => {
           Email: 'alice@twake.local',
           OrgID: 'twp-test',
           OrgDomain: 'twake.local',
+          ContextName: 'default',
         })
         .matchHeader('authorization', /^Basic /)
         .reply(201, { ok: true });

--- a/test/plugins/twake/cozyProvision.test.ts
+++ b/test/plugins/twake/cozyProvision.test.ts
@@ -105,9 +105,39 @@ describe('CozyProvision plugin', () => {
       expect(call.routingKey).to.equal('user.created');
       expect(call.message).to.deep.include({
         twakeId: 'alice',
-        email: 'alice@twake.local',
+        internalEmail: 'alice@twake.local',
         organizationDomain: 'twake.local',
         workplaceFqdn: 'alice.twake.local',
+      });
+    });
+
+    it('forwards primary phoneNumber as mobile when provided', async () => {
+      nock(COZY_URL)
+        .post('/instances')
+        .query(true)
+        .reply(201, { ok: true })
+        .patch('/instances/grace.twake.local')
+        .query({ OnboardingFinished: 'true' })
+        .reply(200, { ok: true });
+
+      const user: ScimUser = {
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: 'grace',
+        phoneNumbers: [
+          { value: '+33600000000', primary: true },
+          { value: '+33700000000' },
+        ],
+      };
+
+      const hook = plugin.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await hook(user);
+
+      expect(plugin.stub.calls).to.have.length(1);
+      expect(plugin.stub.calls[0].message).to.deep.include({
+        twakeId: 'grace',
+        mobile: '+33600000000',
       });
     });
 


### PR DESCRIPTION
## What's broken

cozy-stack's `UserCreatedMessage` (`pkg/rabbitmq/handlers.go:127-141`) reads `internalEmail`, not `email`. The email we attach to `user.created` deserialises to `""`, so as soon as cozy-stack's org-contact-sync runs (triggered by the non-empty `organizationDomain` we always send) it nacks the message:

```
user.created: missing internalEmail for organization contact sync, nacking message
```

Symptom only surfaces once the earlier blockers are out of the way (`#66`, `#67`, `#68`, `#69`) — before that the message never reached `SyncCreatedOrgContact`.

## The fix

- Rename the field in the published payload: `email` → `internalEmail`.
- Forward the SCIM user's primary `phoneNumbers[primary=true].value` as `mobile`. cozy-stack uses it for the user's `phone` setting and on the org contact card; previously always blank for SCIM-provisioned users.

New unit test asserts `mobile` is forwarded; existing test updated for the field rename.

## Stacked on #69 / #68

Independent fix but shares the same `cozyProvision.publishUserCreated` area. Easy rebase once the earlier PRs land.

## Test plan

- [x] `npm test` — 741 passing (+1 new), 0 failing
- [x] End-to-end on a real stack with #66-#69 applied: `auth/user.created` is consumed by `stack.user.created`, no DLQ growth, cozy contact card on the org instance has the user's mobile