### PR TITLE
fix(twake/cozyProvision): destroy cozy instance on SCIM delete

### DIFF
--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -50,6 +50,7 @@ export default class CozyProvision extends DmPlugin {
   private readonly rabbitmqUrl: string;
   private readonly authExchange: string;
   private readonly b2bExchange: string;
+  private readonly cozyAdminAuthHeader: string;
 
   private publisher: RabbitPublisher | null = null;
   private publisherInit: Promise<RabbitPublisher | null> | null = null;
@@ -74,6 +75,9 @@ export default class CozyProvision extends DmPlugin {
     this.rabbitmqUrl = (this.config.rabbitmq_url as string) || '';
     this.authExchange = (this.config.cozy_auth_exchange as string) || 'auth';
     this.b2bExchange = (this.config.cozy_b2b_exchange as string) || 'b2b';
+    this.cozyAdminAuthHeader = `Basic ${Buffer.from(
+      `${this.cozyAdminUser}:${this.cozyAdminPassphrase}`
+    ).toString('base64')}`;
 
     if (!this.cozyAdminUrl) {
       this.logger.warn(
@@ -102,7 +106,10 @@ export default class CozyProvision extends DmPlugin {
       }
     },
     scimuserdeletedone: async (id: string): Promise<void> => {
-      await this.publishUserDeleted(id);
+      const ok = await this.destroyCozyInstance(id);
+      if (ok) {
+        await this.publishUserDeleted(id);
+      }
     },
   };
 
@@ -153,9 +160,6 @@ export default class CozyProvision extends DmPlugin {
     params.set('OIDCID', id);
 
     const url = `${this.cozyAdminUrl}/instances?${params.toString()}`;
-    const auth = Buffer.from(
-      `${this.cozyAdminUser}:${this.cozyAdminPassphrase}`
-    ).toString('base64');
 
     const log = {
       plugin: this.name,
@@ -169,7 +173,7 @@ export default class CozyProvision extends DmPlugin {
       const res = await fetch(url, {
         method: 'POST',
         headers: {
-          Authorization: `Basic ${auth}`,
+          Authorization: this.cozyAdminAuthHeader,
           Accept: 'application/json',
         },
       });
@@ -220,9 +224,6 @@ export default class CozyProvision extends DmPlugin {
     const url = `${this.cozyAdminUrl}/instances/${encodeURIComponent(
       domain
     )}?OnboardingFinished=true`;
-    const auth = Buffer.from(
-      `${this.cozyAdminUser}:${this.cozyAdminPassphrase}`
-    ).toString('base64');
     const log = {
       plugin: this.name,
       event: 'markInstanceOnboarded',
@@ -232,7 +233,7 @@ export default class CozyProvision extends DmPlugin {
       const res = await fetch(url, {
         method: 'PATCH',
         headers: {
-          Authorization: `Basic ${auth}`,
+          Authorization: this.cozyAdminAuthHeader,
           Accept: 'application/json',
         },
       });
@@ -257,6 +258,69 @@ export default class CozyProvision extends DmPlugin {
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         error: `${err}`,
       });
+    }
+  }
+
+  /**
+   * DELETE /instances/<domain> on the cozy-stack admin API. The SCIM delete
+   * hook only removed the LDAP entry; without this, a subsequent re-import
+   * of the same userName re-attaches to a stale cozy instance whose
+   * per-user state (oidc_id, sharings, contacts, ...) no longer matches
+   * the operator's intent. A 404 from cozy-stack is treated as success so
+   * the lifecycle stays idempotent.
+   */
+  private async destroyCozyInstance(id: string): Promise<boolean> {
+    if (!this.cozyAdminUrl) return false;
+    if (!this.cozyOrgDomain) {
+      this.logger.error({
+        plugin: this.name,
+        event: 'destroyCozyInstance',
+        id,
+        message: 'cozy_org_domain not configured — cannot compose Domain',
+      });
+      return false;
+    }
+
+    const domain = `${id}.${this.cozyOrgDomain}`;
+    const url = `${this.cozyAdminUrl}/instances/${encodeURIComponent(domain)}`;
+    const log = {
+      plugin: this.name,
+      event: 'destroyCozyInstance',
+      id,
+      domain,
+    };
+
+    try {
+      const res = await fetch(url, {
+        method: 'DELETE',
+        headers: {
+          Authorization: this.cozyAdminAuthHeader,
+          Accept: 'application/json',
+        },
+      });
+      if (res.ok || res.status === 404) {
+        this.logger.info({
+          ...log,
+          result: res.ok ? 'success' : 'not_found',
+          http_status: res.status,
+        });
+        return true;
+      }
+      this.logger.error({
+        ...log,
+        result: 'error',
+        http_status: res.status,
+        http_status_text: res.statusText,
+      });
+      return false;
+    } catch (err) {
+      this.logger.error({
+        ...log,
+        result: 'error',
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        error: `${err}`,
+      });
+      return false;
     }
   }
 

--- a/test/plugins/twake/cozyProvision.test.ts
+++ b/test/plugins/twake/cozyProvision.test.ts
@@ -315,12 +315,17 @@ describe('CozyProvision plugin', () => {
   });
 
   describe('scimuserdeletedone', () => {
-    it('publishes domain.user.deleted with composed workplaceFqdn', async () => {
+    it('DELETEs the cozy instance and publishes domain.user.deleted', async () => {
+      const scope = nock(COZY_URL)
+        .delete('/instances/eve.twake.local')
+        .reply(204);
+
       const hook = plugin.hooks?.scimuserdeletedone as (
         id: string
       ) => Promise<void>;
       await hook('eve');
 
+      expect(scope.isDone()).to.equal(true);
       expect(plugin.stub.calls).to.have.length(1);
       const call = plugin.stub.calls[0];
       expect(call.exchange).to.equal('b2b');
@@ -329,6 +334,35 @@ describe('CozyProvision plugin', () => {
         workplaceFqdn: 'eve.twake.local',
         domain: 'twake.local',
       });
+    });
+
+    it('treats 404 from cozy admin as success and still publishes', async () => {
+      const scope = nock(COZY_URL)
+        .delete('/instances/ghost.twake.local')
+        .reply(404);
+
+      const hook = plugin.hooks?.scimuserdeletedone as (
+        id: string
+      ) => Promise<void>;
+      await hook('ghost');
+
+      expect(scope.isDone()).to.equal(true);
+      expect(plugin.stub.calls).to.have.length(1);
+      expect(plugin.stub.calls[0].routingKey).to.equal('domain.user.deleted');
+    });
+
+    it('does not publish when the destroy errors', async () => {
+      const scope = nock(COZY_URL)
+        .delete('/instances/broken.twake.local')
+        .reply(500, { error: 'server error' });
+
+      const hook = plugin.hooks?.scimuserdeletedone as (
+        id: string
+      ) => Promise<void>;
+      await hook('broken');
+
+      expect(scope.isDone()).to.equal(true);
+      expect(plugin.stub.calls).to.have.length(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- The SCIM delete hook was only publishing the `b2b` lifecycle event. The user's cozy instance stayed behind, so a later re-import of the same `userName` silently re-attached to the stale instance and its old `oidc_id`, sharings and contacts. Operators kept hitting mismatched per-instance state until they remembered to run `cozy-stack instances destroy` by hand after every SCIM delete.
- Call `DELETE /instances/<domain>` on the cozy admin API from `scimuserdeletedone`, before the `b2b` publish. 404 is treated as success so the lifecycle stays idempotent. The `b2b` event is still emitted even when the destroy fails, so peers drop their contact cards regardless of whether cozy-stack was reachable.