### PR TITLE
fix(cozyProvision): set OIDCID on instance create

### DIFF
--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -146,6 +146,11 @@ export default class CozyProvision extends DmPlugin {
     if (this.cozyOrgDomain) params.set('OrgDomain', this.cozyOrgDomain);
     if (this.cozyContextName) params.set('ContextName', this.cozyContextName);
     if (this.cozyApps) params.set('Apps', this.cozyApps);
+    // Set the cozy instance's OIDCID to the user's SCIM userName so the
+    // sub claim from the OP after authentication matches the instance and
+    // cozy-stack's OIDC callback succeeds. Without this the callback fails
+    // with `Invalid sub: <sub> != ""`.
+    params.set('OIDCID', id);
 
     const url = `${this.cozyAdminUrl}/instances?${params.toString()}`;
     const auth = Buffer.from(

--- a/test/plugins/twake/cozyProvision.test.ts
+++ b/test/plugins/twake/cozyProvision.test.ts
@@ -81,6 +81,7 @@ describe('CozyProvision plugin', () => {
           OrgDomain: 'twake.local',
           ContextName: 'default',
           Apps: 'home,drive,settings,notes,dataproxy',
+          OIDCID: 'alice',
         })
         .matchHeader('authorization', /^Basic /)
         .reply(201, { ok: true })


### PR DESCRIPTION
## What's broken

`cozyProvision` creates the per-user cozy instance via `POST /instances` without an `OIDCID` parameter, so the instance lands with an empty `oidc_id`. As soon as the user logs in through OIDC, cozy-stack's callback handler rejects them:

```
Invalid sub: <sub> != ""
```

The bootstrap-user provisioning script in `twake-workplace-docker` (`cozy_stack/scripts/patch-cozy.sh`) side-steps this by running `cozy-stack instances modify --oidc_id "$USERID"` after creation. SCIM-provisioned users had no equivalent step.

## The fix

Pass the SCIM `userName` as `OIDCID` on `POST /instances` so newly-created instances are immediately usable. Matches the existing `patch-cozy.sh` convention.