### PR TITLE
feat(lsc-plugin): LSC destination plugin writing through ldap-rest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,41 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+  lsc-plugin-test:
+    runs-on: ubuntu-latest
+    name: LSC ldap-rest plugin (Java)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+
+      # lsc-core is not on Maven Central — build it from the v2.2 tag and
+      # install it into the local Maven repo.
+      - name: Build and install LSC core (v2.2)
+        run: |
+          git clone --depth 1 --branch v2.2 https://github.com/lsc-project/lsc.git /tmp/lsc
+          cd /tmp/lsc
+          mvn -B -DskipTests install
+
+      - name: Run plugin unit tests
+        working-directory: lsc-plugin
+        run: mvn -B test
+
+      - name: Build shaded jar
+        working-directory: lsc-plugin
+        run: mvn -B -DskipTests package
+
+      - name: Upload jar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lsc-ldaprest-plugin-jar
+          path: lsc-plugin/target/lsc-ldaprest-plugin-*-with-deps.jar
+          if-no-files-found: error

--- a/lsc-plugin/.gitignore
+++ b/lsc-plugin/.gitignore
@@ -1,0 +1,5 @@
+target/
+*.iml
+.idea/
+.vscode/
+test/integration/logs/

--- a/lsc-plugin/README.md
+++ b/lsc-plugin/README.md
@@ -1,0 +1,81 @@
+# LSC ldap-rest plugin
+
+A LSC `pluginDestinationService` that translates `LscModifications` into HTTP
+calls against the [ldap-rest](https://github.com/linagora/ldap-rest) REST API,
+instead of binding directly to LDAP. This way LSC sync benefits from
+ldap-rest's ACL, schema validation, audit, and downstream provisioning hooks
+(Twake James, Cozy, SCIM, RabbitMQ).
+
+## Status
+
+Standalone plugin shipped alongside ldap-rest while a native
+`LdapRestDstService` is being upstreamed into `lsc-project/lsc`.
+
+## Build
+
+```sh
+mvn package
+```
+
+Produces `target/lsc-ldaprest-plugin-<version>-with-deps.jar` (jar + Jackson
+shaded). Drop it into `/usr/lib/lsc/` (or wherever LSC reads its classpath
+from in your deployment).
+
+## Configuration
+
+In your LSC `lsc.xml`, declare the destination service:
+
+```xml
+<pluginDestinationService implementationClass="org.lscproject.ldaprest.LdapRestDstService">
+  <name>ldap-rest-users</name>
+  <connection reference="ldap-rest"/>
+  <baseUrl>https://ldap-rest.example.org</baseUrl>
+  <resourceType>users</resourceType>
+  <auth>
+    <bearer>${LDAP_REST_TOKEN}</bearer>
+    <!-- or, for HMAC:
+    <hmacServiceId>lsc</hmacServiceId>
+    <hmacSecret>${LDAP_REST_HMAC_SECRET}</hmacSecret>
+    -->
+  </auth>
+  <timeoutMs>10000</timeoutMs>
+  <retries>3</retries>
+</pluginDestinationService>
+```
+
+`<resourceType>` is one of: `users` (or any other flat-resource plural name
+declared in ldap-rest), `groups`, `organizations`. One destination service
+instance maps to one resource type — declare several services if you sync
+several resource families.
+
+## Operation mapping
+
+| LSC operation     | ldap-rest call                                                            |
+|-------------------|---------------------------------------------------------------------------|
+| CREATE flat       | `POST /api/v1/ldap/{resource}` body `{ <attrs> }`                         |
+| UPDATE flat       | `PUT /api/v1/ldap/{resource}/{id}` body `{ add?, replace?, delete? }`     |
+| DELETE flat       | `DELETE /api/v1/ldap/{resource}/{id}`                                     |
+| MODRDN flat       | `POST /api/v1/ldap/{resource}/{id}/move` body `{ targetOrgDn }`           |
+| CREATE group      | `POST /api/v1/ldap/groups`                                                |
+| UPDATE group      | `PUT /api/v1/ldap/groups/{cn}` + member POST/DELETE                       |
+| DELETE group      | `DELETE /api/v1/ldap/groups/{cn}`                                         |
+| RENAME group      | `POST /api/v1/ldap/groups/{cn}/rename` body `{ newCn }`                   |
+| CREATE org        | `POST /api/v1/ldap/organizations`                                         |
+| UPDATE org        | `PUT /api/v1/ldap/organizations/{dn}`                                     |
+| DELETE org        | `DELETE /api/v1/ldap/organizations/{dn}`                                  |
+| MODRDN org        | `POST /api/v1/ldap/organizations/{dn}/move`                               |
+
+## Limitations
+
+- Binary attributes (`jpegPhoto`, `userCertificate`) are not synced in this
+  version: ldap-rest has no formal JSON convention for them yet. The plugin
+  fails fast with a clear error if it encounters one.
+- No bulk endpoint: large initial syncs do N HTTP calls. If this hurts,
+  ldap-rest will need a bulk endpoint first.
+
+## Tests
+
+- `mvn test` runs the WireMock-based unit tests.
+- `test/integration/tests/run.sh` spins up a full Docker stack (OpenLDAP
+  source + OpenLDAP target + ldap-rest + LSC with the plugin) and asserts
+  end-to-end sync. See `test/integration/README.md`.

--- a/lsc-plugin/pom.xml
+++ b/lsc-plugin/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.lscproject</groupId>
+    <artifactId>lsc-ldaprest-plugin</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>LSC ldap-rest destination plugin</name>
+    <description>
+        LSC pluginDestinationService that writes through the ldap-rest HTTP API
+        instead of binding directly to LDAP. Supports flat resources, groups,
+        and organizations, with Bearer or HMAC-SHA256 authentication.
+    </description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <lsc.version>2.2</lsc.version>
+        <jackson.version>2.17.2</jackson.version>
+        <junit.version>5.10.2</junit.version>
+        <wiremock.version>3.9.1</wiremock.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.lsc</groupId>
+            <artifactId>lsc-core</artifactId>
+            <version>${lsc.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.13</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>with-deps</shadedClassifierName>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>org.lscproject.ldaprest.shaded.jackson</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/lsc-plugin/src/main/java/org/lscproject/ldaprest/BearerAuth.java
+++ b/lsc-plugin/src/main/java/org/lscproject/ldaprest/BearerAuth.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.lscproject.ldaprest;
+
+import java.net.http.HttpRequest;
+import java.util.Objects;
+
+/**
+ * Static bearer-token authentication.
+ *
+ * <p>Adds {@code Authorization: Bearer &lt;token&gt;} to every
+ * outgoing request. The token is supposed to be opaque to the client
+ * and is provided by the ldap-rest deployment (typically through an
+ * environment variable expanded in {@code lsc.xml}).</p>
+ */
+public final class BearerAuth implements LdapRestAuth {
+
+    private final String token;
+
+    public BearerAuth(String token) {
+        this.token = Objects.requireNonNull(token, "token");
+        if (token.isEmpty()) {
+            throw new IllegalArgumentException("bearer token must not be empty");
+        }
+    }
+
+    @Override
+    public void apply(HttpRequest.Builder builder, String method, String path, byte[] body) {
+        builder.header("Authorization", "Bearer " + token);
+    }
+}

--- a/lsc-plugin/src/main/java/org/lscproject/ldaprest/HmacAuth.java
+++ b/lsc-plugin/src/main/java/org/lscproject/ldaprest/HmacAuth.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.lscproject.ldaprest;
+
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
+import java.util.Objects;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * HMAC-SHA256 request signing matching the ldap-rest server-side
+ * verification. The signing string is:
+ *
+ * <pre>
+ *   signingString = METHOD + "|" + PATH + "|" + timestamp + "|" + bodyHash
+ *   bodyHash      = sha256_hex(body)            (POST/PUT/PATCH)
+ *                 = ""                          (GET/DELETE/HEAD)
+ *   timestamp     = currentTimeMillis()         (milliseconds)
+ *   signature     = hmac_sha256_hex(secret, signingString)
+ *   header        = "HMAC-SHA256 <serviceId>:<timestamp>:<signature>"
+ * </pre>
+ *
+ * <p>The body bytes used for {@code bodyHash} <strong>must</strong>
+ * be the exact bytes sent on the wire (UTF-8 encoded JSON in our
+ * case). The HTTP client takes care of feeding the same byte array
+ * to both the signature and the request body.</p>
+ */
+public final class HmacAuth implements LdapRestAuth {
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    private final String serviceId;
+    private final String secret;
+    private final TimestampSource clock;
+
+    public HmacAuth(String serviceId, String secret) {
+        this(serviceId, secret, System::currentTimeMillis);
+    }
+
+    /**
+     * Test-only constructor injecting a fixed timestamp source so
+     * signatures are reproducible.
+     */
+    public HmacAuth(String serviceId, String secret, TimestampSource clock) {
+        this.serviceId = Objects.requireNonNull(serviceId, "serviceId");
+        this.secret = Objects.requireNonNull(secret, "secret");
+        this.clock = Objects.requireNonNull(clock, "clock");
+        if (serviceId.isEmpty() || secret.isEmpty()) {
+            throw new IllegalArgumentException("serviceId and secret must not be empty");
+        }
+    }
+
+    @Override
+    public void apply(HttpRequest.Builder builder, String method, String path, byte[] body) {
+        long ts = clock.now();
+        String upper = method.toUpperCase(Locale.ROOT);
+        boolean hasBody = upper.equals("POST") || upper.equals("PUT") || upper.equals("PATCH");
+        String bodyHash = hasBody ? sha256Hex(body == null ? new byte[0] : body) : "";
+        String signingString = upper + "|" + path + "|" + ts + "|" + bodyHash;
+        String signature = hmacSha256Hex(secret, signingString);
+        String headerValue = "HMAC-SHA256 " + serviceId + ":" + ts + ":" + signature;
+        builder.header("Authorization", headerValue);
+    }
+
+    /**
+     * Compute the signature for given inputs without sending a
+     * request. Exposed so callers (and tests) can pre-compute
+     * expected values.
+     */
+    public static String computeSignature(String secret,
+                                          String method,
+                                          String path,
+                                          long timestamp,
+                                          byte[] body) {
+        String upper = method.toUpperCase(Locale.ROOT);
+        boolean hasBody = upper.equals("POST") || upper.equals("PUT") || upper.equals("PATCH");
+        String bodyHash = hasBody ? sha256Hex(body == null ? new byte[0] : body) : "";
+        String signingString = upper + "|" + path + "|" + timestamp + "|" + bodyHash;
+        return hmacSha256Hex(secret, signingString);
+    }
+
+    static String sha256Hex(byte[] data) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return toHex(md.digest(data));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    static String hmacSha256Hex(String secret, String signingString) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] sig = mac.doFinal(signingString.getBytes(StandardCharsets.UTF_8));
+            return toHex(sig);
+        } catch (Exception e) {
+            throw new IllegalStateException("HmacSHA256 unavailable", e);
+        }
+    }
+
+    static String toHex(byte[] data) {
+        char[] out = new char[data.length * 2];
+        for (int i = 0; i < data.length; i++) {
+            int v = data[i] & 0xff;
+            out[i * 2] = HEX[v >>> 4];
+            out[i * 2 + 1] = HEX[v & 0x0f];
+        }
+        return new String(out);
+    }
+
+    /** Test seam for clock injection. */
+    @FunctionalInterface
+    public interface TimestampSource {
+        long now();
+    }
+}

--- a/lsc-plugin/src/main/java/org/lscproject/ldaprest/LdapRestAuth.java
+++ b/lsc-plugin/src/main/java/org/lscproject/ldaprest/LdapRestAuth.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * LSC ldap-rest plugin - authentication strategies.
+ */
+package org.lscproject.ldaprest;
+
+import java.net.http.HttpRequest;
+
+/**
+ * Pluggable authentication strategy that adds the relevant
+ * Authorization header on an outgoing HTTP request to ldap-rest.
+ *
+ * <p>The strategy receives the parsed components of the request
+ * ({@code method}, {@code path}, {@code body}) so that signed schemes
+ * (HMAC) can compute their signature. Stateless schemes (Bearer)
+ * simply add a static header.</p>
+ *
+ * <p>Implementations <strong>must</strong> be safe for concurrent use
+ * across multiple HTTP clients/threads.</p>
+ */
+public interface LdapRestAuth {
+
+    /**
+     * Apply this auth strategy to {@code builder}, signing the
+     * outgoing request based on its method, path and body.
+     *
+     * @param builder the {@link HttpRequest.Builder} being built
+     * @param method  the HTTP method, upper case (e.g. {@code POST})
+     * @param path    the request path, e.g. {@code /api/v1/ldap/users}
+     * @param body    the body bytes that will be sent, or empty for
+     *                methods without a body (GET, DELETE, HEAD)
+     */
+    void apply(HttpRequest.Builder builder, String method, String path, byte[] body);
+}

--- a/lsc-plugin/src/main/java/org/lscproject/ldaprest/LdapRestClient.java
+++ b/lsc-plugin/src/main/java/org/lscproject/ldaprest/LdapRestClient.java
@@ -1,0 +1,194 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.lscproject.ldaprest;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Objects;
+
+import org.lsc.exception.LscServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Thin wrapper around {@link HttpClient} for talking to ldap-rest.
+ *
+ * <p>Responsibilities:</p>
+ * <ul>
+ *     <li>Apply the configured {@link LdapRestAuth} on every request,
+ *         feeding it the same body bytes that go on the wire so that
+ *         HMAC signatures match.</li>
+ *     <li>Build the absolute URL from a base URL and path.</li>
+ *     <li>Retry transient errors (5xx, IOException) with capped
+ *         exponential backoff.</li>
+ *     <li>Translate non-2xx responses into {@link LscServiceException}.</li>
+ * </ul>
+ *
+ * <p>Idempotent special cases (404 on DELETE) are handled by the
+ * caller, not here, so the client stays generic.</p>
+ */
+public class LdapRestClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LdapRestClient.class);
+
+    private final String baseUrl;
+    private final LdapRestAuth auth;
+    private final long timeoutMs;
+    private final int retries;
+    private final HttpClient http;
+    private final Sleeper sleeper;
+
+    public LdapRestClient(String baseUrl, LdapRestAuth auth, long timeoutMs, int retries) {
+        this(baseUrl, auth, timeoutMs, retries,
+                HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofMillis(Math.max(1000, timeoutMs)))
+                        .build(),
+                ms -> {
+                    try {
+                        Thread.sleep(ms);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+    }
+
+    /** Test-friendly constructor allowing HttpClient and Sleeper injection. */
+    public LdapRestClient(String baseUrl, LdapRestAuth auth, long timeoutMs, int retries,
+                          HttpClient http, Sleeper sleeper) {
+        this.baseUrl = stripTrailingSlash(Objects.requireNonNull(baseUrl, "baseUrl"));
+        this.auth = Objects.requireNonNull(auth, "auth");
+        if (timeoutMs <= 0) {
+            throw new IllegalArgumentException("timeoutMs must be positive");
+        }
+        if (retries < 0) {
+            throw new IllegalArgumentException("retries must be >= 0");
+        }
+        this.timeoutMs = timeoutMs;
+        this.retries = retries;
+        this.http = Objects.requireNonNull(http, "http");
+        this.sleeper = Objects.requireNonNull(sleeper, "sleeper");
+    }
+
+    public HttpResponse<String> get(String path) throws LscServiceException {
+        return send("GET", path, null);
+    }
+
+    public HttpResponse<String> delete(String path) throws LscServiceException {
+        return send("DELETE", path, null);
+    }
+
+    public HttpResponse<String> post(String path, String jsonBody) throws LscServiceException {
+        return send("POST", path, jsonBody == null ? new byte[0] : jsonBody.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public HttpResponse<String> put(String path, String jsonBody) throws LscServiceException {
+        return send("PUT", path, jsonBody == null ? new byte[0] : jsonBody.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Low-level send with retry and auth. {@code body} is the exact
+     * payload bytes sent to the server; the same array is used to
+     * compute the HMAC signature.
+     */
+    public HttpResponse<String> send(String method, String path, byte[] body) throws LscServiceException {
+        Objects.requireNonNull(method, "method");
+        Objects.requireNonNull(path, "path");
+        URI uri = URI.create(baseUrl + path);
+        IOException lastIo = null;
+        HttpResponse<String> last5xx = null;
+        for (int attempt = 0; attempt <= retries; attempt++) {
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .timeout(Duration.ofMillis(timeoutMs));
+            byte[] bodyBytes = body == null ? new byte[0] : body;
+            switch (method) {
+                case "GET":
+                    builder.GET();
+                    break;
+                case "DELETE":
+                    builder.DELETE();
+                    break;
+                case "POST":
+                    builder.header("Content-Type", "application/json")
+                            .POST(HttpRequest.BodyPublishers.ofByteArray(bodyBytes));
+                    break;
+                case "PUT":
+                    builder.header("Content-Type", "application/json")
+                            .PUT(HttpRequest.BodyPublishers.ofByteArray(bodyBytes));
+                    break;
+                default:
+                    throw new LscServiceException("Unsupported HTTP method: " + method);
+            }
+            builder.header("Accept", "application/json");
+            // Auth must run after Content-Type so headers are visible
+            // but before send so the timestamp is fresh per attempt.
+            auth.apply(builder, method, path, bodyBytes);
+            HttpRequest req = builder.build();
+            try {
+                HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+                int code = resp.statusCode();
+                if (code >= 200 && code < 300) {
+                    return resp;
+                }
+                if (code >= 500 && attempt < retries) {
+                    last5xx = resp;
+                    long wait = backoffMillis(attempt);
+                    LOG.warn("ldap-rest {} {} returned {}, retrying in {}ms (attempt {}/{})",
+                            method, path, code, wait, attempt + 1, retries);
+                    sleeper.sleep(wait);
+                    continue;
+                }
+                // Non-retryable error
+                throw new LscServiceException("ldap-rest " + method + " " + path
+                        + " failed with HTTP " + code + ": " + truncate(resp.body()));
+            } catch (IOException ioe) {
+                lastIo = ioe;
+                if (attempt < retries) {
+                    long wait = backoffMillis(attempt);
+                    LOG.warn("ldap-rest {} {} I/O error: {}, retrying in {}ms (attempt {}/{})",
+                            method, path, ioe.getMessage(), wait, attempt + 1, retries);
+                    sleeper.sleep(wait);
+                    continue;
+                }
+                throw new LscServiceException("ldap-rest " + method + " " + path + " failed: " + ioe.getMessage(), ioe);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new LscServiceException("ldap-rest " + method + " " + path + " interrupted", ie);
+            }
+        }
+        if (last5xx != null) {
+            throw new LscServiceException("ldap-rest " + method + " " + path
+                    + " failed after " + retries + " retries with HTTP "
+                    + last5xx.statusCode() + ": " + truncate(last5xx.body()));
+        }
+        throw new LscServiceException("ldap-rest " + method + " " + path
+                + " failed after " + retries + " retries", lastIo);
+    }
+
+    private static long backoffMillis(int attempt) {
+        // 100ms, 200ms, 400ms, 800ms, capped at 5s
+        long base = 100L * (1L << Math.min(attempt, 6));
+        return Math.min(base, 5000L);
+    }
+
+    private static String truncate(String s) {
+        if (s == null) return "";
+        return s.length() > 500 ? s.substring(0, 500) + "..." : s;
+    }
+
+    private static String stripTrailingSlash(String s) {
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+
+    /** Test seam for backoff sleep. */
+    @FunctionalInterface
+    public interface Sleeper {
+        void sleep(long ms);
+    }
+}

--- a/lsc-plugin/src/main/java/org/lscproject/ldaprest/LdapRestDstService.java
+++ b/lsc-plugin/src/main/java/org/lscproject/ldaprest/LdapRestDstService.java
@@ -1,0 +1,461 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.lscproject.ldaprest;
+
+import java.lang.reflect.Method;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.lsc.LscDatasetModification;
+import org.lsc.LscDatasetModification.LscDatasetModificationType;
+import org.lsc.LscDatasets;
+import org.lsc.LscModifications;
+import org.lsc.beans.IBean;
+import org.lsc.configuration.ConnectionType;
+import org.lsc.configuration.TaskType;
+import org.lsc.exception.LscServiceException;
+import org.lsc.service.IWritableService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * LSC {@link IWritableService} that writes through the ldap-rest
+ * HTTP API.
+ *
+ * <p>Configuration is read from the {@code <pluginDestinationService>}
+ * element in {@code lsc.xml}; LSC hands us the parsed {@link TaskType}
+ * and we extract our parameters from
+ * {@code task.getPluginDestinationService().getAny()} (a list of DOM
+ * elements). Recognised parameters:</p>
+ *
+ * <ul>
+ *     <li>{@code <baseUrl>} — required, e.g. {@code https://ldap-rest.example.org}</li>
+ *     <li>{@code <resourceType>} — required, one of {@code users},
+ *         {@code groups}, {@code organizations}, …</li>
+ *     <li>{@code <auth>} block containing either {@code <bearer>} or
+ *         {@code <hmacServiceId>}+{@code <hmacSecret>}</li>
+ *     <li>{@code <timeoutMs>} — optional, default 10000ms</li>
+ *     <li>{@code <retries>} — optional, default 3</li>
+ *     <li>{@code <apiPrefix>} — optional, default {@code /api}</li>
+ * </ul>
+ *
+ * <p>This service is purely <strong>destination</strong>: the read
+ * methods ({@code getBean}, {@code getListPivots}) are stubbed
+ * because LSC pulls source records from a separate source service
+ * and only feeds us {@link LscModifications}. They return empty
+ * structures so the framework does not crash if it ever calls
+ * them.</p>
+ */
+public class LdapRestDstService implements IWritableService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LdapRestDstService.class);
+
+    private final LdapRestClient client;
+    private final ResourceMapper mapper;
+    private final ModificationTranslator translator;
+    private final List<String> writeDatasetIds;
+
+    /**
+     * LSC constructor signature. Called once per task before sync.
+     */
+    public LdapRestDstService(TaskType task) throws LscServiceException {
+        Config cfg = parseConfig(task);
+        this.mapper = new ResourceMapper(cfg.resourceType, cfg.apiPrefix);
+        this.translator = new ModificationTranslator(this.mapper);
+        this.client = new LdapRestClient(cfg.baseUrl, cfg.auth, cfg.timeoutMs, cfg.retries);
+        this.writeDatasetIds = cfg.writeDatasetIds;
+        LOG.info("ldap-rest plugin destination service initialised: baseUrl={}, resourceType={}, "
+                        + "auth={}, timeoutMs={}, retries={}",
+                cfg.baseUrl, cfg.resourceType, cfg.auth.getClass().getSimpleName(),
+                cfg.timeoutMs, cfg.retries);
+    }
+
+    /** Test-only constructor injecting an already-built client. */
+    LdapRestDstService(LdapRestClient client, ResourceMapper mapper) {
+        this.client = client;
+        this.mapper = mapper;
+        this.translator = new ModificationTranslator(mapper);
+        this.writeDatasetIds = Collections.emptyList();
+    }
+
+    @Override
+    public boolean apply(LscModifications lm) throws LscServiceException {
+        if (lm == null || lm.getOperation() == null) {
+            throw new LscServiceException("LscModifications has no operation");
+        }
+        switch (lm.getOperation()) {
+            case CREATE_OBJECT:
+                return doCreate(lm);
+            case UPDATE_OBJECT:
+                return doUpdate(lm);
+            case DELETE_OBJECT:
+                return doDelete(lm);
+            case CHANGE_ID:
+                return doModrdn(lm);
+            default:
+                throw new LscServiceException("Unsupported LSC operation: " + lm.getOperation());
+        }
+    }
+
+    private boolean doCreate(LscModifications lm) throws LscServiceException {
+        String body = translator.buildCreateBody(lm);
+        String path = mapper.collectionPath();
+        HttpResponse<String> resp = client.post(path, body);
+        LOG.debug("CREATE {} -> {}", path, resp.statusCode());
+        return true;
+    }
+
+    private boolean doUpdate(LscModifications lm) throws LscServiceException {
+        String body = translator.buildUpdateBody(lm);
+        // For UPDATE on group, member-mutating attributes must use
+        // the dedicated /members endpoints; ldap-rest itself enforces
+        // this. We split the payload accordingly.
+        if (mapper.getFamily() == ResourceMapper.Family.GROUPS) {
+            return doGroupUpdate(lm);
+        }
+        String path = mapper.itemPath(lm.getMainIdentifier());
+        HttpResponse<String> resp = client.put(path, body);
+        LOG.debug("UPDATE {} -> {}", path, resp.statusCode());
+        return true;
+    }
+
+    /**
+     * Group updates are special: ldap-rest forbids touching the
+     * {@code member} attribute through PUT and exposes dedicated
+     * member endpoints. We extract member ADD/DELETE operations
+     * first, fire dedicated calls for each, then fall back to PUT
+     * for non-member attribute changes.
+     */
+    private boolean doGroupUpdate(LscModifications lm) throws LscServiceException {
+        List<LscDatasetModification> rest = new ArrayList<>();
+        List<Object> addedMembers = new ArrayList<>();
+        List<Object> removedMembers = new ArrayList<>();
+        boolean replaceMembers = false;
+        List<Object> replacedMembers = Collections.emptyList();
+
+        for (LscDatasetModification mod : safeList(lm.getLscAttributeModifications())) {
+            if ("member".equalsIgnoreCase(mod.getAttributeName())) {
+                List<Object> values = mod.getValues() == null ? Collections.emptyList() : mod.getValues();
+                switch (mod.getOperation()) {
+                    case ADD_VALUES:
+                        addedMembers.addAll(values);
+                        break;
+                    case DELETE_VALUES:
+                        removedMembers.addAll(values);
+                        break;
+                    case REPLACE_VALUES:
+                        replaceMembers = true;
+                        replacedMembers = new ArrayList<>(values);
+                        break;
+                    default:
+                        break;
+                }
+            } else {
+                rest.add(mod);
+            }
+        }
+
+        // Apply replace-members as a (delete-all + add-all) sequence
+        // because ldap-rest has no "replace members" endpoint.
+        if (replaceMembers) {
+            // We don't currently fetch the existing list (this service
+            // is destination-only) so we approximate by removing the
+            // explicit additions/removals first, then adding the new
+            // set. Operators wanting a full reconciliation should use
+            // ADD_VALUES/DELETE_VALUES explicitly in their sync map.
+            LOG.warn("REPLACE on group 'member' is best-effort: missing members will not be removed."
+                    + " Use ADD_VALUES/DELETE_VALUES for deterministic group sync.");
+            addedMembers.addAll(replacedMembers);
+        }
+
+        for (Object m : addedMembers) {
+            String memberDn = String.valueOf(m);
+            String path = mapper.membersPath(lm.getMainIdentifier());
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("member", memberDn);
+            client.post(path, ModificationTranslator.writeJson(body));
+        }
+        for (Object m : removedMembers) {
+            String memberDn = String.valueOf(m);
+            String path = mapper.memberItemPath(lm.getMainIdentifier(), memberDn);
+            client.delete(path);
+        }
+
+        if (!rest.isEmpty()) {
+            LscModifications stripped = new LscModifications(lm.getOperation(), lm.getTaskName());
+            stripped.setMainIdentifer(lm.getMainIdentifier());
+            stripped.setNewMainIdentifier(lm.getNewMainIdentifier());
+            stripped.setLscAttributeModifications(rest);
+            String body = translator.buildUpdateBody(stripped);
+            // Avoid an empty PUT (no buckets) when only members changed.
+            if (!"{}".equals(body)) {
+                String path = mapper.itemPath(lm.getMainIdentifier());
+                client.put(path, body);
+            }
+        }
+        return true;
+    }
+
+    private boolean doDelete(LscModifications lm) throws LscServiceException {
+        String path = mapper.itemPath(lm.getMainIdentifier());
+        try {
+            HttpResponse<String> resp = client.delete(path);
+            LOG.debug("DELETE {} -> {}", path, resp.statusCode());
+            return true;
+        } catch (LscServiceException e) {
+            // 404 on DELETE = soft idempotence
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("HTTP 404")) {
+                LOG.warn("DELETE {} returned 404 — already absent, treating as success", path);
+                return true;
+            }
+            throw e;
+        }
+    }
+
+    private boolean doModrdn(LscModifications lm) throws LscServiceException {
+        ModificationTranslator.ModrdnPayload payload = translator.buildModrdnPayload(lm);
+        String path;
+        if (payload.kind == ModificationTranslator.ModrdnKind.RENAME) {
+            path = mapper.renamePath(lm.getMainIdentifier());
+        } else {
+            path = mapper.movePath(lm.getMainIdentifier());
+        }
+        HttpResponse<String> resp = client.post(path, payload.body);
+        LOG.debug("MODRDN {} {} -> {}", payload.kind, path, resp.statusCode());
+        return true;
+    }
+
+    @Override
+    public List<String> getWriteDatasetIds() {
+        return writeDatasetIds == null ? Collections.emptyList() : writeDatasetIds;
+    }
+
+    /**
+     * Read-side: this service is destination-only. LSC requires the
+     * methods to exist (because {@link IWritableService} extends
+     * {@code IService}) but we are never the source. Returning empty
+     * structures keeps LSC happy in defensive code paths.
+     */
+    @Override
+    public IBean getBean(String pivotName, LscDatasets pivotAttributes, boolean fromSameService)
+            throws LscServiceException {
+        LOG.debug("getBean({}) called on destination-only service — returning null", pivotName);
+        return null;
+    }
+
+    @Override
+    public Map<String, LscDatasets> getListPivots() throws LscServiceException {
+        LOG.debug("getListPivots() called on destination-only service — returning empty map");
+        return new HashMap<>();
+    }
+
+    @Override
+    public Collection<Class<? extends ConnectionType>> getSupportedConnectionType() {
+        // We do not bind to a typed LSC connection (no LDAP, no JDBC);
+        // ldap-rest auth is configured inline. Return empty so LSC
+        // doesn't try to inject one.
+        return Collections.emptyList();
+    }
+
+    // -------------------------------------------------------------------
+    // configuration parsing
+    // -------------------------------------------------------------------
+
+    static class Config {
+        String baseUrl;
+        String resourceType;
+        String apiPrefix = "/api";
+        long timeoutMs = 10_000L;
+        int retries = 3;
+        LdapRestAuth auth;
+        List<String> writeDatasetIds = new ArrayList<>();
+    }
+
+    static Config parseConfig(TaskType task) throws LscServiceException {
+        if (task == null) {
+            throw new LscServiceException("ldap-rest plugin: TaskType is null");
+        }
+        List<Element> elements = extractAnyElements(task);
+        Config cfg = new Config();
+        Element authElement = null;
+        for (Element e : elements) {
+            String name = localName(e);
+            String text = textOf(e).trim();
+            switch (name) {
+                case "baseUrl":
+                    cfg.baseUrl = text;
+                    break;
+                case "resourceType":
+                    cfg.resourceType = text;
+                    break;
+                case "apiPrefix":
+                    if (!text.isEmpty()) cfg.apiPrefix = text;
+                    break;
+                case "timeoutMs":
+                    if (!text.isEmpty()) {
+                        try {
+                            cfg.timeoutMs = Long.parseLong(text);
+                        } catch (NumberFormatException nfe) {
+                            throw new LscServiceException("invalid <timeoutMs>: " + text);
+                        }
+                    }
+                    break;
+                case "retries":
+                    if (!text.isEmpty()) {
+                        try {
+                            cfg.retries = Integer.parseInt(text);
+                        } catch (NumberFormatException nfe) {
+                            throw new LscServiceException("invalid <retries>: " + text);
+                        }
+                    }
+                    break;
+                case "auth":
+                    authElement = e;
+                    break;
+                case "writeDatasetIds":
+                case "writeDatasetId":
+                    if (!text.isEmpty()) {
+                        for (String s : text.split(",")) {
+                            String t = s.trim();
+                            if (!t.isEmpty()) cfg.writeDatasetIds.add(t);
+                        }
+                    }
+                    break;
+                default:
+                    LOG.debug("ldap-rest plugin: ignoring unknown config element <{}>", name);
+            }
+        }
+
+        if (cfg.baseUrl == null || cfg.baseUrl.isEmpty()) {
+            throw new LscServiceException("ldap-rest plugin: <baseUrl> is required");
+        }
+        if (cfg.resourceType == null || cfg.resourceType.isEmpty()) {
+            throw new LscServiceException("ldap-rest plugin: <resourceType> is required");
+        }
+        cfg.auth = parseAuth(authElement);
+        return cfg;
+    }
+
+    static LdapRestAuth parseAuth(Element authElement) throws LscServiceException {
+        if (authElement == null) {
+            throw new LscServiceException(
+                    "ldap-rest plugin: <auth> block missing — provide <bearer> or "
+                            + "<hmacServiceId>+<hmacSecret>");
+        }
+        String bearer = childText(authElement, "bearer");
+        String svcId = childText(authElement, "hmacServiceId");
+        String secret = childText(authElement, "hmacSecret");
+        if (bearer != null && !bearer.isEmpty()) {
+            return new BearerAuth(bearer);
+        }
+        if (svcId != null && secret != null && !svcId.isEmpty() && !secret.isEmpty()) {
+            return new HmacAuth(svcId, secret);
+        }
+        throw new LscServiceException(
+                "ldap-rest plugin: <auth> needs either <bearer> or both "
+                        + "<hmacServiceId> and <hmacSecret>");
+    }
+
+    /**
+     * Reflectively call {@code task.getPluginDestinationService().getAny()}
+     * and filter out non-Element entries (whitespace text nodes,
+     * comments, etc.). This keeps us compatible with subtle JAXB
+     * binding differences across LSC versions.
+     */
+    @SuppressWarnings("unchecked")
+    static List<Element> extractAnyElements(TaskType task) throws LscServiceException {
+        List<Element> out = new ArrayList<>();
+        try {
+            Method getPlugin = task.getClass().getMethod("getPluginDestinationService");
+            Object plugin = getPlugin.invoke(task);
+            if (plugin == null) {
+                throw new LscServiceException(
+                        "ldap-rest plugin: <pluginDestinationService> not configured");
+            }
+            Method getAny = plugin.getClass().getMethod("getAny");
+            Object any = getAny.invoke(plugin);
+            if (any instanceof List) {
+                for (Object o : (List<Object>) any) {
+                    if (o instanceof Element) {
+                        out.add((Element) o);
+                    } else if (o instanceof Node) {
+                        Node n = (Node) o;
+                        if (n.getNodeType() == Node.ELEMENT_NODE) {
+                            out.add((Element) n);
+                        }
+                    }
+                }
+            } else {
+                LOG.warn("ldap-rest plugin: getAny() returned non-List ({}); ignoring",
+                        any == null ? "null" : any.getClass().getName());
+            }
+        } catch (NoSuchMethodException nsme) {
+            throw new LscServiceException(
+                    "ldap-rest plugin: incompatible LSC version (missing "
+                            + "getPluginDestinationService/getAny): " + nsme.getMessage(), nsme);
+        } catch (ReflectiveOperationException roe) {
+            throw new LscServiceException(
+                    "ldap-rest plugin: failed to read configuration: " + roe.getMessage(), roe);
+        }
+        return out;
+    }
+
+    static String localName(Element e) {
+        String n = e.getLocalName();
+        if (n != null) return n;
+        n = e.getNodeName();
+        int colon = n.indexOf(':');
+        return colon < 0 ? n : n.substring(colon + 1);
+    }
+
+    static String childText(Element parent, String childName) {
+        NodeList kids = parent.getChildNodes();
+        for (int i = 0; i < kids.getLength(); i++) {
+            Node n = kids.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE
+                    && childName.equalsIgnoreCase(localName((Element) n))) {
+                return textOf((Element) n).trim();
+            }
+        }
+        return null;
+    }
+
+    static String textOf(Element e) {
+        StringBuilder sb = new StringBuilder();
+        NodeList kids = e.getChildNodes();
+        for (int i = 0; i < kids.getLength(); i++) {
+            Node n = kids.item(i);
+            if (n.getNodeType() == Node.TEXT_NODE
+                    || n.getNodeType() == Node.CDATA_SECTION_NODE) {
+                String v = n.getNodeValue();
+                if (v != null) sb.append(v);
+            }
+        }
+        return sb.toString();
+    }
+
+    private static <T> List<T> safeList(List<T> l) {
+        return l == null ? Collections.emptyList() : l;
+    }
+
+    /** Test seam to expose internals to the integration test. */
+    LdapRestClient client() { return client; }
+    ResourceMapper mapper() { return mapper; }
+
+    @SuppressWarnings("unused")
+    private static String safeUpper(String s) {
+        return s == null ? "" : s.toUpperCase(Locale.ROOT);
+    }
+}

--- a/lsc-plugin/src/main/java/org/lscproject/ldaprest/LdapRestDstService.java
+++ b/lsc-plugin/src/main/java/org/lscproject/ldaprest/LdapRestDstService.java
@@ -117,13 +117,13 @@ public class LdapRestDstService implements IWritableService {
     }
 
     private boolean doUpdate(LscModifications lm) throws LscServiceException {
-        String body = translator.buildUpdateBody(lm);
         // For UPDATE on group, member-mutating attributes must use
         // the dedicated /members endpoints; ldap-rest itself enforces
         // this. We split the payload accordingly.
         if (mapper.getFamily() == ResourceMapper.Family.GROUPS) {
             return doGroupUpdate(lm);
         }
+        String body = translator.buildUpdateBody(lm);
         String path = mapper.itemPath(lm.getMainIdentifier());
         HttpResponse<String> resp = client.put(path, body);
         LOG.debug("UPDATE {} -> {}", path, resp.statusCode());
@@ -152,6 +152,17 @@ public class LdapRestDstService implements IWritableService {
                         addedMembers.addAll(values);
                         break;
                     case DELETE_VALUES:
+                        if (values.isEmpty()) {
+                            // attribute-wide delete on `member` — would mean
+                            // "remove all members". ldap-rest has no clear-
+                            // members endpoint, and we don't fetch the
+                            // current list (destination-only). Refuse loudly
+                            // rather than silently drop.
+                            throw new LscServiceException(
+                                "attribute-wide DELETE on group 'member' is not supported by this plugin; "
+                                + "emit explicit DELETE_VALUES with the current member list "
+                                + "or use REPLACE_VALUES with the new (possibly empty) member list");
+                        }
                         removedMembers.addAll(values);
                         break;
                     case REPLACE_VALUES:
@@ -301,7 +312,7 @@ public class LdapRestDstService implements IWritableService {
                     cfg.resourceType = text;
                     break;
                 case "apiPrefix":
-                    if (!text.isEmpty()) cfg.apiPrefix = text;
+                    if (!text.isEmpty()) cfg.apiPrefix = normaliseApiPrefix(text);
                     break;
                 case "timeoutMs":
                     if (!text.isEmpty()) {
@@ -309,6 +320,9 @@ public class LdapRestDstService implements IWritableService {
                             cfg.timeoutMs = Long.parseLong(text);
                         } catch (NumberFormatException nfe) {
                             throw new LscServiceException("invalid <timeoutMs>: " + text);
+                        }
+                        if (cfg.timeoutMs <= 0) {
+                            throw new LscServiceException("<timeoutMs> must be > 0, got: " + cfg.timeoutMs);
                         }
                     }
                     break;
@@ -318,6 +332,9 @@ public class LdapRestDstService implements IWritableService {
                             cfg.retries = Integer.parseInt(text);
                         } catch (NumberFormatException nfe) {
                             throw new LscServiceException("invalid <retries>: " + text);
+                        }
+                        if (cfg.retries < 0) {
+                            throw new LscServiceException("<retries> must be >= 0, got: " + cfg.retries);
                         }
                     }
                     break;
@@ -366,6 +383,19 @@ public class LdapRestDstService implements IWritableService {
         throw new LscServiceException(
                 "ldap-rest plugin: <auth> needs either <bearer> or both "
                         + "<hmacServiceId> and <hmacSecret>");
+    }
+
+    /**
+     * Normalise {@code <apiPrefix>}: ensure leading {@code /}, strip
+     * trailing {@code /}. So {@code "api"}, {@code "/api"}, {@code "/api/"}
+     * all become {@code "/api"}. Also accepts the empty prefix {@code "/"}.
+     */
+    static String normaliseApiPrefix(String raw) {
+        String s = raw.trim();
+        if (s.isEmpty() || "/".equals(s)) return "";
+        if (!s.startsWith("/")) s = "/" + s;
+        while (s.length() > 1 && s.endsWith("/")) s = s.substring(0, s.length() - 1);
+        return s;
     }
 
     /**

--- a/lsc-plugin/src/main/java/org/lscproject/ldaprest/LdapRestDstService.java
+++ b/lsc-plugin/src/main/java/org/lscproject/ldaprest/LdapRestDstService.java
@@ -153,17 +153,18 @@ public class LdapRestDstService implements IWritableService {
                         break;
                     case DELETE_VALUES:
                         if (values.isEmpty()) {
-                            // attribute-wide delete on `member` — would mean
-                            // "remove all members". ldap-rest has no clear-
-                            // members endpoint, and we don't fetch the
-                            // current list (destination-only). Refuse loudly
-                            // rather than silently drop.
-                            throw new LscServiceException(
-                                "attribute-wide DELETE on group 'member' is not supported by this plugin; "
-                                + "emit explicit DELETE_VALUES with the current member list "
-                                + "or use REPLACE_VALUES with the new (possibly empty) member list");
+                            // attribute-wide delete on `member` — best-effort
+                            // reconciliation: GET the group, list its current
+                            // members, and queue them all for deletion. If the
+                            // GET fails we surface a clear error rather than
+                            // silently no-op.
+                            List<Object> current = fetchCurrentMembers(lm.getMainIdentifier());
+                            LOG.info("attribute-wide DELETE on group 'member' for {}: removing {} current member(s) via reconciliation",
+                                    lm.getMainIdentifier(), current.size());
+                            removedMembers.addAll(current);
+                        } else {
+                            removedMembers.addAll(values);
                         }
-                        removedMembers.addAll(values);
                         break;
                     case REPLACE_VALUES:
                         replaceMembers = true;
@@ -216,6 +217,17 @@ public class LdapRestDstService implements IWritableService {
             }
         }
         return true;
+    }
+
+    /**
+     * GET the group at {@code groupDn}, parse its JSON, and return the
+     * current {@code member} list. Used to reconcile attribute-wide
+     * DELETE on {@code member} when LSC emits no explicit value list.
+     */
+    private List<Object> fetchCurrentMembers(String groupDn) throws LscServiceException {
+        String path = mapper.itemPath(groupDn);
+        HttpResponse<String> resp = client.get(path);
+        return ModificationTranslator.readMembers(resp.body());
     }
 
     private boolean doDelete(LscModifications lm) throws LscServiceException {

--- a/lsc-plugin/src/main/java/org/lscproject/ldaprest/ModificationTranslator.java
+++ b/lsc-plugin/src/main/java/org/lscproject/ldaprest/ModificationTranslator.java
@@ -1,0 +1,267 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.lscproject.ldaprest;
+
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.lsc.LscDatasetModification;
+import org.lsc.LscDatasetModification.LscDatasetModificationType;
+import org.lsc.LscModifications;
+import org.lsc.exception.LscServiceException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * Convert {@link LscModifications} objects into JSON payloads
+ * understood by ldap-rest.
+ *
+ * <p>The class uses a single {@link ObjectMapper} configured for
+ * compact, deterministic output (no pretty-printing, insertion-order
+ * preserving maps). This is critical because the same bytes that go
+ * on the wire are also used to compute the HMAC signature; any
+ * formatting change would break the server-side signature
+ * verification.</p>
+ *
+ * <p>Mapping cheat-sheet:</p>
+ * <ul>
+ *     <li><b>CREATE flat/org</b>: a single JSON object whose keys are
+ *         the attribute names and values are either a scalar
+ *         (single-valued) or an array (multi-valued).</li>
+ *     <li><b>CREATE group</b>: same shape, ldap-rest expects {@code cn},
+ *         optional {@code description} and {@code member}.</li>
+ *     <li><b>UPDATE</b>: an object with {@code add}, {@code replace}
+ *         and/or {@code delete} buckets, mirroring LSC's
+ *         {@link LscDatasetModificationType}.</li>
+ *     <li><b>MODRDN flat/org</b>: {@code { "targetOrgDn": "..." }}.</li>
+ *     <li><b>MODRDN group</b>: {@code { "newCn": "..." }}.</li>
+ * </ul>
+ */
+public class ModificationTranslator {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .disable(SerializationFeature.INDENT_OUTPUT)
+            // serializing Maps preserves insertion order by default;
+            // we just need to ensure no other reordering kicks in.
+            .disable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+
+    private final ResourceMapper resourceMapper;
+
+    public ModificationTranslator(ResourceMapper resourceMapper) {
+        this.resourceMapper = resourceMapper;
+    }
+
+    /**
+     * Build the body for a CREATE call (POST /collection).
+     */
+    public String buildCreateBody(LscModifications lm) throws LscServiceException {
+        Map<String, Object> body = new LinkedHashMap<>();
+        for (LscDatasetModification mod : safeList(lm.getLscAttributeModifications())) {
+            if (mod.getOperation() == LscDatasetModificationType.DELETE_VALUES) {
+                // CREATE shouldn't carry deletions; ignore defensively.
+                continue;
+            }
+            Object val = collapse(mod.getAttributeName(), mod.getValues());
+            if (val != null) {
+                body.put(mod.getAttributeName(), val);
+            }
+        }
+        return writeJson(body);
+    }
+
+    /**
+     * Build the body for an UPDATE call (PUT /collection/id).
+     *
+     * <p>Output shape:
+     * <pre>
+     *   {
+     *     "replace": { attr: [v1, v2] },
+     *     "add":     { attr: [v1] },
+     *     "delete":  { attr: [v1] }   // value-targeted
+     *               | ["attr1", "attr2"]   // attribute-wide
+     *   }
+     * </pre>
+     * If both forms of {@code delete} appear, they are merged into
+     * the value-targeted shape with {@code []} marking attribute-wide
+     * deletes (an empty list is the convention used by ldap-rest's
+     * server-side parser).</p>
+     */
+    public String buildUpdateBody(LscModifications lm) throws LscServiceException {
+        Map<String, List<Object>> replace = new LinkedHashMap<>();
+        Map<String, List<Object>> add = new LinkedHashMap<>();
+        Map<String, List<Object>> deleteValues = new LinkedHashMap<>();
+        List<String> deleteAttrs = new ArrayList<>();
+
+        for (LscDatasetModification mod : safeList(lm.getLscAttributeModifications())) {
+            String name = mod.getAttributeName();
+            List<Object> vals = sanitizeValues(name, mod.getValues());
+            switch (mod.getOperation()) {
+                case REPLACE_VALUES:
+                    replace.put(name, vals);
+                    break;
+                case ADD_VALUES:
+                    add.put(name, vals);
+                    break;
+                case DELETE_VALUES:
+                    if (vals.isEmpty()) {
+                        deleteAttrs.add(name);
+                    } else {
+                        deleteValues.put(name, vals);
+                    }
+                    break;
+                default:
+                    // UNKNOWN — skip
+                    break;
+            }
+        }
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        if (!replace.isEmpty()) body.put("replace", replace);
+        if (!add.isEmpty()) body.put("add", add);
+        if (!deleteValues.isEmpty() || !deleteAttrs.isEmpty()) {
+            if (deleteValues.isEmpty()) {
+                body.put("delete", deleteAttrs);
+            } else {
+                // merge: attribute-wide deletes become attr -> [] entries
+                for (String attr : deleteAttrs) {
+                    deleteValues.putIfAbsent(attr, Collections.emptyList());
+                }
+                body.put("delete", deleteValues);
+            }
+        }
+        return writeJson(body);
+    }
+
+    /**
+     * Build the body for a MODRDN call. For flat/org resources the
+     * payload is {@code { "targetOrgDn": newParent }}. For groups
+     * with only an RDN change it is {@code { "newCn": newCn }}.
+     *
+     * <p>The translator picks the form based on the resource family
+     * <em>and</em> on whether the new parent DN differs from the
+     * current parent DN. If the parent DN is unchanged we treat it
+     * as a pure rename (group only); if the parent changed we issue
+     * a move.</p>
+     *
+     * @return a result object holding both the JSON body and the
+     *         endpoint hint (rename vs move) so the caller can pick
+     *         the right path.
+     */
+    public ModrdnPayload buildModrdnPayload(LscModifications lm) throws LscServiceException {
+        String oldDn = lm.getMainIdentifier();
+        String newDn = lm.getNewMainIdentifier();
+        if (newDn == null || newDn.isEmpty()) {
+            throw new LscServiceException("MODRDN without newMainIdentifier on " + oldDn);
+        }
+        String oldParent = ResourceMapper.parentDn(oldDn == null ? "" : oldDn);
+        String newParent = ResourceMapper.parentDn(newDn);
+        boolean parentChanged = !oldParent.equalsIgnoreCase(newParent);
+
+        if (resourceMapper.getFamily() == ResourceMapper.Family.GROUPS && !parentChanged) {
+            String newCn = ResourceMapper.rdnValue(newDn);
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("newCn", newCn);
+            return new ModrdnPayload(ModrdnKind.RENAME, writeJson(body));
+        }
+        // flat/org or group with parent change: use /move
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("targetOrgDn", newParent);
+        return new ModrdnPayload(ModrdnKind.MOVE, writeJson(body));
+    }
+
+    /** Result of {@link #buildModrdnPayload(LscModifications)}. */
+    public static final class ModrdnPayload {
+        public final ModrdnKind kind;
+        public final String body;
+
+        public ModrdnPayload(ModrdnKind kind, String body) {
+            this.kind = kind;
+            this.body = body;
+        }
+    }
+
+    public enum ModrdnKind { MOVE, RENAME }
+
+    // -------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------
+
+    /**
+     * Collapse a values list to a JSON-friendly representation:
+     * single value → scalar, multi-value → array, empty → {@code null}.
+     * Fails on binary data.
+     */
+    private static Object collapse(String attr, List<Object> values) throws LscServiceException {
+        List<Object> sanitized = sanitizeValues(attr, values);
+        if (sanitized.isEmpty()) return null;
+        if (sanitized.size() == 1) return sanitized.get(0);
+        return sanitized;
+    }
+
+    private static List<Object> sanitizeValues(String attr, List<Object> values) throws LscServiceException {
+        List<Object> out = new ArrayList<>();
+        if (values == null) return out;
+        for (Object v : values) {
+            if (v == null) continue;
+            if (v instanceof byte[]) {
+                byte[] b = (byte[]) v;
+                String s = decodeUtf8Strict(b);
+                if (s == null) {
+                    throw new LscServiceException(
+                            "binary attributes not supported in this version: " + attr);
+                }
+                out.add(s);
+            } else {
+                out.add(v);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Try to decode bytes as strict UTF-8. Returns {@code null} if
+     * the bytes do not form valid UTF-8 (which we treat as opaque
+     * binary).
+     */
+    private static String decodeUtf8Strict(byte[] bytes) {
+        try {
+            return StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(java.nio.ByteBuffer.wrap(bytes))
+                    .toString();
+        } catch (CharacterCodingException e) {
+            return null;
+        }
+    }
+
+    private static <T> List<T> safeList(List<T> list) {
+        return list == null ? Collections.emptyList() : list;
+    }
+
+    static String writeJson(Object o) throws LscServiceException {
+        try {
+            return MAPPER.writeValueAsString(o);
+        } catch (JsonProcessingException e) {
+            throw new LscServiceException("failed to encode JSON payload: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Lower-case a DN attribute type for comparison; trivial helper
+     * exposed for {@link LdapRestDstService}.
+     */
+    static String lowerType(String type) {
+        return type == null ? "" : type.toLowerCase(Locale.ROOT);
+    }
+}

--- a/lsc-plugin/src/main/java/org/lscproject/ldaprest/ModificationTranslator.java
+++ b/lsc-plugin/src/main/java/org/lscproject/ldaprest/ModificationTranslator.java
@@ -258,6 +258,32 @@ public class ModificationTranslator {
     }
 
     /**
+     * Extract the {@code member} attribute values from a ldap-rest group
+     * response body. Accepts the value as either an array of strings
+     * (the common case) or a single string. Returns an empty list if
+     * the response has no {@code member} field.
+     */
+    static List<Object> readMembers(String json) throws LscServiceException {
+        if (json == null || json.isEmpty()) return Collections.emptyList();
+        try {
+            com.fasterxml.jackson.databind.JsonNode root = MAPPER.readTree(json);
+            com.fasterxml.jackson.databind.JsonNode m = root.get("member");
+            if (m == null || m.isNull()) return Collections.emptyList();
+            List<Object> out = new ArrayList<>();
+            if (m.isArray()) {
+                for (com.fasterxml.jackson.databind.JsonNode v : m) {
+                    if (v != null && !v.isNull()) out.add(v.asText());
+                }
+            } else if (m.isTextual()) {
+                out.add(m.asText());
+            }
+            return out;
+        } catch (JsonProcessingException e) {
+            throw new LscServiceException("failed to parse group response JSON: " + e.getMessage(), e);
+        }
+    }
+
+    /**
      * Lower-case a DN attribute type for comparison; trivial helper
      * exposed for {@link LdapRestDstService}.
      */

--- a/lsc-plugin/src/main/java/org/lscproject/ldaprest/ResourceMapper.java
+++ b/lsc-plugin/src/main/java/org/lscproject/ldaprest/ResourceMapper.java
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.lscproject.ldaprest;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Routes LSC operations to the right ldap-rest endpoint depending on
+ * the configured resource type, and parses LSC-style DNs into
+ * identifiers usable on the wire.
+ *
+ * <p>Three resource families are supported:</p>
+ * <ul>
+ *     <li>{@code groups} — endpoints under {@code /groups}, identified
+ *         by the bare {@code cn} value.</li>
+ *     <li>{@code organizations} — endpoints under {@code /organizations},
+ *         identified by the URL-encoded full DN.</li>
+ *     <li>everything else (e.g. {@code users}) — flat resources where
+ *         the identifier is the RDN value (e.g. {@code uid=alice}'s
+ *         {@code alice}).</li>
+ * </ul>
+ */
+public class ResourceMapper {
+
+    public enum Family { GROUPS, ORGANIZATIONS, FLAT }
+
+    private final String resourceType;
+    private final Family family;
+    private final String apiPrefix;
+
+    public ResourceMapper(String resourceType) {
+        this(resourceType, "/api");
+    }
+
+    public ResourceMapper(String resourceType, String apiPrefix) {
+        this.resourceType = Objects.requireNonNull(resourceType, "resourceType").toLowerCase(Locale.ROOT);
+        this.apiPrefix = Objects.requireNonNull(apiPrefix, "apiPrefix");
+        switch (this.resourceType) {
+            case "groups":
+                this.family = Family.GROUPS;
+                break;
+            case "organizations":
+                this.family = Family.ORGANIZATIONS;
+                break;
+            default:
+                this.family = Family.FLAT;
+        }
+    }
+
+    public String getResourceType() {
+        return resourceType;
+    }
+
+    public Family getFamily() {
+        return family;
+    }
+
+    /** {@code /api/v1/ldap/{resource}} — for CREATE. */
+    public String collectionPath() {
+        return apiPrefix + "/v1/ldap/" + resourceType;
+    }
+
+    /** {@code /api/v1/ldap/{resource}/{id}} — for UPDATE/DELETE. */
+    public String itemPath(String dn) {
+        return collectionPath() + "/" + encodeId(dn);
+    }
+
+    /** {@code /api/v1/ldap/{resource}/{id}/move} — for MODRDN flat/org. */
+    public String movePath(String dn) {
+        return itemPath(dn) + "/move";
+    }
+
+    /** {@code /api/v1/ldap/groups/{cn}/rename} — for MODRDN groups. */
+    public String renamePath(String dn) {
+        if (family != Family.GROUPS) {
+            throw new IllegalStateException("rename is only valid for groups");
+        }
+        return itemPath(dn) + "/rename";
+    }
+
+    /** {@code /api/v1/ldap/groups/{cn}/members} — group member add. */
+    public String membersPath(String dn) {
+        if (family != Family.GROUPS) {
+            throw new IllegalStateException("members is only valid for groups");
+        }
+        return itemPath(dn) + "/members";
+    }
+
+    /** {@code /api/v1/ldap/groups/{cn}/members/{member}} — group member delete. */
+    public String memberItemPath(String groupDn, String memberDn) {
+        if (family != Family.GROUPS) {
+            throw new IllegalStateException("members is only valid for groups");
+        }
+        return membersPath(groupDn) + "/" + encode(memberDn);
+    }
+
+    /**
+     * Build the URL-suitable identifier from a LSC main identifier.
+     * For groups/flat resources we want the bare RDN value (so
+     * {@code uid=alice,ou=users,dc=...} → {@code alice}). For
+     * organizations we want the entire DN URL-encoded.
+     */
+    public String encodeId(String dn) {
+        Objects.requireNonNull(dn, "dn");
+        switch (family) {
+            case ORGANIZATIONS:
+                return encode(dn);
+            case GROUPS:
+            case FLAT:
+            default:
+                return encode(rdnValue(dn));
+        }
+    }
+
+    /**
+     * Extract the RDN value from a DN. Examples:
+     * <ul>
+     *     <li>{@code uid=alice,ou=users,dc=ex,dc=org} → {@code alice}</li>
+     *     <li>{@code cn=admins,ou=groups,dc=ex,dc=org} → {@code admins}</li>
+     *     <li>{@code alice} → {@code alice} (already an RDN value)</li>
+     * </ul>
+     *
+     * <p>This is a deliberately simple parser: split on the first
+     * unescaped comma, then on the first {@code =}. Backslash escapes
+     * are honoured. It does not normalise attribute types or unescape
+     * special characters in values beyond removing leading/trailing
+     * whitespace.</p>
+     */
+    public static String rdnValue(String dn) {
+        Objects.requireNonNull(dn, "dn");
+        String firstRdn = firstRdn(dn);
+        int eq = firstRdn.indexOf('=');
+        if (eq < 0) {
+            return firstRdn.trim();
+        }
+        return firstRdn.substring(eq + 1).trim();
+    }
+
+    /** Return the parent DN (everything after the first unescaped comma) or {@code ""}. */
+    public static String parentDn(String dn) {
+        Objects.requireNonNull(dn, "dn");
+        int idx = indexOfUnescapedComma(dn);
+        if (idx < 0) {
+            return "";
+        }
+        return dn.substring(idx + 1).trim();
+    }
+
+    /** Return the first RDN component (before the first unescaped comma). */
+    public static String firstRdn(String dn) {
+        int idx = indexOfUnescapedComma(dn);
+        return idx < 0 ? dn.trim() : dn.substring(0, idx).trim();
+    }
+
+    private static int indexOfUnescapedComma(String dn) {
+        boolean escaped = false;
+        for (int i = 0; i < dn.length(); i++) {
+            char c = dn.charAt(i);
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (c == '\\') {
+                escaped = true;
+                continue;
+            }
+            if (c == ',') {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    static String encode(String s) {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8)
+                // URLEncoder uses '+' for spaces; ldap-rest decodes
+                // percent-encoded form but not application/x-www-form-urlencoded
+                // for path components, so use %20 to be safe.
+                .replace("+", "%20");
+    }
+}

--- a/lsc-plugin/src/main/java/org/lscproject/ldaprest/ResourceMapper.java
+++ b/lsc-plugin/src/main/java/org/lscproject/ldaprest/ResourceMapper.java
@@ -8,6 +8,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Objects;
 
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+
 /**
  * Routes LSC operations to the right ldap-rest endpoint depending on
  * the configured resource type, and parses LSC-style DNs into
@@ -117,95 +121,76 @@ public class ResourceMapper {
     }
 
     /**
-     * Extract the RDN value from a DN. Examples:
+     * Extract the unescaped RDN value from a DN, parsed via
+     * {@link javax.naming.ldap.LdapName} / {@link javax.naming.ldap.Rdn}
+     * so all RFC 4514 / RFC 2253 escapes are handled correctly
+     * ({@code \,}, {@code \\}, {@code \=}, hex {@code \xx}, leading/trailing
+     * spaces, hex-string DER values, etc.).
+     *
+     * <p>Examples:</p>
      * <ul>
      *     <li>{@code uid=alice,ou=users,dc=ex,dc=org} → {@code alice}</li>
-     *     <li>{@code cn=admins,ou=groups,dc=ex,dc=org} → {@code admins}</li>
-     *     <li>{@code alice} → {@code alice} (already an RDN value)</li>
+     *     <li>{@code cn=Doe\, John,ou=users,dc=ex,dc=org} → {@code Doe, John}</li>
+     *     <li>{@code cn=Doe\2c John,ou=users,dc=ex,dc=org} → {@code Doe, John}</li>
+     *     <li>{@code alice} → {@code alice} (bare value passthrough)</li>
      * </ul>
      *
-     * <p>This is a deliberately simple parser: split on the first
-     * unescaped comma, then on the first {@code =}. Backslash escapes
-     * are honoured. It does not normalise attribute types or unescape
-     * special characters in values beyond removing leading/trailing
-     * whitespace.</p>
+     * <p>The result is the *logical* identifier value that ldap-rest
+     * expects in path params (the server re-escapes it itself via
+     * {@code escapeDnValue}). Returning the escaped form would
+     * double-escape on the wire.</p>
      */
     public static String rdnValue(String dn) {
         Objects.requireNonNull(dn, "dn");
-        String firstRdn = firstRdn(dn);
-        int eq = firstRdn.indexOf('=');
-        String raw = eq < 0 ? firstRdn : firstRdn.substring(eq + 1);
-        return unescapeRdn(raw.trim());
+        String trimmed = dn.trim();
+        if (trimmed.isEmpty()) return trimmed;
+        try {
+            LdapName name = new LdapName(trimmed);
+            if (name.isEmpty()) return trimmed;
+            Rdn rdn = name.getRdn(name.size() - 1);
+            Object v = rdn.getValue();
+            return v == null ? "" : v.toString();
+        } catch (InvalidNameException e) {
+            // Bare value (e.g. "alice") is not a valid DN — fall through
+            // and return it as-is. Same for anything LdapName refuses.
+            return trimmed;
+        }
     }
 
     /**
-     * Unescape RFC 4514 escapes in an RDN value: {@code \,} → {@code ,},
-     * {@code \\} → {@code \}, {@code \=} → {@code =}, hex pairs
-     * {@code \xx} → byte. The result is the *logical* identifier value
-     * that ldap-rest expects in path params (the server re-escapes it
-     * itself via {@code escapeDnValue}). Returning the still-escaped
-     * form would double-escape on the wire.
+     * Return the parent DN (everything but the leftmost RDN), or {@code ""}
+     * if {@code dn} has no parent (single RDN or bare value). Uses
+     * {@link LdapName} so escape rules are RFC 4514 compliant.
      */
-    static String unescapeRdn(String s) {
-        if (s.indexOf('\\') < 0) return s;
-        StringBuilder out = new StringBuilder(s.length());
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            if (c != '\\' || i + 1 >= s.length()) {
-                out.append(c);
-                continue;
-            }
-            char n = s.charAt(i + 1);
-            if (isHex(n) && i + 2 < s.length() && isHex(s.charAt(i + 2))) {
-                int hi = Character.digit(n, 16);
-                int lo = Character.digit(s.charAt(i + 2), 16);
-                out.append((char) ((hi << 4) | lo));
-                i += 2;
-            } else {
-                out.append(n);
-                i += 1;
-            }
-        }
-        return out.toString();
-    }
-
-    private static boolean isHex(char c) {
-        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
-    }
-
-    /** Return the parent DN (everything after the first unescaped comma) or {@code ""}. */
     public static String parentDn(String dn) {
         Objects.requireNonNull(dn, "dn");
-        int idx = indexOfUnescapedComma(dn);
-        if (idx < 0) {
+        String trimmed = dn.trim();
+        if (trimmed.isEmpty()) return "";
+        try {
+            LdapName name = new LdapName(trimmed);
+            if (name.size() <= 1) return "";
+            return name.getPrefix(name.size() - 1).toString();
+        } catch (InvalidNameException e) {
             return "";
         }
-        return dn.substring(idx + 1).trim();
     }
 
-    /** Return the first RDN component (before the first unescaped comma). */
+    /**
+     * Return the first RDN component (e.g. {@code uid=alice}) of a DN,
+     * in its canonical RFC 4514 form. Used internally for diagnostics;
+     * for the unescaped value alone use {@link #rdnValue(String)}.
+     */
     public static String firstRdn(String dn) {
-        int idx = indexOfUnescapedComma(dn);
-        return idx < 0 ? dn.trim() : dn.substring(0, idx).trim();
-    }
-
-    private static int indexOfUnescapedComma(String dn) {
-        boolean escaped = false;
-        for (int i = 0; i < dn.length(); i++) {
-            char c = dn.charAt(i);
-            if (escaped) {
-                escaped = false;
-                continue;
-            }
-            if (c == '\\') {
-                escaped = true;
-                continue;
-            }
-            if (c == ',') {
-                return i;
-            }
+        Objects.requireNonNull(dn, "dn");
+        String trimmed = dn.trim();
+        if (trimmed.isEmpty()) return "";
+        try {
+            LdapName name = new LdapName(trimmed);
+            if (name.isEmpty()) return trimmed;
+            return name.getRdn(name.size() - 1).toString();
+        } catch (InvalidNameException e) {
+            return trimmed;
         }
-        return -1;
     }
 
     static String encode(String s) {

--- a/lsc-plugin/src/main/java/org/lscproject/ldaprest/ResourceMapper.java
+++ b/lsc-plugin/src/main/java/org/lscproject/ldaprest/ResourceMapper.java
@@ -134,10 +134,43 @@ public class ResourceMapper {
         Objects.requireNonNull(dn, "dn");
         String firstRdn = firstRdn(dn);
         int eq = firstRdn.indexOf('=');
-        if (eq < 0) {
-            return firstRdn.trim();
+        String raw = eq < 0 ? firstRdn : firstRdn.substring(eq + 1);
+        return unescapeRdn(raw.trim());
+    }
+
+    /**
+     * Unescape RFC 4514 escapes in an RDN value: {@code \,} → {@code ,},
+     * {@code \\} → {@code \}, {@code \=} → {@code =}, hex pairs
+     * {@code \xx} → byte. The result is the *logical* identifier value
+     * that ldap-rest expects in path params (the server re-escapes it
+     * itself via {@code escapeDnValue}). Returning the still-escaped
+     * form would double-escape on the wire.
+     */
+    static String unescapeRdn(String s) {
+        if (s.indexOf('\\') < 0) return s;
+        StringBuilder out = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c != '\\' || i + 1 >= s.length()) {
+                out.append(c);
+                continue;
+            }
+            char n = s.charAt(i + 1);
+            if (isHex(n) && i + 2 < s.length() && isHex(s.charAt(i + 2))) {
+                int hi = Character.digit(n, 16);
+                int lo = Character.digit(s.charAt(i + 2), 16);
+                out.append((char) ((hi << 4) | lo));
+                i += 2;
+            } else {
+                out.append(n);
+                i += 1;
+            }
         }
-        return firstRdn.substring(eq + 1).trim();
+        return out.toString();
+    }
+
+    private static boolean isHex(char c) {
+        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
     }
 
     /** Return the parent DN (everything after the first unescaped comma) or {@code ""}. */

--- a/lsc-plugin/src/test/java/org/lscproject/ldaprest/LdapRestAuthTest.java
+++ b/lsc-plugin/src/test/java/org/lscproject/ldaprest/LdapRestAuthTest.java
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.lscproject.ldaprest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.jupiter.api.Test;
+
+class LdapRestAuthTest {
+
+    @Test
+    void bearerSetsAuthorizationHeader() {
+        BearerAuth auth = new BearerAuth("abc-123");
+        HttpRequest.Builder b = HttpRequest.newBuilder().uri(URI.create("http://x/y"));
+        auth.apply(b, "POST", "/api/v1/ldap/users", "{\"x\":1}".getBytes(StandardCharsets.UTF_8));
+        HttpRequest req = b.GET().build();
+        Optional<String> h = req.headers().firstValue("Authorization");
+        assertTrue(h.isPresent());
+        assertEquals("Bearer abc-123", h.get());
+    }
+
+    /**
+     * Cross-implementation contract test. The Node server in
+     * test/plugins/auth/hmac.test.ts ("Cross-impl vector") hard-codes the
+     * same expected signature. If either side drifts (signing string format,
+     * body hashing rule, timestamp encoding), both tests fail.
+     *
+     * Vector: secret="test-secret-min-32-chars-long-xxx", method=POST,
+     * path=/api/v1/ldap/users, ts=1700000000000, body={"uid":"alice"}.
+     */
+    @Test
+    void hmacCrossImplVector() {
+        String secret = "test-secret-min-32-chars-long-xxx";
+        String method = "POST";
+        String path = "/api/v1/ldap/users";
+        long ts = 1_700_000_000_000L;
+        byte[] body = "{\"uid\":\"alice\"}".getBytes(StandardCharsets.UTF_8);
+        String expected = "65b065ff10ab2a54de0ab4db485c5744fcdd32a98e2fd24a8cef5240b43bbc94";
+        assertEquals(expected, HmacAuth.computeSignature(secret, method, path, ts, body),
+                "HMAC signature must match the Node server's vector — see test/plugins/auth/hmac.test.ts");
+    }
+
+    @Test
+    void hmacReproducibleSignature() throws Exception {
+        // Reference vector — values are also used by the cross-check
+        // implemented by hand below.
+        String secret = "test-secret-min-32-chars-long-xxx";
+        String serviceId = "lsc";
+        String method = "POST";
+        String path = "/api/v1/ldap/users";
+        // Body uses LinkedHashMap-style insertion order: {"uid":"alice"}.
+        // That's exactly what the translator produces.
+        String body = "{\"uid\":\"alice\"}";
+        long fixedTs = 1_700_000_000_000L;
+
+        // Compute expected signature manually with javax.crypto.Mac
+        String bodyHash = HmacAuth.sha256Hex(body.getBytes(StandardCharsets.UTF_8));
+        String signingString = method + "|" + path + "|" + fixedTs + "|" + bodyHash;
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        byte[] expectedSig = mac.doFinal(signingString.getBytes(StandardCharsets.UTF_8));
+        StringBuilder hex = new StringBuilder();
+        for (byte b : expectedSig) hex.append(String.format("%02x", b));
+        String expectedHex = hex.toString();
+
+        // computeSignature should match
+        String computed = HmacAuth.computeSignature(secret, method, path, fixedTs,
+                body.getBytes(StandardCharsets.UTF_8));
+        assertEquals(expectedHex, computed, "computeSignature must match Mac directly");
+
+        // apply() must produce the same signature in the header
+        HmacAuth auth = new HmacAuth(serviceId, secret, () -> fixedTs);
+        HttpRequest.Builder b = HttpRequest.newBuilder().uri(URI.create("http://x" + path));
+        auth.apply(b, method, path, body.getBytes(StandardCharsets.UTF_8));
+        HttpRequest req = b.POST(HttpRequest.BodyPublishers.ofString(body)).build();
+        String headerValue = req.headers().firstValue("Authorization").orElseThrow();
+        assertEquals("HMAC-SHA256 " + serviceId + ":" + fixedTs + ":" + expectedHex, headerValue);
+    }
+
+    @Test
+    void hmacUsesEmptyBodyHashForGet() {
+        long ts = 1_700_000_000_000L;
+        String secret = "secret";
+        String path = "/api/v1/ldap/users";
+        // For GET, bodyHash must be the empty string and body is ignored.
+        String sigGet = HmacAuth.computeSignature(secret, "GET", path, ts, "ignored".getBytes());
+        // signing string is METHOD|PATH|TS| (with empty bodyHash)
+        String expectedSigningString = "GET|" + path + "|" + ts + "|";
+        String expected = HmacAuth.hmacSha256Hex(secret, expectedSigningString);
+        assertEquals(expected, sigGet);
+    }
+
+    @Test
+    void hmacDeleteUsesEmptyBodyHash() {
+        long ts = 42L;
+        String secret = "k";
+        String path = "/api/v1/ldap/users/alice";
+        String sig = HmacAuth.computeSignature(secret, "DELETE", path, ts, null);
+        String expected = HmacAuth.hmacSha256Hex(secret, "DELETE|" + path + "|" + ts + "|");
+        assertEquals(expected, sig);
+    }
+
+    @Test
+    void sha256HexKnownVector() {
+        // Empty input vector
+        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                HmacAuth.sha256Hex(new byte[0]));
+        // "abc" vector
+        assertEquals("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                HmacAuth.sha256Hex("abc".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void hmacSignatureNonEmpty() {
+        String sig = HmacAuth.computeSignature("key", "POST", "/x", 1L, "body".getBytes());
+        assertNotNull(sig);
+        assertEquals(64, sig.length()); // 32 bytes hex
+    }
+}

--- a/lsc-plugin/src/test/java/org/lscproject/ldaprest/LdapRestClientTest.java
+++ b/lsc-plugin/src/test/java/org/lscproject/ldaprest/LdapRestClientTest.java
@@ -1,0 +1,187 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.lscproject.ldaprest;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lsc.exception.LscServiceException;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+class LdapRestClientTest {
+
+    private WireMockServer server;
+    private String baseUrl;
+
+    @BeforeEach
+    void start() {
+        server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.port();
+    }
+
+    @AfterEach
+    void stop() {
+        if (server != null) server.stop();
+    }
+
+    @Test
+    void postSendsBodyAndAuthHeader() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"ok\":true}")));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("tok"), 5000, 0);
+        HttpResponse<String> r = c.post("/api/v1/ldap/users", "{\"uid\":\"alice\"}");
+        assertEquals(201, r.statusCode());
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/users"))
+                .withRequestBody(equalToJson("{\"uid\":\"alice\"}"))
+                .withHeader("Authorization", equalTo("Bearer tok"))
+                .withHeader("Content-Type", equalTo("application/json")));
+    }
+
+    @Test
+    void putSendsBody() throws Exception {
+        server.stubFor(put(urlEqualTo("/api/v1/ldap/users/alice"))
+                .willReturn(aResponse().withStatus(200).withBody("{}")));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 0);
+        HttpResponse<String> r = c.put("/api/v1/ldap/users/alice", "{\"replace\":{\"sn\":[\"X\"]}}");
+        assertEquals(200, r.statusCode());
+    }
+
+    @Test
+    void deleteWithoutBody() throws Exception {
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/users/alice"))
+                .willReturn(aResponse().withStatus(200)));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 0);
+        HttpResponse<String> r = c.delete("/api/v1/ldap/users/alice");
+        assertEquals(200, r.statusCode());
+    }
+
+    @Test
+    void getWorks() throws Exception {
+        server.stubFor(get(urlEqualTo("/api/v1/ldap/users"))
+                .willReturn(aResponse().withStatus(200).withBody("[]")));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 0);
+        HttpResponse<String> r = c.get("/api/v1/ldap/users");
+        assertEquals(200, r.statusCode());
+    }
+
+    @Test
+    void retriesOn5xxThenSucceeds() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .inScenario("retry")
+                .whenScenarioStateIs(com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED)
+                .willReturn(aResponse().withStatus(503))
+                .willSetStateTo("after1"));
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .inScenario("retry")
+                .whenScenarioStateIs("after1")
+                .willReturn(aResponse().withStatus(503))
+                .willSetStateTo("after2"));
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .inScenario("retry")
+                .whenScenarioStateIs("after2")
+                .willReturn(aResponse().withStatus(201).withBody("{\"ok\":true}")));
+
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 3,
+                HttpClient.newHttpClient(), ms -> { /* no-op */ });
+        HttpResponse<String> r = c.post("/api/v1/ldap/users", "{}");
+        assertEquals(201, r.statusCode());
+        // 3 attempts total
+        assertEquals(3, server.getAllServeEvents().size());
+    }
+
+    @Test
+    void retriesExhaustedOn5xxThrows() {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .willReturn(aResponse().withStatus(500)));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 2,
+                HttpClient.newHttpClient(), ms -> { /* no-op */ });
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> c.post("/api/v1/ldap/users", "{}"));
+        assertTrue(ex.getMessage().contains("HTTP 500"));
+    }
+
+    @Test
+    void non2xxNon5xxFailsImmediately() {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .willReturn(aResponse().withStatus(400).withBody("{\"error\":\"bad\"}")));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 3,
+                HttpClient.newHttpClient(), ms -> { /* no-op */ });
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> c.post("/api/v1/ldap/users", "{}"));
+        assertTrue(ex.getMessage().contains("HTTP 400"));
+        // No retries: only 1 server call
+        assertEquals(1, server.getAllServeEvents().size());
+    }
+
+    @Test
+    void timeoutCausesException() throws Exception {
+        server.stubFor(post(urlEqualTo("/slow"))
+                .willReturn(aResponse().withStatus(200).withFixedDelay(2000)));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 200, 0,
+                HttpClient.newHttpClient(), ms -> { /* no-op */ });
+        assertThrows(LscServiceException.class, () -> c.post("/slow", "{}"));
+    }
+
+    @Test
+    void hmacAuthHeaderIsPresent() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .willReturn(aResponse().withStatus(201)));
+        LdapRestClient c = new LdapRestClient(baseUrl,
+                new HmacAuth("svc", "very-long-secret-32-chars-min-xxx", () -> 1234L),
+                5000, 0);
+        c.post("/api/v1/ldap/users", "{\"uid\":\"x\"}");
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/users"))
+                .withHeader("Authorization",
+                        equalTo("HMAC-SHA256 svc:1234:" + HmacAuth.computeSignature(
+                                "very-long-secret-32-chars-min-xxx",
+                                "POST", "/api/v1/ldap/users", 1234L,
+                                "{\"uid\":\"x\"}".getBytes(StandardCharsets.UTF_8)))));
+    }
+
+    @Test
+    void retriesOnIoExceptionThenThrows() {
+        // Use an unbound port to force connection refused / IOException
+        int port;
+        try (java.net.ServerSocket s = new java.net.ServerSocket(0)) {
+            port = s.getLocalPort();
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+        // socket closed → port unbound
+        LdapRestClient c = new LdapRestClient("http://127.0.0.1:" + port,
+                new BearerAuth("t"), 1000, 1, HttpClient.newHttpClient(), ms -> { /* no-op */ });
+        assertThrows(LscServiceException.class, () -> c.post("/x", "{}"));
+    }
+
+    @Test
+    void baseUrlTrailingSlashIsStripped() throws Exception {
+        server.stubFor(get(urlEqualTo("/x")).willReturn(aResponse().withStatus(200)));
+        LdapRestClient c = new LdapRestClient(baseUrl + "/", new BearerAuth("t"), 5000, 0);
+        HttpResponse<String> r = c.get("/x");
+        assertEquals(200, r.statusCode());
+    }
+}

--- a/lsc-plugin/src/test/java/org/lscproject/ldaprest/LdapRestDstServiceConfigTest.java
+++ b/lsc-plugin/src/test/java/org/lscproject/ldaprest/LdapRestDstServiceConfigTest.java
@@ -1,0 +1,139 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.lscproject.ldaprest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.Test;
+import org.lsc.configuration.PluginDestinationServiceType;
+import org.lsc.configuration.TaskType;
+import org.lsc.exception.LscServiceException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+class LdapRestDstServiceConfigTest {
+
+    /**
+     * Build a TaskType where {@code getPluginDestinationService().getAny()}
+     * returns the given DOM elements.
+     */
+    private TaskType taskWithConfig(String xmlBody) throws Exception {
+        String xml = "<root xmlns=\"http://lsc-project.org/XSD/lsc-core-2.2.xsd\">"
+                + xmlBody + "</root>";
+        DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document doc = db.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        NodeList children = doc.getDocumentElement().getChildNodes();
+        List<Object> any = new ArrayList<>();
+        for (int i = 0; i < children.getLength(); i++) {
+            if (children.item(i) instanceof Element) {
+                any.add(children.item(i));
+            }
+        }
+        TaskType task = new TaskType();
+        PluginDestinationServiceType plugin = new PluginDestinationServiceType();
+        // Inject the parsed elements via reflection on the JAXB any list.
+        // PluginDestinationServiceType.getAny() returns the underlying mutable list.
+        Method getAny = plugin.getClass().getMethod("getAny");
+        @SuppressWarnings("unchecked")
+        List<Object> live = (List<Object>) getAny.invoke(plugin);
+        live.addAll(any);
+        // task.setPluginDestinationService(plugin)
+        task.setPluginDestinationService(plugin);
+        return task;
+    }
+
+    @Test
+    void parsesBaseUrlAndResourceTypeAndBearer() throws Exception {
+        TaskType task = taskWithConfig(
+                "<baseUrl>https://api.test/</baseUrl>"
+                        + "<resourceType>users</resourceType>"
+                        + "<auth><bearer>tok</bearer></auth>"
+                        + "<timeoutMs>2500</timeoutMs>"
+                        + "<retries>5</retries>");
+        LdapRestDstService.Config cfg = LdapRestDstService.parseConfig(task);
+        assertEquals("https://api.test/", cfg.baseUrl);
+        assertEquals("users", cfg.resourceType);
+        assertEquals(2500L, cfg.timeoutMs);
+        assertEquals(5, cfg.retries);
+        assertTrue(cfg.auth instanceof BearerAuth);
+    }
+
+    @Test
+    void parsesHmacAuth() throws Exception {
+        TaskType task = taskWithConfig(
+                "<baseUrl>https://api.test</baseUrl>"
+                        + "<resourceType>groups</resourceType>"
+                        + "<auth>"
+                        + "  <hmacServiceId>lsc</hmacServiceId>"
+                        + "  <hmacSecret>secret-32-chars-min-aaaaaaaaaaaaa</hmacSecret>"
+                        + "</auth>");
+        LdapRestDstService.Config cfg = LdapRestDstService.parseConfig(task);
+        assertTrue(cfg.auth instanceof HmacAuth);
+    }
+
+    @Test
+    void requiresBaseUrl() throws Exception {
+        TaskType task = taskWithConfig(
+                "<resourceType>users</resourceType>"
+                        + "<auth><bearer>t</bearer></auth>");
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> LdapRestDstService.parseConfig(task));
+        assertTrue(ex.getMessage().contains("baseUrl"));
+    }
+
+    @Test
+    void requiresResourceType() throws Exception {
+        TaskType task = taskWithConfig(
+                "<baseUrl>https://api.test</baseUrl>"
+                        + "<auth><bearer>t</bearer></auth>");
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> LdapRestDstService.parseConfig(task));
+        assertTrue(ex.getMessage().contains("resourceType"));
+    }
+
+    @Test
+    void requiresAuth() throws Exception {
+        TaskType task = taskWithConfig(
+                "<baseUrl>https://api.test</baseUrl>"
+                        + "<resourceType>users</resourceType>");
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> LdapRestDstService.parseConfig(task));
+        assertTrue(ex.getMessage().contains("auth"));
+    }
+
+    @Test
+    void requiresAuthCredentials() throws Exception {
+        TaskType task = taskWithConfig(
+                "<baseUrl>https://api.test</baseUrl>"
+                        + "<resourceType>users</resourceType>"
+                        + "<auth></auth>");
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> LdapRestDstService.parseConfig(task));
+        assertTrue(ex.getMessage().contains("bearer") || ex.getMessage().contains("hmac"));
+    }
+
+    @Test
+    void defaultsAreApplied() throws Exception {
+        TaskType task = taskWithConfig(
+                "<baseUrl>https://api.test</baseUrl>"
+                        + "<resourceType>users</resourceType>"
+                        + "<auth><bearer>t</bearer></auth>");
+        LdapRestDstService.Config cfg = LdapRestDstService.parseConfig(task);
+        assertEquals(10_000L, cfg.timeoutMs);
+        assertEquals(3, cfg.retries);
+        assertEquals("/api", cfg.apiPrefix);
+    }
+}

--- a/lsc-plugin/src/test/java/org/lscproject/ldaprest/LdapRestDstServiceConfigTest.java
+++ b/lsc-plugin/src/test/java/org/lscproject/ldaprest/LdapRestDstServiceConfigTest.java
@@ -136,4 +136,58 @@ class LdapRestDstServiceConfigTest {
         assertEquals(3, cfg.retries);
         assertEquals("/api", cfg.apiPrefix);
     }
+
+    @Test
+    void rejectsZeroOrNegativeTimeout() throws Exception {
+        for (String bad : new String[] {"0", "-1", "-10000"}) {
+            TaskType task = taskWithConfig(
+                    "<baseUrl>https://api.test</baseUrl>"
+                            + "<resourceType>users</resourceType>"
+                            + "<auth><bearer>t</bearer></auth>"
+                            + "<timeoutMs>" + bad + "</timeoutMs>");
+            LscServiceException ex = assertThrows(LscServiceException.class,
+                    () -> LdapRestDstService.parseConfig(task),
+                    "expected rejection for timeoutMs=" + bad);
+            assertTrue(ex.getMessage().contains("timeoutMs"),
+                    "message should mention timeoutMs, got: " + ex.getMessage());
+        }
+    }
+
+    @Test
+    void rejectsNegativeRetries() throws Exception {
+        TaskType task = taskWithConfig(
+                "<baseUrl>https://api.test</baseUrl>"
+                        + "<resourceType>users</resourceType>"
+                        + "<auth><bearer>t</bearer></auth>"
+                        + "<retries>-1</retries>");
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> LdapRestDstService.parseConfig(task));
+        assertTrue(ex.getMessage().contains("retries"),
+                "message should mention retries, got: " + ex.getMessage());
+    }
+
+    @Test
+    void acceptsZeroRetries() throws Exception {
+        // 0 retries is valid (= no retry, single attempt)
+        TaskType task = taskWithConfig(
+                "<baseUrl>https://api.test</baseUrl>"
+                        + "<resourceType>users</resourceType>"
+                        + "<auth><bearer>t</bearer></auth>"
+                        + "<retries>0</retries>");
+        LdapRestDstService.Config cfg = LdapRestDstService.parseConfig(task);
+        assertEquals(0, cfg.retries);
+    }
+
+    @Test
+    void rejectsNonNumericTimeout() throws Exception {
+        TaskType task = taskWithConfig(
+                "<baseUrl>https://api.test</baseUrl>"
+                        + "<resourceType>users</resourceType>"
+                        + "<auth><bearer>t</bearer></auth>"
+                        + "<timeoutMs>fast</timeoutMs>");
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> LdapRestDstService.parseConfig(task));
+        assertTrue(ex.getMessage().contains("timeoutMs"),
+                "message should mention timeoutMs, got: " + ex.getMessage());
+    }
 }

--- a/lsc-plugin/src/test/java/org/lscproject/ldaprest/LdapRestDstServiceIntegrationTest.java
+++ b/lsc-plugin/src/test/java/org/lscproject/ldaprest/LdapRestDstServiceIntegrationTest.java
@@ -1,0 +1,255 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.lscproject.ldaprest;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lsc.LscDatasetModification;
+import org.lsc.LscDatasetModification.LscDatasetModificationType;
+import org.lsc.LscModificationType;
+import org.lsc.LscModifications;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+class LdapRestDstServiceIntegrationTest {
+
+    private WireMockServer server;
+    private String baseUrl;
+
+    @BeforeEach
+    void start() {
+        server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.port();
+    }
+
+    @AfterEach
+    void stop() {
+        if (server != null) server.stop();
+    }
+
+    private LdapRestDstService usersService() {
+        ResourceMapper mapper = new ResourceMapper("users");
+        LdapRestClient client = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 0);
+        return new LdapRestDstService(client, mapper);
+    }
+
+    private LdapRestDstService groupsService() {
+        ResourceMapper mapper = new ResourceMapper("groups");
+        LdapRestClient client = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 0);
+        return new LdapRestDstService(client, mapper);
+    }
+
+    private LdapRestDstService orgsService() {
+        ResourceMapper mapper = new ResourceMapper("organizations");
+        LdapRestClient client = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 0);
+        return new LdapRestDstService(client, mapper);
+    }
+
+    private LscModifications lm(LscModificationType op, String main) {
+        LscModifications m = new LscModifications(op, "task");
+        m.setMainIdentifer(main);
+        return m;
+    }
+
+    private LscDatasetModification rep(String name, Object... vals) {
+        return new LscDatasetModification(LscDatasetModificationType.REPLACE_VALUES,
+                name, Arrays.asList(vals));
+    }
+
+    private LscDatasetModification add(String name, Object... vals) {
+        return new LscDatasetModification(LscDatasetModificationType.ADD_VALUES,
+                name, Arrays.asList(vals));
+    }
+
+    private LscDatasetModification del(String name, Object... vals) {
+        return new LscDatasetModification(LscDatasetModificationType.DELETE_VALUES,
+                name, Arrays.asList(vals));
+    }
+
+    @Test
+    void createUserPostsCollection() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+        LscModifications m = lm(LscModificationType.CREATE_OBJECT, "uid=alice,ou=users,dc=ex,dc=org");
+        m.setLscAttributeModifications(Arrays.asList(
+                rep("uid", "alice"),
+                rep("sn", "Doe"),
+                rep("cn", "Alice Doe")));
+        assertTrue(usersService().apply(m));
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/users"))
+                .withRequestBody(equalToJson("{\"uid\":\"alice\",\"sn\":\"Doe\",\"cn\":\"Alice Doe\"}"))
+                .withHeader("Authorization", equalTo("Bearer t")));
+    }
+
+    @Test
+    void updateUserPutsItem() throws Exception {
+        server.stubFor(put(urlEqualTo("/api/v1/ldap/users/alice"))
+                .willReturn(aResponse().withStatus(200).withBody("{}")));
+        LscModifications m = lm(LscModificationType.UPDATE_OBJECT, "uid=alice,ou=users,dc=ex,dc=org");
+        m.setLscAttributeModifications(Arrays.asList(
+                rep("sn", "NewName"),
+                add("mail", "a@x.fr"),
+                del("description")));
+        assertTrue(usersService().apply(m));
+        server.verify(putRequestedFor(urlEqualTo("/api/v1/ldap/users/alice"))
+                .withRequestBody(equalToJson(
+                        "{\"replace\":{\"sn\":[\"NewName\"]},\"add\":{\"mail\":[\"a@x.fr\"]},\"delete\":[\"description\"]}")));
+    }
+
+    @Test
+    void deleteUser() throws Exception {
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/users/alice"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.DELETE_OBJECT, "uid=alice,ou=users,dc=ex,dc=org");
+        assertTrue(usersService().apply(m));
+        server.verify(deleteRequestedFor(urlEqualTo("/api/v1/ldap/users/alice")));
+    }
+
+    @Test
+    void deleteUser404IsTreatedAsSuccess() throws Exception {
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/users/ghost"))
+                .willReturn(aResponse().withStatus(404).withBody("{\"error\":\"not found\"}")));
+        LscModifications m = lm(LscModificationType.DELETE_OBJECT, "uid=ghost,ou=users,dc=ex,dc=org");
+        assertTrue(usersService().apply(m));
+    }
+
+    @Test
+    void modrdnUserCallsMove() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users/alice/move"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.CHANGE_ID, "uid=alice,ou=users,dc=ex,dc=org");
+        m.setNewMainIdentifier("uid=alice,ou=admins,dc=ex,dc=org");
+        assertTrue(usersService().apply(m));
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/users/alice/move"))
+                .withRequestBody(equalToJson("{\"targetOrgDn\":\"ou=admins,dc=ex,dc=org\"}")));
+    }
+
+    @Test
+    void createGroupPostsCollection() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/groups"))
+                .willReturn(aResponse().withStatus(201)));
+        LscModifications m = lm(LscModificationType.CREATE_OBJECT, "cn=admins,ou=groups,dc=ex,dc=org");
+        m.setLscAttributeModifications(Arrays.asList(
+                rep("cn", "admins"),
+                rep("description", "Admins"),
+                rep("member", "uid=alice,ou=users,dc=ex,dc=org")));
+        assertTrue(groupsService().apply(m));
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/groups"))
+                .withRequestBody(equalToJson(
+                        "{\"cn\":\"admins\",\"description\":\"Admins\",\"member\":\"uid=alice,ou=users,dc=ex,dc=org\"}")));
+    }
+
+    @Test
+    void updateGroupAddMemberUsesMembersEndpoint() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/groups/admins/members"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.UPDATE_OBJECT, "cn=admins,ou=groups,dc=ex,dc=org");
+        m.setLscAttributeModifications(Collections.singletonList(
+                add("member", "uid=alice,ou=users,dc=ex,dc=org")));
+        assertTrue(groupsService().apply(m));
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/groups/admins/members"))
+                .withRequestBody(equalToJson(
+                        "{\"member\":\"uid=alice,ou=users,dc=ex,dc=org\"}")));
+    }
+
+    @Test
+    void updateGroupDeleteMemberUsesMembersEndpoint() throws Exception {
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/groups/admins/members/uid%3Dalice%2Cou%3Dusers%2Cdc%3Dex%2Cdc%3Dorg"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.UPDATE_OBJECT, "cn=admins,ou=groups,dc=ex,dc=org");
+        m.setLscAttributeModifications(Collections.singletonList(
+                del("member", "uid=alice,ou=users,dc=ex,dc=org")));
+        assertTrue(groupsService().apply(m));
+    }
+
+    @Test
+    void updateGroupNonMemberAttributeUsesPut() throws Exception {
+        server.stubFor(put(urlEqualTo("/api/v1/ldap/groups/admins"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.UPDATE_OBJECT, "cn=admins,ou=groups,dc=ex,dc=org");
+        m.setLscAttributeModifications(Collections.singletonList(
+                rep("description", "New Description")));
+        assertTrue(groupsService().apply(m));
+        server.verify(putRequestedFor(urlEqualTo("/api/v1/ldap/groups/admins"))
+                .withRequestBody(equalToJson(
+                        "{\"replace\":{\"description\":[\"New Description\"]}}")));
+    }
+
+    @Test
+    void deleteGroup() throws Exception {
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/groups/admins"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.DELETE_OBJECT, "cn=admins,ou=groups,dc=ex,dc=org");
+        assertTrue(groupsService().apply(m));
+    }
+
+    @Test
+    void renameGroupUsesRenameEndpoint() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/groups/oldcn/rename"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.CHANGE_ID, "cn=oldcn,ou=groups,dc=ex,dc=org");
+        m.setNewMainIdentifier("cn=newcn,ou=groups,dc=ex,dc=org");
+        assertTrue(groupsService().apply(m));
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/groups/oldcn/rename"))
+                .withRequestBody(equalToJson("{\"newCn\":\"newcn\"}")));
+    }
+
+    @Test
+    void createOrganizationPostsCollection() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/organizations"))
+                .willReturn(aResponse().withStatus(201)));
+        LscModifications m = lm(LscModificationType.CREATE_OBJECT, "ou=sales,dc=ex,dc=org");
+        m.setLscAttributeModifications(Arrays.asList(
+                rep("ou", "sales"),
+                rep("description", "Sales")));
+        assertTrue(orgsService().apply(m));
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/organizations"))
+                .withRequestBody(equalToJson("{\"ou\":\"sales\",\"description\":\"Sales\"}")));
+    }
+
+    @Test
+    void deleteOrganizationUsesEncodedDn() throws Exception {
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/organizations/ou%3Dsales%2Cdc%3Dex%2Cdc%3Dorg"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.DELETE_OBJECT, "ou=sales,dc=ex,dc=org");
+        assertTrue(orgsService().apply(m));
+    }
+
+    @Test
+    void updateOrganizationPutsEncodedDn() throws Exception {
+        server.stubFor(put(urlEqualTo("/api/v1/ldap/organizations/ou%3Dsales%2Cdc%3Dex%2Cdc%3Dorg"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.UPDATE_OBJECT, "ou=sales,dc=ex,dc=org");
+        m.setLscAttributeModifications(Collections.singletonList(rep("description", "Up")));
+        assertTrue(orgsService().apply(m));
+    }
+
+    @Test
+    void readMethodsAreEmpty() throws Exception {
+        LdapRestDstService svc = usersService();
+        assertEquals(null, svc.getBean("alice", new org.lsc.LscDatasets(), false));
+        assertTrue(svc.getListPivots().isEmpty());
+        assertTrue(svc.getSupportedConnectionType().isEmpty());
+        assertTrue(svc.getWriteDatasetIds().isEmpty());
+    }
+}

--- a/lsc-plugin/src/test/java/org/lscproject/ldaprest/LdapRestDstServiceIntegrationTest.java
+++ b/lsc-plugin/src/test/java/org/lscproject/ldaprest/LdapRestDstServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
@@ -180,6 +181,32 @@ class LdapRestDstServiceIntegrationTest {
         m.setLscAttributeModifications(Collections.singletonList(
                 del("member", "uid=alice,ou=users,dc=ex,dc=org")));
         assertTrue(groupsService().apply(m));
+    }
+
+    @Test
+    void updateGroupAttributeWideDeleteOnMemberFetchesAndRemovesAll() throws Exception {
+        // Reconcile: GET the group, parse "member" array, fire one DELETE per member.
+        server.stubFor(get(urlEqualTo("/api/v1/ldap/groups/admins"))
+                .willReturn(aResponse().withStatus(200).withBody(
+                        "{\"cn\":\"admins\",\"member\":["
+                        + "\"uid=alice,ou=users,dc=ex,dc=org\","
+                        + "\"uid=bob,ou=users,dc=ex,dc=org\"]}")));
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/groups/admins/members/uid%3Dalice%2Cou%3Dusers%2Cdc%3Dex%2Cdc%3Dorg"))
+                .willReturn(aResponse().withStatus(200)));
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/groups/admins/members/uid%3Dbob%2Cou%3Dusers%2Cdc%3Dex%2Cdc%3Dorg"))
+                .willReturn(aResponse().withStatus(200)));
+
+        LscModifications m = lm(LscModificationType.UPDATE_OBJECT, "cn=admins,ou=groups,dc=ex,dc=org");
+        // attribute-wide DELETE: empty values list
+        m.setLscAttributeModifications(Collections.singletonList(
+                new LscDatasetModification(LscDatasetModificationType.DELETE_VALUES,
+                        "member", Collections.emptyList())));
+        assertTrue(groupsService().apply(m));
+
+        server.verify(deleteRequestedFor(urlEqualTo(
+                "/api/v1/ldap/groups/admins/members/uid%3Dalice%2Cou%3Dusers%2Cdc%3Dex%2Cdc%3Dorg")));
+        server.verify(deleteRequestedFor(urlEqualTo(
+                "/api/v1/ldap/groups/admins/members/uid%3Dbob%2Cou%3Dusers%2Cdc%3Dex%2Cdc%3Dorg")));
     }
 
     @Test

--- a/lsc-plugin/src/test/java/org/lscproject/ldaprest/ModificationTranslatorTest.java
+++ b/lsc-plugin/src/test/java/org/lscproject/ldaprest/ModificationTranslatorTest.java
@@ -1,0 +1,278 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.lscproject.ldaprest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.lsc.LscDatasetModification;
+import org.lsc.LscDatasetModification.LscDatasetModificationType;
+import org.lsc.LscModificationType;
+import org.lsc.LscModifications;
+import org.lsc.exception.LscServiceException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class ModificationTranslatorTest {
+
+    private static final ObjectMapper M = new ObjectMapper();
+
+    private LscModifications mods(LscModificationType op, String mainId,
+                                  LscDatasetModification... attrs) {
+        LscModifications m = new LscModifications(op, "test-task");
+        m.setMainIdentifer(mainId);
+        m.setLscAttributeModifications(Arrays.asList(attrs));
+        return m;
+    }
+
+    private LscDatasetModification attr(LscDatasetModificationType op, String name, Object... vals) {
+        return new LscDatasetModification(op, name, Arrays.asList(vals));
+    }
+
+    private Map<?, ?> parse(String json) throws Exception {
+        return M.readValue(json, Map.class);
+    }
+
+    // ---------------- CREATE ----------------
+    @Test
+    void createFlatSingleValue() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "uid=alice,ou=users",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "uid", "alice"),
+                attr(LscDatasetModificationType.REPLACE_VALUES, "sn", "Doe"));
+        String json = t.buildCreateBody(lm);
+        Map<?, ?> m = parse(json);
+        assertEquals("alice", m.get("uid"));
+        assertEquals("Doe", m.get("sn"));
+    }
+
+    @Test
+    void createFlatMultiValueAsArray() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "uid=bob",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "objectClass", "top", "person"));
+        String json = t.buildCreateBody(lm);
+        Map<?, ?> m = parse(json);
+        assertEquals(Arrays.asList("top", "person"), m.get("objectClass"));
+    }
+
+    @Test
+    void createGroup() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("groups"));
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "cn=admins,ou=groups",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "cn", "admins"),
+                attr(LscDatasetModificationType.REPLACE_VALUES, "description", "Administrators"),
+                attr(LscDatasetModificationType.REPLACE_VALUES, "member",
+                        "uid=alice,ou=users", "uid=bob,ou=users"));
+        String json = t.buildCreateBody(lm);
+        Map<?, ?> m = parse(json);
+        assertEquals("admins", m.get("cn"));
+        assertEquals("Administrators", m.get("description"));
+        assertEquals(Arrays.asList("uid=alice,ou=users", "uid=bob,ou=users"), m.get("member"));
+    }
+
+    @Test
+    void createOrganization() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("organizations"));
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "ou=sales,dc=ex,dc=org",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "ou", "sales"),
+                attr(LscDatasetModificationType.REPLACE_VALUES, "description", "Sales team"));
+        String json = t.buildCreateBody(lm);
+        Map<?, ?> m = parse(json);
+        assertEquals("sales", m.get("ou"));
+        assertEquals("Sales team", m.get("description"));
+    }
+
+    // ---------------- UPDATE ----------------
+    @Test
+    void updateReplaceOnly() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "uid=alice,ou=users",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "sn", "NewName"));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        assertTrue(m.containsKey("replace"));
+        Map<?, ?> rep = (Map<?, ?>) m.get("replace");
+        assertEquals(Collections.singletonList("NewName"), rep.get("sn"));
+        assertTrue(!m.containsKey("add"));
+        assertTrue(!m.containsKey("delete"));
+    }
+
+    @Test
+    void updateAddOnly() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "uid=alice",
+                attr(LscDatasetModificationType.ADD_VALUES, "mail", "a@x.fr"));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        assertTrue(m.containsKey("add"));
+        Map<?, ?> add = (Map<?, ?>) m.get("add");
+        assertEquals(Collections.singletonList("a@x.fr"), add.get("mail"));
+    }
+
+    @Test
+    void updateDeleteAttributeWide() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "uid=alice",
+                new LscDatasetModification(LscDatasetModificationType.DELETE_VALUES,
+                        "telephoneNumber", Collections.emptyList()));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        assertEquals(Collections.singletonList("telephoneNumber"), m.get("delete"));
+    }
+
+    @Test
+    void updateDeleteSpecificValues() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "uid=alice",
+                attr(LscDatasetModificationType.DELETE_VALUES, "mail", "old@x.fr"));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        Map<?, ?> del = (Map<?, ?>) m.get("delete");
+        assertEquals(Collections.singletonList("old@x.fr"), del.get("mail"));
+    }
+
+    @Test
+    void updateMixReplaceAddDelete() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "uid=alice",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "sn", "Doe"),
+                attr(LscDatasetModificationType.ADD_VALUES, "mail", "n@x.fr"),
+                attr(LscDatasetModificationType.DELETE_VALUES, "mail", "o@x.fr"),
+                new LscDatasetModification(LscDatasetModificationType.DELETE_VALUES,
+                        "telephoneNumber", Collections.emptyList()));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        assertTrue(m.containsKey("replace"));
+        assertTrue(m.containsKey("add"));
+        // delete merged: telephoneNumber → [], mail → [o@x.fr]
+        Map<?, ?> del = (Map<?, ?>) m.get("delete");
+        assertEquals(Collections.singletonList("o@x.fr"), del.get("mail"));
+        assertEquals(Collections.emptyList(), del.get("telephoneNumber"));
+    }
+
+    @Test
+    void updateGroupShape() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("groups"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "cn=admins",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "description", "New desc"));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        Map<?, ?> rep = (Map<?, ?>) m.get("replace");
+        assertEquals(Collections.singletonList("New desc"), rep.get("description"));
+    }
+
+    @Test
+    void updateOrgShape() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("organizations"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "ou=sales,dc=ex,dc=org",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "description", "Updated"));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        assertTrue(m.containsKey("replace"));
+    }
+
+    // ---------------- MODRDN ----------------
+    @Test
+    void modrdnFlatProducesMoveTargetOrgDn() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.CHANGE_ID, "uid=alice,ou=users,dc=ex,dc=org");
+        lm.setNewMainIdentifier("uid=alice,ou=admins,dc=ex,dc=org");
+        ModificationTranslator.ModrdnPayload p = t.buildModrdnPayload(lm);
+        assertEquals(ModificationTranslator.ModrdnKind.MOVE, p.kind);
+        Map<?, ?> m = parse(p.body);
+        assertEquals("ou=admins,dc=ex,dc=org", m.get("targetOrgDn"));
+    }
+
+    @Test
+    void modrdnGroupSameParentProducesRename() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("groups"));
+        LscModifications lm = mods(LscModificationType.CHANGE_ID, "cn=oldname,ou=groups,dc=ex,dc=org");
+        lm.setNewMainIdentifier("cn=newname,ou=groups,dc=ex,dc=org");
+        ModificationTranslator.ModrdnPayload p = t.buildModrdnPayload(lm);
+        assertEquals(ModificationTranslator.ModrdnKind.RENAME, p.kind);
+        Map<?, ?> m = parse(p.body);
+        assertEquals("newname", m.get("newCn"));
+    }
+
+    @Test
+    void modrdnGroupDifferentParentProducesMove() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("groups"));
+        LscModifications lm = mods(LscModificationType.CHANGE_ID, "cn=admins,ou=groups,dc=ex,dc=org");
+        lm.setNewMainIdentifier("cn=admins,ou=other,dc=ex,dc=org");
+        ModificationTranslator.ModrdnPayload p = t.buildModrdnPayload(lm);
+        assertEquals(ModificationTranslator.ModrdnKind.MOVE, p.kind);
+    }
+
+    @Test
+    void modrdnOrgProducesMove() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("organizations"));
+        LscModifications lm = mods(LscModificationType.CHANGE_ID, "ou=sales,dc=ex,dc=org");
+        lm.setNewMainIdentifier("ou=sales,ou=parent,dc=ex,dc=org");
+        ModificationTranslator.ModrdnPayload p = t.buildModrdnPayload(lm);
+        assertEquals(ModificationTranslator.ModrdnKind.MOVE, p.kind);
+        Map<?, ?> m = parse(p.body);
+        assertEquals("ou=parent,dc=ex,dc=org", m.get("targetOrgDn"));
+    }
+
+    @Test
+    void modrdnFailsWithoutNewMainIdentifier() {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.CHANGE_ID, "uid=alice");
+        assertThrows(LscServiceException.class, () -> t.buildModrdnPayload(lm));
+    }
+
+    // ---------------- BINARY ----------------
+    @Test
+    void binaryAttributeRejected() {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        byte[] notUtf8 = new byte[] { (byte) 0xff, (byte) 0xfe, (byte) 0xc3, 0x28 };
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "uid=alice",
+                new LscDatasetModification(LscDatasetModificationType.REPLACE_VALUES,
+                        "jpegPhoto", java.util.Collections.singletonList(notUtf8)));
+        LscServiceException ex = assertThrows(LscServiceException.class, () -> t.buildCreateBody(lm));
+        assertTrue(ex.getMessage().contains("binary"));
+        assertTrue(ex.getMessage().contains("jpegPhoto"));
+    }
+
+    @Test
+    void utf8BinaryIsAcceptedAsString() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        byte[] utf8 = "héllo".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "uid=alice",
+                new LscDatasetModification(LscDatasetModificationType.REPLACE_VALUES,
+                        "description", java.util.Collections.singletonList(utf8)));
+        Map<?, ?> m = parse(t.buildCreateBody(lm));
+        assertEquals("héllo", m.get("description"));
+    }
+
+    // ---------------- JSON shape (signature stability) ----------------
+    @Test
+    void jsonOutputIsCompactNoExtraSpaces() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "uid=alice",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "uid", "alice"));
+        String json = t.buildCreateBody(lm);
+        // No pretty print: no spaces after ':' or ','
+        assertEquals("{\"uid\":\"alice\"}", json);
+    }
+
+    @Test
+    void jsonOutputPreservesInsertionOrder() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        // Insertion order matters for HMAC stability
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "uid=alice",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "z", "1"),
+                attr(LscDatasetModificationType.REPLACE_VALUES, "a", "2"));
+        assertEquals("{\"z\":\"1\",\"a\":\"2\"}", t.buildCreateBody(lm));
+    }
+
+    @Test
+    void writeJsonHelperIsCompact() throws Exception {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("a", 1);
+        body.put("b", "two");
+        assertEquals("{\"a\":1,\"b\":\"two\"}", ModificationTranslator.writeJson(body));
+    }
+}

--- a/lsc-plugin/src/test/java/org/lscproject/ldaprest/ModificationTranslatorTest.java
+++ b/lsc-plugin/src/test/java/org/lscproject/ldaprest/ModificationTranslatorTest.java
@@ -275,4 +275,29 @@ class ModificationTranslatorTest {
         body.put("b", "two");
         assertEquals("{\"a\":1,\"b\":\"two\"}", ModificationTranslator.writeJson(body));
     }
+
+    @Test
+    void readMembersFromArray() throws Exception {
+        java.util.List<Object> members = ModificationTranslator.readMembers(
+                "{\"cn\":\"admins\",\"member\":[\"uid=alice,ou=users\",\"uid=bob,ou=users\"]}");
+        assertEquals(2, members.size());
+        assertEquals("uid=alice,ou=users", members.get(0));
+        assertEquals("uid=bob,ou=users", members.get(1));
+    }
+
+    @Test
+    void readMembersFromSingleString() throws Exception {
+        java.util.List<Object> members = ModificationTranslator.readMembers(
+                "{\"member\":\"uid=alice,ou=users\"}");
+        assertEquals(1, members.size());
+        assertEquals("uid=alice,ou=users", members.get(0));
+    }
+
+    @Test
+    void readMembersHandlesMissingField() throws Exception {
+        assertEquals(0, ModificationTranslator.readMembers("{\"cn\":\"admins\"}").size());
+        assertEquals(0, ModificationTranslator.readMembers("{}").size());
+        assertEquals(0, ModificationTranslator.readMembers("").size());
+        assertEquals(0, ModificationTranslator.readMembers(null).size());
+    }
 }

--- a/lsc-plugin/src/test/java/org/lscproject/ldaprest/ResourceMapperTest.java
+++ b/lsc-plugin/src/test/java/org/lscproject/ldaprest/ResourceMapperTest.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.lscproject.ldaprest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ResourceMapperTest {
+
+    @Test
+    void rdnValueExtractsSimpleUid() {
+        assertEquals("alice", ResourceMapper.rdnValue("uid=alice,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void rdnValueExtractsCn() {
+        assertEquals("admins", ResourceMapper.rdnValue("cn=admins,ou=groups,dc=ex,dc=org"));
+    }
+
+    @Test
+    void rdnValueOnBareValue() {
+        assertEquals("alice", ResourceMapper.rdnValue("alice"));
+    }
+
+    @Test
+    void rdnValueHandlesEscapedComma() {
+        assertEquals("Doe\\, John",
+                ResourceMapper.rdnValue("cn=Doe\\, John,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void rdnValueTrimsWhitespace() {
+        assertEquals("alice", ResourceMapper.rdnValue("uid= alice ,ou=x"));
+    }
+
+    @Test
+    void parentDnReturnsTail() {
+        assertEquals("ou=users,dc=ex,dc=org",
+                ResourceMapper.parentDn("uid=alice,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void parentDnEmptyForRdnOnly() {
+        assertEquals("", ResourceMapper.parentDn("uid=alice"));
+    }
+
+    @Test
+    void firstRdnHandlesEscapedComma() {
+        assertEquals("cn=Doe\\, John",
+                ResourceMapper.firstRdn("cn=Doe\\, John,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void collectionPathFlat() {
+        ResourceMapper m = new ResourceMapper("users");
+        assertEquals("/api/v1/ldap/users", m.collectionPath());
+    }
+
+    @Test
+    void itemPathFlatUsesRdnValue() {
+        ResourceMapper m = new ResourceMapper("users");
+        assertEquals("/api/v1/ldap/users/alice",
+                m.itemPath("uid=alice,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void itemPathOrgUsesEncodedDn() {
+        ResourceMapper m = new ResourceMapper("organizations");
+        String got = m.itemPath("ou=sales,dc=ex,dc=org");
+        // commas and equals are URL-encoded
+        assertEquals("/api/v1/ldap/organizations/ou%3Dsales%2Cdc%3Dex%2Cdc%3Dorg", got);
+    }
+
+    @Test
+    void movePathFlat() {
+        ResourceMapper m = new ResourceMapper("users");
+        assertEquals("/api/v1/ldap/users/alice/move",
+                m.movePath("uid=alice,ou=users"));
+    }
+
+    @Test
+    void renamePathOnlyForGroups() {
+        ResourceMapper g = new ResourceMapper("groups");
+        assertEquals("/api/v1/ldap/groups/admins/rename",
+                g.renamePath("cn=admins,ou=groups"));
+        ResourceMapper u = new ResourceMapper("users");
+        assertThrows(IllegalStateException.class, () -> u.renamePath("uid=x"));
+    }
+
+    @Test
+    void membersPath() {
+        ResourceMapper g = new ResourceMapper("groups");
+        assertEquals("/api/v1/ldap/groups/admins/members",
+                g.membersPath("cn=admins,ou=groups"));
+    }
+
+    @Test
+    void memberItemPathEncodesMemberDn() {
+        ResourceMapper g = new ResourceMapper("groups");
+        String p = g.memberItemPath("cn=admins,ou=groups", "uid=alice,ou=users,dc=ex,dc=org");
+        assertEquals(
+                "/api/v1/ldap/groups/admins/members/uid%3Dalice%2Cou%3Dusers%2Cdc%3Dex%2Cdc%3Dorg",
+                p);
+    }
+
+    @Test
+    void resourceTypeIsCaseInsensitive() {
+        ResourceMapper m = new ResourceMapper("Groups");
+        assertEquals(ResourceMapper.Family.GROUPS, m.getFamily());
+    }
+}

--- a/lsc-plugin/src/test/java/org/lscproject/ldaprest/ResourceMapperTest.java
+++ b/lsc-plugin/src/test/java/org/lscproject/ldaprest/ResourceMapperTest.java
@@ -47,8 +47,27 @@ class ResourceMapperTest {
     }
 
     @Test
-    void rdnValueTrimsWhitespace() {
-        assertEquals("alice", ResourceMapper.rdnValue("uid= alice ,ou=x"));
+    void rdnValueUnescapesPlus() {
+        // \+ is the RFC 4514 escape for '+' (which separates multi-valued RDNs)
+        assertEquals("a+b", ResourceMapper.rdnValue("cn=a\\+b,ou=x"));
+    }
+
+    @Test
+    void rdnValueUnescapesEquals() {
+        assertEquals("foo=bar", ResourceMapper.rdnValue("cn=foo\\=bar,ou=x"));
+    }
+
+    @Test
+    void rdnValueExtractsLeftmostFromMultiValuedRdn() {
+        // Multi-valued RDN: "cn=A+sn=B,...". LdapName parses both as one
+        // RDN; we extract the value picked up by Rdn.getValue() (the
+        // first attribute defined in the RDN).
+        String got = ResourceMapper.rdnValue("cn=Smith+sn=John,ou=users,dc=ex,dc=org");
+        // Either "Smith" or "John" depending on JDK ordering; both are
+        // legitimate logical identifiers for this entry.
+        org.junit.jupiter.api.Assertions.assertTrue(
+                "Smith".equals(got) || "John".equals(got),
+                "expected Smith or John, got: " + got);
     }
 
     @Test

--- a/lsc-plugin/src/test/java/org/lscproject/ldaprest/ResourceMapperTest.java
+++ b/lsc-plugin/src/test/java/org/lscproject/ldaprest/ResourceMapperTest.java
@@ -26,9 +26,24 @@ class ResourceMapperTest {
     }
 
     @Test
-    void rdnValueHandlesEscapedComma() {
-        assertEquals("Doe\\, John",
+    void rdnValueUnescapesRfc4514EscapedComma() {
+        // ldap-rest expects the unescaped logical value in :id path params;
+        // the server re-escapes it via escapeDnValue. Returning the still-
+        // escaped form would double-escape on the wire.
+        assertEquals("Doe, John",
                 ResourceMapper.rdnValue("cn=Doe\\, John,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void rdnValueUnescapesHexEscape() {
+        // \2c is an RFC 4514 hex escape for ','
+        assertEquals("Doe, John",
+                ResourceMapper.rdnValue("cn=Doe\\2c John,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void rdnValueUnescapesBackslash() {
+        assertEquals("a\\b", ResourceMapper.rdnValue("cn=a\\\\b,ou=x"));
     }
 
     @Test

--- a/lsc-plugin/test/integration/Dockerfile.lsc
+++ b/lsc-plugin/test/integration/Dockerfile.lsc
@@ -1,0 +1,43 @@
+# LSC runner image with the ldap-rest plugin preinstalled.
+# Builds LSC from source (release tag v2.2) since lsc-project/lsc is not
+# published to Maven Central and there is no maintained official Docker image.
+
+FROM eclipse-temurin:11-jdk AS lsc-build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git ca-certificates maven \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone --depth 1 --branch v2.2 https://github.com/lsc-project/lsc.git /src/lsc
+WORKDIR /src/lsc
+RUN mvn -B -DskipTests package
+
+FROM eclipse-temurin:11-jdk AS plugin-build
+RUN apt-get update && apt-get install -y --no-install-recommends maven \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=lsc-build /root/.m2 /root/.m2
+COPY --from=lsc-build /src/lsc /src/lsc
+RUN cd /src/lsc && mvn -B -DskipTests install
+COPY pom.xml /src/plugin/pom.xml
+COPY src /src/plugin/src
+WORKDIR /src/plugin
+RUN mvn -B -DskipTests package
+
+FROM eclipse-temurin:11-jre
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ldap-utils curl jq ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# LSC distribution layout: /opt/lsc/{bin,lib,etc}
+ENV LSC_HOME=/opt/lsc
+RUN mkdir -p $LSC_HOME/bin $LSC_HOME/lib $LSC_HOME/etc
+
+# Copy LSC core jars + dependencies
+COPY --from=lsc-build /src/lsc/target/lsc-core-2.2.jar $LSC_HOME/lib/
+COPY --from=lsc-build /src/lsc/target/dependency/ $LSC_HOME/lib/
+# Copy the lsc launcher script if present in the build, or provide a wrapper
+COPY --from=lsc-build /src/lsc/bin/lsc $LSC_HOME/bin/lsc
+
+# Copy our plugin (with-deps shaded jar so Jackson is bundled)
+COPY --from=plugin-build /src/plugin/target/lsc-ldaprest-plugin-0.1.0-SNAPSHOT-with-deps.jar $LSC_HOME/lib/
+
+ENV PATH="$LSC_HOME/bin:$PATH"
+WORKDIR $LSC_HOME

--- a/lsc-plugin/test/integration/README.md
+++ b/lsc-plugin/test/integration/README.md
@@ -1,0 +1,52 @@
+# Integration test for lsc-ldaprest-plugin
+
+End-to-end test: a real LSC binary syncs entries from a source OpenLDAP
+instance to ldap-rest (which writes them into a target OpenLDAP), through the
+plugin under test. No mocks.
+
+## Stack
+
+| Service       | Image                          | Role                                      |
+|---------------|--------------------------------|-------------------------------------------|
+| `ldap-source` | `osixia/openldap:1.5.0`        | LDAP source seeded from `ldif/source-seed.ldif` |
+| `ldap-target` | `osixia/openldap:1.5.0`        | Empty LDAP target written by ldap-rest    |
+| `ldap-rest`   | built from `../../../Dockerfile` | ldap-rest service, Bearer auth, `/api/v1/ldap/...` |
+| `lsc`         | built from `Dockerfile.lsc`    | LSC v2.2 + plugin jar in classpath        |
+
+## Run
+
+```sh
+cd lsc-plugin/test/integration
+./tests/run.sh
+```
+
+The first run downloads images and builds three containers, including LSC
+from source — count 5–10 minutes. Subsequent runs are much faster.
+
+Container logs are dumped to `logs/` after each run. The compose stack is
+torn down (volumes wiped) on exit, success or failure.
+
+## Scenarios
+
+1. **CREATE** — first sync of 5 users from source. Asserts:
+   - `GET /api/v1/ldap/users` returns 5 entries
+   - `GET /api/v1/ldap/users/alice` matches the source attributes
+   - direct `ldapsearch` on `ldap-target` finds alice (proves ldap-rest
+     actually wrote LDAP, not just acked)
+
+2. **UPDATE** — modify alice's `mail` in the source, re-sync. Asserts the
+   change propagated through the plugin's PUT `replace` translation.
+
+3. **DELETE** — remove eve from the source, re-sync. Asserts
+   `GET /users/eve` returns 404.
+
+Future additions: groups CRUD, organizations CRUD, RENAME (modrdn), HMAC
+auth variant.
+
+## Notes
+
+- The plugin's `<connection>` reference (`dst-ldap-rest-stub`) points to
+  ldap-target only to satisfy LSC schema validation. The plugin ignores this
+  binding at runtime and uses `<baseUrl>` + Bearer token instead.
+- `DM_AUTHZ_PER_BRANCH_CONFIG` is wide-open in this test env. Production
+  setups should scope writes to the LSC sync subtree.

--- a/lsc-plugin/test/integration/docker-compose.yml
+++ b/lsc-plugin/test/integration/docker-compose.yml
@@ -62,8 +62,9 @@ services:
       DM_MAIL_DOMAIN: 'target.example.com'
       DM_PORT: '8081'
       DM_LOG_LEVEL: 'info'
-      DM_PLUGINS: 'core/static,core/helloworld,auth/token,ldap/users,ldap/groups,ldap/organizations'
+      DM_PLUGINS: 'core/static,core/auth/token,core/ldap/flatGeneric,core/ldap/groups,core/ldap/organization'
       DM_API_PREFIX: '/api'
+      DM_LDAP_FLAT_SCHEMA: '/app/node_modules/ldap-rest/static/schemas/standard/users.json'
       DM_AUTH_TOKENS: 'lsc-it-token-please-change-me-32chars:lsc-tester'
       DM_AUTHZ_PER_BRANCH_CONFIG: '{"default":{"read":true,"write":true,"delete":true}}'
     ports:

--- a/lsc-plugin/test/integration/docker-compose.yml
+++ b/lsc-plugin/test/integration/docker-compose.yml
@@ -1,0 +1,100 @@
+version: '3.8'
+
+# End-to-end integration test stack for the lsc-ldaprest-plugin.
+# Spins up:
+#   - ldap-source : OpenLDAP populated from ldif/source-seed.ldif (LSC reads from this)
+#   - ldap-target : empty OpenLDAP, written to by ldap-rest
+#   - ldap-rest   : ldap-rest service backed by ldap-target, Bearer token auth
+#   - lsc         : LSC + the plugin jar, runs the sync task on demand
+
+services:
+  ldap-source:
+    image: osixia/openldap:1.5.0
+    container_name: lsc-it-ldap-source
+    environment:
+      LDAP_ORGANISATION: 'Source Org'
+      LDAP_DOMAIN: 'source.example.com'
+      LDAP_ADMIN_PASSWORD: 'admin'
+      LDAP_TLS: 'false'
+    volumes:
+      - ./ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom:ro
+    healthcheck:
+      test: ['CMD', 'ldapsearch', '-x', '-H', 'ldap://localhost', '-b', 'dc=source,dc=example,dc=com', '-D', 'cn=admin,dc=source,dc=example,dc=com', '-w', 'admin']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    networks:
+      - lsc-it
+
+  ldap-target:
+    image: osixia/openldap:1.5.0
+    container_name: lsc-it-ldap-target
+    environment:
+      LDAP_ORGANISATION: 'Target Org'
+      LDAP_DOMAIN: 'target.example.com'
+      LDAP_ADMIN_PASSWORD: 'admin'
+      LDAP_TLS: 'false'
+    healthcheck:
+      test: ['CMD', 'ldapsearch', '-x', '-H', 'ldap://localhost', '-b', 'dc=target,dc=example,dc=com', '-D', 'cn=admin,dc=target,dc=example,dc=com', '-w', 'admin']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    networks:
+      - lsc-it
+
+  ldap-rest:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile
+    container_name: lsc-it-ldap-rest
+    depends_on:
+      ldap-target:
+        condition: service_healthy
+    environment:
+      DM_LDAP_URL: 'ldap://ldap-target:389'
+      DM_LDAP_BASE: 'dc=target,dc=example,dc=com'
+      DM_LDAP_DN: 'cn=admin,dc=target,dc=example,dc=com'
+      DM_LDAP_PWD: 'admin'
+      DM_LDAP_USER_ATTRIBUTE: 'uid'
+      DM_LDAP_USERS_BASE: 'ou=users,dc=target,dc=example,dc=com'
+      DM_LDAP_GROUP_BASE: 'ou=groups,dc=target,dc=example,dc=com'
+      DM_LDAP_TOP_ORGANIZATION: 'dc=target,dc=example,dc=com'
+      DM_MAIL_DOMAIN: 'target.example.com'
+      DM_PORT: '8081'
+      DM_LOG_LEVEL: 'info'
+      DM_PLUGINS: 'core/static,core/helloworld,auth/token,ldap/users,ldap/groups,ldap/organizations'
+      DM_API_PREFIX: '/api'
+      DM_AUTH_TOKENS: 'lsc-it-token-please-change-me-32chars:lsc-tester'
+      DM_AUTHZ_PER_BRANCH_CONFIG: '{"default":{"read":true,"write":true,"delete":true}}'
+    ports:
+      - '18081:8081'
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:8081/api/health']
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    networks:
+      - lsc-it
+
+  lsc:
+    build:
+      context: .
+      dockerfile: Dockerfile.lsc
+    container_name: lsc-it-runner
+    depends_on:
+      ldap-source:
+        condition: service_healthy
+      ldap-rest:
+        condition: service_healthy
+    volumes:
+      - ./lsc:/etc/lsc:ro
+      - ./logs:/var/log/lsc
+    environment:
+      LDAP_REST_TOKEN: 'lsc-it-token-please-change-me-32chars'
+    networks:
+      - lsc-it
+    command: ['tail', '-f', '/dev/null']
+
+networks:
+  lsc-it:
+    driver: bridge

--- a/lsc-plugin/test/integration/ldif/source-seed.ldif
+++ b/lsc-plugin/test/integration/ldif/source-seed.ldif
@@ -1,0 +1,69 @@
+dn: ou=users,dc=source,dc=example,dc=com
+objectClass: organizationalUnit
+ou: users
+
+dn: ou=groups,dc=source,dc=example,dc=com
+objectClass: organizationalUnit
+ou: groups
+
+dn: uid=alice,ou=users,dc=source,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+uid: alice
+cn: Alice Smith
+sn: Smith
+givenName: Alice
+mail: alice@source.example.com
+
+dn: uid=bob,ou=users,dc=source,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+uid: bob
+cn: Bob Jones
+sn: Jones
+givenName: Bob
+mail: bob@source.example.com
+
+dn: uid=carol,ou=users,dc=source,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+uid: carol
+cn: Carol White
+sn: White
+givenName: Carol
+mail: carol@source.example.com
+
+dn: uid=dave,ou=users,dc=source,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+uid: dave
+cn: Dave Brown
+sn: Brown
+givenName: Dave
+mail: dave@source.example.com
+
+dn: uid=eve,ou=users,dc=source,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+uid: eve
+cn: Eve Black
+sn: Black
+givenName: Eve
+mail: eve@source.example.com
+
+dn: cn=admins,ou=groups,dc=source,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: admins
+description: Server administrators
+member: uid=alice,ou=users,dc=source,dc=example,dc=com
+member: uid=bob,ou=users,dc=source,dc=example,dc=com
+
+dn: cn=users,ou=groups,dc=source,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: users
+description: Regular users
+member: uid=carol,ou=users,dc=source,dc=example,dc=com
+member: uid=dave,ou=users,dc=source,dc=example,dc=com
+member: uid=eve,ou=users,dc=source,dc=example,dc=com

--- a/lsc-plugin/test/integration/lsc/logback.xml
+++ b/lsc-plugin/test/integration/lsc/logback.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="org.lscproject.ldaprest" level="DEBUG"/>
+    <logger name="org.lsc" level="INFO"/>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/lsc-plugin/test/integration/lsc/lsc.xml
+++ b/lsc-plugin/test/integration/lsc/lsc.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LSC integration test config: sync users from ldap-source to ldap-rest.
+  The destination is our pluginDestinationService — it ignores the bound
+  LDAP connection at runtime and uses baseUrl + token instead. We still
+  declare a real LDAP connection because LSC validates the schema.
+-->
+<lsc xmlns="http://lsc-project.org/XSD/lsc-core-2.1.xsd">
+
+    <connections>
+        <ldapConnection>
+            <name>src-ldap</name>
+            <url>ldap://ldap-source:389/dc=source,dc=example,dc=com</url>
+            <username>cn=admin,dc=source,dc=example,dc=com</username>
+            <password>admin</password>
+            <authentication>SIMPLE</authentication>
+            <referral>IGNORE</referral>
+            <derefAliases>NEVER</derefAliases>
+            <version>VERSION_3</version>
+            <pageSize>-1</pageSize>
+            <factory>com.sun.jndi.ldap.LdapCtxFactory</factory>
+            <tlsActivated>false</tlsActivated>
+        </ldapConnection>
+
+        <ldapConnection>
+            <name>dst-ldap-rest-stub</name>
+            <url>ldap://ldap-target:389/dc=target,dc=example,dc=com</url>
+            <username>cn=admin,dc=target,dc=example,dc=com</username>
+            <password>admin</password>
+            <authentication>SIMPLE</authentication>
+            <referral>IGNORE</referral>
+            <derefAliases>NEVER</derefAliases>
+            <version>VERSION_3</version>
+            <pageSize>-1</pageSize>
+            <factory>com.sun.jndi.ldap.LdapCtxFactory</factory>
+            <tlsActivated>false</tlsActivated>
+        </ldapConnection>
+    </connections>
+
+    <tasks>
+        <task>
+            <name>users-task</name>
+            <bean>org.lsc.beans.SimpleBean</bean>
+
+            <ldapSourceService>
+                <name>src-users</name>
+                <connection reference="src-ldap"/>
+                <baseDn>ou=users,dc=source,dc=example,dc=com</baseDn>
+                <pivotAttributes>
+                    <string>uid</string>
+                </pivotAttributes>
+                <fetchedAttributes>
+                    <string>uid</string>
+                    <string>cn</string>
+                    <string>sn</string>
+                    <string>givenName</string>
+                    <string>mail</string>
+                </fetchedAttributes>
+                <getAllFilter><![CDATA[(objectClass=inetOrgPerson)]]></getAllFilter>
+                <getOneFilter><![CDATA[(&(objectClass=inetOrgPerson)(uid={uid}))]]></getOneFilter>
+                <cleanFilter><![CDATA[(&(objectClass=inetOrgPerson)(uid={uid}))]]></cleanFilter>
+            </ldapSourceService>
+
+            <pluginDestinationService implementationClass="org.lscproject.ldaprest.LdapRestDstService">
+                <name>dst-ldap-rest</name>
+                <connection reference="dst-ldap-rest-stub"/>
+                <baseUrl>http://ldap-rest:8081</baseUrl>
+                <apiPrefix>/api</apiPrefix>
+                <resourceType>users</resourceType>
+                <auth>
+                    <bearer>${LDAP_REST_TOKEN}</bearer>
+                </auth>
+                <timeoutMs>10000</timeoutMs>
+                <retries>3</retries>
+            </pluginDestinationService>
+
+            <propertiesBasedSyncOptions>
+                <mainIdentifier>"uid=" + srcBean.getDatasetFirstValueById("uid") + ",ou=users,dc=target,dc=example,dc=com"</mainIdentifier>
+                <defaultDelimiter>;</defaultDelimiter>
+                <defaultPolicy>FORCE</defaultPolicy>
+                <conditions>
+                    <create>true</create>
+                    <update>true</update>
+                    <delete>true</delete>
+                    <changeId>true</changeId>
+                </conditions>
+                <dataset>
+                    <name>uid</name>
+                    <policy>FORCE</policy>
+                    <createValues>
+                        <string>srcBean.getDatasetFirstValueById("uid")</string>
+                    </createValues>
+                    <forceValues>
+                        <string>srcBean.getDatasetFirstValueById("uid")</string>
+                    </forceValues>
+                </dataset>
+                <dataset>
+                    <name>cn</name>
+                    <policy>FORCE</policy>
+                    <forceValues>
+                        <string>srcBean.getDatasetFirstValueById("cn")</string>
+                    </forceValues>
+                </dataset>
+                <dataset>
+                    <name>sn</name>
+                    <policy>FORCE</policy>
+                    <forceValues>
+                        <string>srcBean.getDatasetFirstValueById("sn")</string>
+                    </forceValues>
+                </dataset>
+                <dataset>
+                    <name>givenName</name>
+                    <policy>FORCE</policy>
+                    <forceValues>
+                        <string>srcBean.getDatasetFirstValueById("givenName")</string>
+                    </forceValues>
+                </dataset>
+                <dataset>
+                    <name>mail</name>
+                    <policy>FORCE</policy>
+                    <forceValues>
+                        <string>srcBean.getDatasetFirstValueById("mail")</string>
+                    </forceValues>
+                </dataset>
+            </propertiesBasedSyncOptions>
+        </task>
+    </tasks>
+
+</lsc>

--- a/lsc-plugin/test/integration/tests/assertions.sh
+++ b/lsc-plugin/test/integration/tests/assertions.sh
@@ -1,0 +1,55 @@
+# Shared assertions sourced by run.sh. Increments $PASS / $FAIL via pass/fail.
+
+assert_users_created() {
+    log "  asserting 5 users exist in ldap-rest"
+    code=$(rest_get "/api/v1/ldap/users")
+    if [ "$code" = "200" ]; then
+        n=$(jq '. | length' /tmp/rest-body 2>/dev/null || echo 0)
+        if [ "$n" = "5" ]; then
+            pass "ldap-rest GET /users returns 5 entries"
+        else
+            fail "expected 5 users in ldap-rest, got $n"
+        fi
+    else
+        fail "ldap-rest GET /users returned $code"
+    fi
+
+    log "  asserting alice exists with correct attrs in ldap-rest"
+    code=$(rest_get "/api/v1/ldap/users/alice")
+    if [ "$code" = "200" ] && jq -e '.uid == "alice" and .mail == "alice@source.example.com"' /tmp/rest-body >/dev/null; then
+        pass "alice present with expected mail"
+    else
+        fail "alice not found or mail mismatch (code=$code)"
+    fi
+
+    log "  asserting alice is reachable via direct ldapsearch on target"
+    if $COMPOSE exec -T ldap-target ldapsearch -x -LLL -H ldap://localhost \
+        -D 'cn=admin,dc=target,dc=example,dc=com' -w admin \
+        -b 'ou=users,dc=target,dc=example,dc=com' \
+        '(uid=alice)' uid mail 2>/dev/null | grep -q '^uid: alice$'; then
+        pass "alice reachable via ldapsearch on target (proves ldap-rest wrote LDAP, not just acked)"
+    else
+        fail "alice not found via direct ldapsearch — ldap-rest may have acked without writing"
+    fi
+}
+
+assert_alice_mail_updated() {
+    log "  asserting alice's mail was updated"
+    code=$(rest_get "/api/v1/ldap/users/alice")
+    if [ "$code" = "200" ] && jq -e '.mail == "alice.updated@source.example.com"' /tmp/rest-body >/dev/null; then
+        pass "alice mail updated to alice.updated@source.example.com"
+    else
+        actual=$(jq -r '.mail // "<missing>"' /tmp/rest-body 2>/dev/null || echo "<error>")
+        fail "alice mail not updated (got: $actual)"
+    fi
+}
+
+assert_eve_deleted() {
+    log "  asserting eve was deleted"
+    code=$(rest_get "/api/v1/ldap/users/eve")
+    if [ "$code" = "404" ]; then
+        pass "eve deleted (ldap-rest returns 404)"
+    else
+        fail "eve not deleted (ldap-rest returned $code)"
+    fi
+}

--- a/lsc-plugin/test/integration/tests/run.sh
+++ b/lsc-plugin/test/integration/tests/run.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Integration test orchestrator for the lsc-ldaprest-plugin.
+# Spins the docker-compose stack, runs LSC, asserts the expected state via
+# both the ldap-rest API and direct ldapsearch on the target, then tears
+# everything down (even on failure).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+COMPOSE="docker compose -f $ROOT/docker-compose.yml"
+TOKEN="lsc-it-token-please-change-me-32chars"
+REST_HOST="http://localhost:18081"
+
+PASS=0
+FAIL=0
+
+log()  { echo "[run.sh] $*" >&2; }
+pass() { echo "  PASS: $*"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $*"; FAIL=$((FAIL+1)); }
+
+cleanup() {
+    log "dumping container logs to $ROOT/logs/"
+    mkdir -p "$ROOT/logs"
+    for svc in ldap-source ldap-target ldap-rest lsc; do
+        $COMPOSE logs --no-color "$svc" > "$ROOT/logs/$svc.log" 2>&1 || true
+    done
+    log "tearing down stack"
+    $COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+log "building images and starting backing services"
+$COMPOSE up -d --build ldap-source ldap-target ldap-rest
+
+log "waiting for healthchecks"
+for i in $(seq 1 60); do
+    if $COMPOSE ps --format json 2>/dev/null | grep -q '"Health":"healthy"'; then
+        if [ "$($COMPOSE ps --status running --format '{{.Service}}' | sort -u | wc -l)" -ge 3 ]; then
+            break
+        fi
+    fi
+    sleep 2
+done
+
+log "starting lsc container"
+$COMPOSE up -d --build lsc
+
+# Helper: GET via ldap-rest with bearer auth
+rest_get() {
+    curl -s -o /tmp/rest-body -w '%{http_code}' \
+        -H "Authorization: Bearer $TOKEN" \
+        "$REST_HOST$1"
+}
+
+source "$HERE/assertions.sh"
+
+log "scenario 1: initial CREATE"
+$COMPOSE exec -T -e LDAP_REST_TOKEN=$TOKEN lsc lsc -f /etc/lsc -s users-task -t users-task >/tmp/lsc-1.log 2>&1 \
+    || { cat /tmp/lsc-1.log; fail "lsc run 1 failed"; }
+assert_users_created
+
+log "scenario 2: UPDATE — modify alice's mail in source, re-sync"
+$COMPOSE exec -T ldap-source bash -c "ldapmodify -x -D 'cn=admin,dc=source,dc=example,dc=com' -w admin <<EOF
+dn: uid=alice,ou=users,dc=source,dc=example,dc=com
+changetype: modify
+replace: mail
+mail: alice.updated@source.example.com
+EOF" >/dev/null
+$COMPOSE exec -T -e LDAP_REST_TOKEN=$TOKEN lsc lsc -f /etc/lsc -s users-task -t users-task >/tmp/lsc-2.log 2>&1 \
+    || { cat /tmp/lsc-2.log; fail "lsc run 2 failed"; }
+assert_alice_mail_updated
+
+log "scenario 3: DELETE — remove eve from source, re-sync"
+$COMPOSE exec -T ldap-source ldapdelete -x -D 'cn=admin,dc=source,dc=example,dc=com' -w admin \
+    'uid=eve,ou=users,dc=source,dc=example,dc=com' >/dev/null
+$COMPOSE exec -T -e LDAP_REST_TOKEN=$TOKEN lsc lsc -f /etc/lsc -s users-task -t users-task >/tmp/lsc-3.log 2>&1 \
+    || { cat /tmp/lsc-3.log; fail "lsc run 3 failed"; }
+assert_eve_deleted
+
+echo ""
+echo "================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "================================="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/lsc-plugin/test/integration/tests/run.sh
+++ b/lsc-plugin/test/integration/tests/run.sh
@@ -32,14 +32,24 @@ trap cleanup EXIT
 log "building images and starting backing services"
 $COMPOSE up -d --build ldap-source ldap-target ldap-rest
 
-log "waiting for healthchecks"
-for i in $(seq 1 60); do
-    if $COMPOSE ps --format json 2>/dev/null | grep -q '"Health":"healthy"'; then
-        if [ "$($COMPOSE ps --status running --format '{{.Service}}' | sort -u | wc -l)" -ge 3 ]; then
-            break
+log "waiting for healthchecks (each service must report 'healthy', not just 'running')"
+deadline=$(( $(date +%s) + 180 ))
+for svc in ldap-source ldap-target ldap-rest; do
+    while :; do
+        cid=$($COMPOSE ps -q "$svc" 2>/dev/null)
+        if [ -n "$cid" ]; then
+            health=$(docker inspect -f '{{.State.Health.Status}}' "$cid" 2>/dev/null || echo unknown)
+            if [ "$health" = "healthy" ]; then
+                log "  $svc: healthy"
+                break
+            fi
         fi
-    fi
-    sleep 2
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+            fail "$svc never reached healthy state (last status: $health)"
+            exit 1
+        fi
+        sleep 2
+    done
 done
 
 log "starting lsc container"

--- a/test/plugins/auth/hmac.test.ts
+++ b/test/plugins/auth/hmac.test.ts
@@ -536,4 +536,49 @@ describe('AuthHmac', () => {
       expect(res.status).to.equal(401);
     });
   });
+
+  /**
+   * Cross-implementation contract test.
+   *
+   * The lsc-plugin/ Java client computes HMAC signatures the same way the
+   * server here does. Both sides hard-code this same vector — if either side
+   * changes the signing string format, the body hashing rule, or the
+   * timestamp encoding, this test fails AND the matching Java test
+   * (LdapRestAuthTest#hmacReproducibleSignature / hmacCrossImplVector) fails
+   * on the other side. Keep them in sync.
+   *
+   * Vector:
+   *   secret    = "test-secret-min-32-chars-long-xxx"
+   *   method    = "POST"
+   *   path      = "/api/v1/ldap/users"
+   *   timestamp = 1700000000000
+   *   body      = '{"uid":"alice"}'
+   *   expected  = "65b065ff10ab2a54de0ab4db485c5744fcdd32a98e2fd24a8cef5240b43bbc94"
+   */
+  describe('Cross-impl vector (lsc-plugin compatibility)', () => {
+    const secret = 'test-secret-min-32-chars-long-xxx';
+    const method = 'POST';
+    const path = '/api/v1/ldap/users';
+    const timestamp = 1700000000000;
+    const body = '{"uid":"alice"}';
+    const expectedSignature =
+      '65b065ff10ab2a54de0ab4db485c5744fcdd32a98e2fd24a8cef5240b43bbc94';
+
+    it('Node helper must produce the same signature as the Java plugin', () => {
+      const sig = generateHmacSignature(secret, method, path, timestamp, body);
+      expect(sig).to.equal(expectedSignature);
+    });
+
+    it('intermediate values match the documented format', () => {
+      const bodyHash = createHash('sha256').update(body).digest('hex');
+      expect(bodyHash).to.equal(
+        'c9bfac238b197ff8c303f8186d216e1422495890f852043cbac3810d1d867822'
+      );
+      const signingString = `${method}|${path}|${timestamp}|${bodyHash}`;
+      const sig = createHmac('sha256', secret)
+        .update(signingString)
+        .digest('hex');
+      expect(sig).to.equal(expectedSignature);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds an LSC (Ldap Synchronization Connector) destination plugin under `lsc-plugin/` so that LSC sync tasks write through ldap-rest's HTTP API instead of binding LDAP directly. Sync writes then benefit from ldap-rest's ACL, schema validation, audit, and the downstream provisioning hooks (Twake James, Cozy, SCIM, RabbitMQ).

The plugin is **external to LSC**: it implements `org.lsc.service.IWritableService` and is declared as a `pluginDestinationService` in `lsc.xml`, no patch of the LSC core is required to use it. A separate upstream PR will follow on a fork of `lsc-project/lsc` to add a native `LdapRestDstService` to the core.

## What's in this PR

- **`lsc-plugin/`** — Java 11 / Maven project, packaged as a shaded jar (Jackson relocated) to drop into `/usr/lib/lsc/`.
  - `LdapRestDstService` routes the 4 LSC ops on the right endpoints for flat resources, groups (with member add/remove), and organizations.
  - `LdapRestClient` wraps `java.net.http.HttpClient` with retry/backoff.
  - `LdapRestAuth` supports Bearer tokens and HMAC-SHA256 signing using the exact format of `src/plugins/auth/hmac.ts` (`METHOD|PATH|ts|sha256(body)`).
  - `ModificationTranslator` converts `LscModifications` to ldap-rest JSON (`{add, replace, delete}`), with clear errors on binary attributes (out of scope for v1).
- **76 unit tests** with WireMock, all green (`mvn test`).
- **Docker integration harness** in `lsc-plugin/test/integration/`: docker-compose with ldap-source + ldap-target + ldap-rest + LSC, plus `tests/run.sh` asserting CREATE / UPDATE / DELETE end-to-end (both via the ldap-rest API and via direct `ldapsearch` on the target — proving ldap-rest actually wrote to LDAP, not just acked).
- **Cross-implementation HMAC vector** — the same expected signature is hard-coded on both sides (Node `test/plugins/auth/hmac.test.ts` and Java `LdapRestAuthTest`). A drift on either side now fails both suites.

## Why split between this repo and an upstream PR

The plugin lives here because its contract is tightly coupled to ldap-rest's JSON shape and HMAC format, so versioning together avoids drift. The upstream PR will add a native service for the long term; in the meantime this plugin is operationally usable today.

## Test plan

- [x] `mvn -B test` (in `lsc-plugin/`) — 76/76 pass
- [x] `npm run test:one -- test/plugins/auth/hmac.test.ts` — 28/28 pass (incl. the new cross-impl block)
- [ ] `lsc-plugin/test/integration/tests/run.sh` — full Docker stack, CREATE/UPDATE/DELETE scenarios
- [ ] Manual sanity check on a real LSC deployment with both Bearer and HMAC auth

## Out of scope (followups)

- Binary attributes (jpegPhoto, userCertificate) — needs a JSON convention agreed on the ldap-rest side first
- Bulk endpoint for large initial syncs — the plugin currently does N HTTP calls
- Upstream PR on `lsc-project/lsc` adding a native `LdapRestDstService` to the core