### PR TITLE
fix(cozyProvision): install default apps on instance create

### DIFF
--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -185,6 +185,7 @@ export interface Config {
   cozy_org_domain?: string;
   cozy_default_locale?: string;
   cozy_context_name?: string;
+  cozy_apps?: string;
   cozy_auth_exchange?: string;
   cozy_b2b_exchange?: string;
   rabbitmq_url?: string;
@@ -468,6 +469,7 @@ const configArgs: ConfigTemplate = [
   ['--cozy-org-domain', 'DM_COZY_ORG_DOMAIN', ''],
   ['--cozy-default-locale', 'DM_COZY_DEFAULT_LOCALE', 'fr'],
   ['--cozy-context-name', 'DM_COZY_CONTEXT_NAME', 'default'],
+  ['--cozy-apps', 'DM_COZY_APPS', 'home,drive,settings,notes,dataproxy'],
   ['--cozy-auth-exchange', 'DM_COZY_AUTH_EXCHANGE', 'auth'],
   ['--cozy-b2b-exchange', 'DM_COZY_B2B_EXCHANGE', 'b2b'],
   ['--rabbitmq-url', 'DM_RABBITMQ_URL', ''],

--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -46,6 +46,7 @@ export default class CozyProvision extends DmPlugin {
   private readonly cozyOrgDomain: string;
   private readonly cozyDefaultLocale: string;
   private readonly cozyContextName: string;
+  private readonly cozyApps: string;
   private readonly rabbitmqUrl: string;
   private readonly authExchange: string;
   private readonly b2bExchange: string;
@@ -69,6 +70,7 @@ export default class CozyProvision extends DmPlugin {
       (this.config.cozy_default_locale as string) || 'fr';
     this.cozyContextName =
       (this.config.cozy_context_name as string) || 'default';
+    this.cozyApps = (this.config.cozy_apps as string) ?? '';
     this.rabbitmqUrl = (this.config.rabbitmq_url as string) || '';
     this.authExchange = (this.config.cozy_auth_exchange as string) || 'auth';
     this.b2bExchange = (this.config.cozy_b2b_exchange as string) || 'b2b';
@@ -143,6 +145,7 @@ export default class CozyProvision extends DmPlugin {
     if (this.cozyOrgId) params.set('OrgID', this.cozyOrgId);
     if (this.cozyOrgDomain) params.set('OrgDomain', this.cozyOrgDomain);
     if (this.cozyContextName) params.set('ContextName', this.cozyContextName);
+    if (this.cozyApps) params.set('Apps', this.cozyApps);
 
     const url = `${this.cozyAdminUrl}/instances?${params.toString()}`;
     const auth = Buffer.from(

--- a/test/plugins/twake/cozyProvision.test.ts
+++ b/test/plugins/twake/cozyProvision.test.ts
@@ -80,6 +80,7 @@ describe('CozyProvision plugin', () => {
           OrgID: 'twp-test',
           OrgDomain: 'twake.local',
           ContextName: 'default',
+          Apps: 'home,drive,settings,notes,dataproxy',
         })
         .matchHeader('authorization', /^Basic /)
         .reply(201, { ok: true })
@@ -111,6 +112,50 @@ describe('CozyProvision plugin', () => {
         organizationDomain: 'twake.local',
         workplaceFqdn: 'alice.twake.local',
       });
+    });
+
+    it('respects cozy_apps override', async () => {
+      dm.config.cozy_apps = 'home,drive';
+      const p = new TestableCozyProvision(dm);
+      const scope = nock(COZY_URL)
+        .post('/instances')
+        .query(q => q.Apps === 'home,drive')
+        .reply(201, { ok: true })
+        .patch('/instances/ivy.twake.local')
+        .query({ OnboardingFinished: 'true' })
+        .reply(200, { ok: true });
+
+      const user: ScimUser = {
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: 'ivy',
+      };
+      const hook = p.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await hook(user);
+      expect(scope.isDone()).to.be.true;
+    });
+
+    it('omits Apps query param when cozy_apps is empty', async () => {
+      dm.config.cozy_apps = '';
+      const p = new TestableCozyProvision(dm);
+      const scope = nock(COZY_URL)
+        .post('/instances')
+        .query(q => !('Apps' in q))
+        .reply(201, { ok: true })
+        .patch('/instances/jack.twake.local')
+        .query({ OnboardingFinished: 'true' })
+        .reply(200, { ok: true });
+
+      const user: ScimUser = {
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: 'jack',
+      };
+      const hook = p.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await hook(user);
+      expect(scope.isDone()).to.be.true;
     });
 
     it('uses SCIM displayName / name as PublicName when provided', async () => {


### PR DESCRIPTION
## What's broken

`cozyProvision` calls `POST /instances` without an `Apps` query param, so cozy-stack creates the per-user instance with no webapps registered. Users land on a blank cloud at first login — no `home`, no `drive`, nothing.

The matching pattern in this stack is what the cozy-stack patcher script does for bootstrap users: `cozy-stack instances add --apps home,drive,notes,settings,dataproxy …`. SCIM-provisioned users should get the same treatment.

## The fix

New env var `DM_COZY_APPS` (CLI: `--cozy-apps`), defaulting to `home,drive,settings,notes,dataproxy` — the standard Twake user app set. Set as the `Apps` query param on `POST /instances`. Operators who want to drive app installs out-of-band can set it to an empty string to keep the previous behaviour.

## Test plan

- [x] `npm test` — 745 passing (+2), 0 failing
- [x] End-to-end on a real stack: SCIM POST → `cozy-stack apps ls --domain <user>.<domain>` lists the configured apps; user lands on a fully provisioned home page at first OIDC login.