### PR TITLE
fix(cozyProvision): set PublicName + Phone on instance create, include domain in publish

### DIFF
--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -136,6 +136,10 @@ export default class CozyProvision extends DmPlugin {
     params.set('Locale', this.extractLocale(user));
     const email = this.extractPrimaryEmail(user);
     if (email) params.set('Email', email);
+    const publicName = this.extractPublicName(user);
+    if (publicName) params.set('PublicName', publicName);
+    const phone = this.extractPrimaryPhone(user);
+    if (phone) params.set('Phone', phone);
     if (this.cozyOrgId) params.set('OrgID', this.cozyOrgId);
     if (this.cozyOrgDomain) params.set('OrgDomain', this.cozyOrgDomain);
     if (this.cozyContextName) params.set('ContextName', this.cozyContextName);
@@ -267,6 +271,7 @@ export default class CozyProvision extends DmPlugin {
 
     const message: Record<string, unknown> = {
       twakeId: id,
+      domain: this.cozyOrgDomain,
       organizationDomain: this.cozyOrgDomain,
       workplaceFqdn: `${id}.${this.cozyOrgDomain}`,
     };
@@ -404,6 +409,33 @@ export default class CozyProvision extends DmPlugin {
     const primary = phones.find(p => p.primary);
     const value = (primary || phones[0]).value;
     return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+
+  /**
+   * Best-effort display name for the cozy instance's `public_name` setting,
+   * which downstream features (org-contact sync, sharing, mailer, …) read
+   * from the instance settings document. Without it cozy-stack's
+   * SyncCreatedOrgContact bails with "missing public_name in settings".
+   *
+   * Order of preference: SCIM displayName → name.formatted →
+   * givenName + familyName → userName/id.
+   */
+  private extractPublicName(user: ScimUser): string | null {
+    if (
+      typeof user.displayName === 'string' &&
+      user.displayName.trim().length > 0
+    ) {
+      return user.displayName.trim();
+    }
+    const formatted = user.name?.formatted;
+    if (typeof formatted === 'string' && formatted.trim().length > 0) {
+      return formatted.trim();
+    }
+    const given = user.name?.givenName?.trim() ?? '';
+    const family = user.name?.familyName?.trim() ?? '';
+    const composed = `${given} ${family}`.trim();
+    if (composed.length > 0) return composed;
+    return this.extractId(user);
   }
 
   private extractLocale(user: ScimUser): string {

--- a/test/plugins/twake/cozyProvision.test.ts
+++ b/test/plugins/twake/cozyProvision.test.ts
@@ -76,6 +76,7 @@ describe('CozyProvision plugin', () => {
           Domain: 'alice.twake.local',
           Locale: 'fr',
           Email: 'alice@twake.local',
+          PublicName: 'alice',
           OrgID: 'twp-test',
           OrgDomain: 'twake.local',
           ContextName: 'default',
@@ -105,10 +106,34 @@ describe('CozyProvision plugin', () => {
       expect(call.routingKey).to.equal('user.created');
       expect(call.message).to.deep.include({
         twakeId: 'alice',
+        domain: 'twake.local',
         internalEmail: 'alice@twake.local',
         organizationDomain: 'twake.local',
         workplaceFqdn: 'alice.twake.local',
       });
+    });
+
+    it('uses SCIM displayName / name as PublicName when provided', async () => {
+      const scope = nock(COZY_URL)
+        .post('/instances')
+        .query(q => q.PublicName === 'Khaled Ferjani' && q.Phone === '+33600000000')
+        .reply(201, { ok: true })
+        .patch('/instances/khaled.twake.local')
+        .query({ OnboardingFinished: 'true' })
+        .reply(200, { ok: true });
+
+      const user: ScimUser = {
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: 'khaled',
+        displayName: 'Khaled Ferjani',
+        phoneNumbers: [{ value: '+33600000000', primary: true }],
+      };
+
+      const hook = plugin.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await hook(user);
+      expect(scope.isDone()).to.be.true;
     });
 
     it('forwards primary phoneNumber as mobile when provided', async () => {


### PR DESCRIPTION
## What's broken

cozy-stack's `SyncCreatedOrgContact` (`pkg/rabbitmq/org_contacts.go:29`) reads `public_name` from the instance's settings document and nacks `user.created` when it's empty:

```
user.created: missing public_name in settings for <user>.<domain>, nacking message
```

For SCIM-provisioned users we never set it — the `POST /instances` call has no `PublicName` (or `Phone`) query param.

## The fix

Two changes, both in `cozyProvision`:

1. **Set `PublicName` and `Phone` on `POST /instances`.** cozy-stack's instances handler (`web/instances/instances.go:71-72`) accepts both directly and persists them in the instance settings doc, where org-contact-sync (and other features) read from. `PublicName` falls back through `displayName → name.formatted → givenName+familyName → userName` so it's never empty.
2. **Include `domain` in the `auth/user.created` publish.** It maps to the deployment's `cozy_org_domain` config — matches what cozy-stack expects and avoids the consumer falling through to its hard-coded `DefaultDomain`.

## Test plan

- [x] `npm test` — 742 passing (+1), 0 failing
- [x] End-to-end on a real stack: SCIM POST creates the instance with `public_name` and `phone` populated; `auth/user.created` is consumed cleanly by `stack.user.created`; org-contact-sync succeeds and the contact card on the org instance carries the user's display name + phone.