### PR TITLE
feat: extract shared rabbitmq plugin from cozyProvision

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,10 @@
       "types": "./dist/src/plugins/ldap/trash.d.ts",
       "import": "./dist/plugins/ldap/trash.js"
     },
+    "./plugin-rabbitmq": {
+      "types": "./dist/src/plugins/rabbitmq.d.ts",
+      "import": "./dist/plugins/rabbitmq.js"
+    },
     "./plugin-scim-baseresolver": {
       "types": "./dist/src/plugins/scim/baseResolver.d.ts",
       "import": "./dist/plugins/scim/baseResolver.js"

--- a/src/abstract/plugin.ts
+++ b/src/abstract/plugin.ts
@@ -99,4 +99,27 @@ export default abstract class DmPlugin {
   opNumber(): number {
     return this.server.operationSequence++;
   }
+
+  /** Names already warned about by requirePlugin, so each warns at most once. */
+  private missingPluginsWarned?: Set<string>;
+
+  /**
+   * Resolve a sibling plugin by its registry name (the value of its `name`
+   * property). Declare it in `dependencies` so it loads first. Returns null and
+   * logs a single warning if it is absent, letting the caller no-op cleanly
+   * rather than throw. Use this instead of indexing `server.loadedPlugins`
+   * directly so consumers share one typed, log-once lookup.
+   */
+  protected requirePlugin<T extends DmPlugin>(name: string): T | null {
+    const plugin = this.server.loadedPlugins[name] as T | undefined;
+    if (plugin) return plugin;
+    if (!this.missingPluginsWarned) this.missingPluginsWarned = new Set();
+    if (!this.missingPluginsWarned.has(name)) {
+      this.missingPluginsWarned.add(name);
+      this.logger.warn(
+        `${this.name}: required plugin '${name}' is not loaded — its features will be skipped`
+      );
+    }
+    return null;
+  }
 }

--- a/src/plugins/rabbitmq.ts
+++ b/src/plugins/rabbitmq.ts
@@ -1,0 +1,260 @@
+/**
+ * @module plugins/rabbitmq
+ *
+ * Shared RabbitMQ transport. Owns a single broker connection for the whole
+ * process and exposes publish/consume so other plugins do not each bundle
+ * (and re-open) their own AMQP client.
+ *
+ * The connection is lazy: it opens on the first publish/subscribe call, not at
+ * load time, so a broker that is down or unconfigured never blocks startup.
+ * `@linagora/rabbitmq-client` is an optional dependency; if the package is not
+ * installed or `rabbitmq_url` is empty, every method is a logged no-op.
+ *
+ * Consumers declare it as a dependency and reach it through the loaded-plugin
+ * registry:
+ *
+ *   dependencies = { rabbitmq: 'core/rabbitmq' };
+ *   const rmq = this.server.loadedPlugins['rabbitmq'] as RabbitMq;
+ *   await rmq.publish('auth', 'user.created', message);
+ */
+import DmPlugin from '../abstract/plugin';
+import type { DM } from '../bin';
+
+/** JSON-serialisable message payload. */
+export type RabbitMessage = Record<string, unknown>;
+
+/** Async handler invoked for each consumed message. */
+export type RabbitMessageHandler = (message: RabbitMessage) => Promise<void>;
+
+/** Options forwarded to the underlying client's `publish()`. */
+export interface PublishOptions {
+  maxAttempts?: number;
+  headers?: Record<string, unknown>;
+  correlationId?: string;
+  messageId?: string;
+  expiration?: string;
+}
+
+/** Options forwarded to the underlying client's `subscribe()`. */
+export interface SubscribeOptions {
+  queueArguments?: Record<string, unknown>;
+}
+
+/**
+ * Subset of `@linagora/rabbitmq-client`'s `RabbitMQClient` that this plugin
+ * relies on. Declared locally because the package is an optional dependency
+ * and may be absent at type-check time.
+ */
+interface RabbitClient {
+  init(): Promise<void>;
+  publish(
+    exchange: string,
+    routingKey: string,
+    message: RabbitMessage,
+    options?: PublishOptions
+  ): Promise<void>;
+  subscribe(
+    exchange: string,
+    routingKey: string,
+    queue: string,
+    handler: RabbitMessageHandler,
+    options?: SubscribeOptions
+  ): Promise<void>;
+  unsubscribe(queue: string): Promise<void>;
+  close(clearSubscriptions?: boolean): Promise<void>;
+}
+
+export default class RabbitMq extends DmPlugin {
+  name = 'rabbitmq';
+
+  private readonly rabbitmqUrl: string;
+
+  private client: RabbitClient | null = null;
+  private clientInit: Promise<RabbitClient | null> | null = null;
+
+  constructor(server: DM) {
+    super(server);
+
+    this.rabbitmqUrl = (this.config.rabbitmq_url as string) || '';
+
+    if (!this.rabbitmqUrl) {
+      this.logger.warn(
+        `${this.name}: rabbitmq_url is empty — AMQP publishes/subscribes will be skipped`
+      );
+    }
+
+    this.registerShutdown();
+  }
+
+  /**
+   * Whether the plugin is configured with a broker URL. Lets consumers decide
+   * whether to bother building a message. A `true` value does not guarantee
+   * the broker is reachable — the connection is still lazy.
+   */
+  isAvailable(): boolean {
+    return this.rabbitmqUrl.length > 0;
+  }
+
+  /**
+   * Publish a JSON message to a topic exchange. No-op (returns silently) when
+   * no broker is configured or the client is unavailable.
+   */
+  async publish(
+    exchange: string,
+    routingKey: string,
+    message: RabbitMessage,
+    options?: PublishOptions
+  ): Promise<void> {
+    const client = await this.getClient();
+    if (!client) return;
+    await client.publish(exchange, routingKey, message, options);
+  }
+
+  /**
+   * Subscribe a handler to a topic exchange/routing-key on a named queue.
+   * No-op when no broker is configured or the client is unavailable.
+   */
+  async subscribe(
+    exchange: string,
+    routingKey: string,
+    queue: string,
+    handler: RabbitMessageHandler,
+    options?: SubscribeOptions
+  ): Promise<void> {
+    const client = await this.getClient();
+    if (!client) return;
+    await client.subscribe(exchange, routingKey, queue, handler, options);
+  }
+
+  /** Stop consuming from a queue. No-op when the client is unavailable. */
+  async unsubscribe(queue: string): Promise<void> {
+    const client = await this.getClient();
+    if (!client) return;
+    await client.unsubscribe(queue);
+  }
+
+  /**
+   * The live broker client, or null when unavailable. Advanced consumers that
+   * need features beyond publish/subscribe can reach the raw client here.
+   */
+  async getRawClient(): Promise<RabbitClient | null> {
+    return this.getClient();
+  }
+
+  /**
+   * Lazy-init the shared AMQP client. The `@linagora/rabbitmq-client`
+   * dependency is optional — if the package or the broker is unreachable,
+   * return null so callers can no-op cleanly.
+   *
+   * Override this in tests to inject a stub client.
+   */
+  protected async getClient(): Promise<RabbitClient | null> {
+    if (this.client) return this.client;
+    if (!this.rabbitmqUrl) return null;
+    if (this.clientInit) return this.clientInit;
+
+    this.clientInit = (async (): Promise<RabbitClient | null> => {
+      try {
+        const client = await this.connect();
+        this.client = client;
+        this.logger.info(
+          `${this.name}: connected to RabbitMQ at ${redactAmqpUrl(
+            this.rabbitmqUrl
+          )}`
+        );
+        return client;
+      } catch (err) {
+        this.logger.warn({
+          plugin: this.name,
+          event: 'rabbitmq_init',
+          message:
+            '@linagora/rabbitmq-client unavailable or broker unreachable — AMQP disabled',
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          error: `${err}`,
+        });
+        // Reset so a later call retries: a transient outage at the first
+        // publish must not disable the broker for the process lifetime. Once
+        // a connect succeeds, the client's own reconnection logic takes over.
+        this.clientInit = null;
+        return null;
+      }
+    })();
+
+    return this.clientInit;
+  }
+
+  /**
+   * Open and initialise the underlying client. Split out so the caching and
+   * retry policy in `getClient()` can be tested without a live broker.
+   */
+  protected async connect(): Promise<RabbitClient> {
+    const mod = await import('@linagora/rabbitmq-client');
+    const client = new mod.RabbitMQClient({
+      url: this.rabbitmqUrl,
+    }) as unknown as RabbitClient;
+    await client.init();
+    return client;
+  }
+
+  private registerShutdown(): void {
+    const shutdown = (): void => {
+      const client = this.client;
+      // Clear both: a closed client must not be returned by a still-pending
+      // initialisation promise.
+      this.client = null;
+      this.clientInit = null;
+      if (!client) return;
+      client.close().catch((err: unknown) => {
+        this.logger.warn({
+          plugin: this.name,
+          event: 'shutdown',
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          error: `${err}`,
+        });
+      });
+    };
+    registerProcessShutdown(shutdown);
+  }
+}
+
+/**
+ * Strip credentials from an AMQP URL before logging — `amqp://user:pass@host`
+ * becomes `amqp://host`. Falls back to `amqp://[broker]` if the URL cannot
+ * be parsed (e.g. malformed config).
+ */
+function redactAmqpUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    u.username = '';
+    u.password = '';
+    return u.toString();
+  } catch {
+    return 'amqp://[broker]';
+  }
+}
+
+/**
+ * Registers a single SIGTERM/SIGINT handler at the process level. Each plugin
+ * instance contributes one callback that fans out from the shared handler, so
+ * we don't accumulate per-instance listeners (which would trip
+ * MaxListenersExceededWarning when many DM instances are created in tests).
+ */
+const shutdownCallbacks: Array<() => void> = [];
+let processShutdownInstalled = false;
+
+function registerProcessShutdown(cb: () => void): void {
+  shutdownCallbacks.push(cb);
+  if (processShutdownInstalled) return;
+  processShutdownInstalled = true;
+  const fanOut = (): void => {
+    for (const fn of shutdownCallbacks.splice(0)) {
+      try {
+        fn();
+      } catch {
+        // Hooks must never throw during shutdown.
+      }
+    }
+  };
+  process.once('SIGTERM', fanOut);
+  process.once('SIGINT', fanOut);
+}

--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -12,9 +12,10 @@
  *   - scimuserdeletedone: publish `b2b` / `domain.user.deleted` so peer
  *     instances can clean up the deleted user's contact card.
  *
- * The RabbitMQ client (`@linagora/rabbitmq-client`) is declared as an
- * optional dependency: if it is not installed at runtime, AMQP publishes
- * are silently skipped and a one-time warning is logged.
+ * AMQP transport is provided by the shared `rabbitmq` plugin (declared as a
+ * dependency). This plugin builds the lifecycle messages and hands them to
+ * that plugin to publish; the broker connection, optional-dependency import,
+ * and "broker absent ⇒ skip" handling all live there.
  */
 import { Buffer } from 'buffer';
 
@@ -23,21 +24,14 @@ import fetch from 'node-fetch';
 import DmPlugin, { type Role } from '../../abstract/plugin';
 import type { DM } from '../../bin';
 import { Hooks } from '../../hooks';
+import type RabbitMq from '../rabbitmq';
 import type { ScimUser } from '../scim/types';
-
-interface RabbitPublisher {
-  init(): Promise<void>;
-  publish(
-    exchange: string,
-    routingKey: string,
-    message: Record<string, unknown>
-  ): Promise<void>;
-  close(clearSubscriptions?: boolean): Promise<void>;
-}
 
 export default class CozyProvision extends DmPlugin {
   name = 'cozyProvision';
   roles: Role[] = ['consistency'] as const;
+
+  dependencies = { rabbitmq: 'core/rabbitmq' };
 
   private readonly cozyAdminUrl: string;
   private readonly cozyAdminPassphrase: string;
@@ -47,13 +41,9 @@ export default class CozyProvision extends DmPlugin {
   private readonly cozyDefaultLocale: string;
   private readonly cozyContextName: string;
   private readonly cozyApps: string;
-  private readonly rabbitmqUrl: string;
   private readonly authExchange: string;
   private readonly b2bExchange: string;
   private readonly cozyAdminAuthHeader: string;
-
-  private publisher: RabbitPublisher | null = null;
-  private publisherInit: Promise<RabbitPublisher | null> | null = null;
 
   constructor(server: DM) {
     super(server);
@@ -72,7 +62,6 @@ export default class CozyProvision extends DmPlugin {
     this.cozyContextName =
       (this.config.cozy_context_name as string) || 'default';
     this.cozyApps = (this.config.cozy_apps as string) ?? '';
-    this.rabbitmqUrl = (this.config.rabbitmq_url as string) || '';
     this.authExchange = (this.config.cozy_auth_exchange as string) || 'auth';
     this.b2bExchange = (this.config.cozy_b2b_exchange as string) || 'b2b';
     this.cozyAdminAuthHeader = `Basic ${Buffer.from(
@@ -89,13 +78,6 @@ export default class CozyProvision extends DmPlugin {
         `${this.name}: cozy_org_domain is empty — workplaceFqdn cannot be composed`
       );
     }
-    if (!this.rabbitmqUrl) {
-      this.logger.warn(
-        `${this.name}: rabbitmq_url is empty — AMQP publishes will be skipped`
-      );
-    }
-
-    this.registerShutdown();
   }
 
   hooks: Hooks = {
@@ -333,8 +315,8 @@ export default class CozyProvision extends DmPlugin {
    * causes cozy-stack to nack the message.
    */
   private async publishUserCreated(user: ScimUser): Promise<void> {
-    const publisher = await this.getPublisher();
-    if (!publisher) return;
+    const rabbitmq = this.rabbitmq();
+    if (!rabbitmq) return;
 
     const id = this.extractId(user);
     if (!id) return;
@@ -351,7 +333,7 @@ export default class CozyProvision extends DmPlugin {
     if (mobile) message.mobile = mobile;
 
     try {
-      await publisher.publish(this.authExchange, 'user.created', message);
+      await rabbitmq.publish(this.authExchange, 'user.created', message);
       this.logger.info({
         plugin: this.name,
         event: 'publishUserCreated',
@@ -376,8 +358,8 @@ export default class CozyProvision extends DmPlugin {
    * instances can drop the deleted user's contact card.
    */
   private async publishUserDeleted(id: string): Promise<void> {
-    const publisher = await this.getPublisher();
-    if (!publisher) return;
+    const rabbitmq = this.rabbitmq();
+    if (!rabbitmq) return;
     if (!this.cozyOrgDomain) {
       this.logger.error({
         plugin: this.name,
@@ -395,7 +377,7 @@ export default class CozyProvision extends DmPlugin {
     };
 
     try {
-      await publisher.publish(this.b2bExchange, 'domain.user.deleted', message);
+      await rabbitmq.publish(this.b2bExchange, 'domain.user.deleted', message);
       this.logger.info({
         plugin: this.name,
         event: 'publishUserDeleted',
@@ -416,45 +398,12 @@ export default class CozyProvision extends DmPlugin {
   }
 
   /**
-   * Lazy-init the AMQP publisher. The `@linagora/rabbitmq-client` dependency
-   * is optional — if the package or the broker is unreachable, return null
-   * so callers can no-op cleanly.
-   *
-   * Override this in tests to inject a stub publisher.
+   * Resolve the shared `rabbitmq` plugin (declared as a dependency, so it loads
+   * first). Returns null and warns once if it is absent, letting the publish
+   * paths no-op cleanly.
    */
-  protected async getPublisher(): Promise<RabbitPublisher | null> {
-    if (this.publisher) return this.publisher;
-    if (!this.rabbitmqUrl) return null;
-    if (this.publisherInit) return this.publisherInit;
-
-    this.publisherInit = (async (): Promise<RabbitPublisher | null> => {
-      try {
-        const mod = await import('@linagora/rabbitmq-client');
-        const client = new mod.RabbitMQClient({
-          url: this.rabbitmqUrl,
-        }) as unknown as RabbitPublisher;
-        await client.init();
-        this.publisher = client;
-        this.logger.info(
-          `${this.name}: connected to RabbitMQ at ${redactAmqpUrl(
-            this.rabbitmqUrl
-          )}`
-        );
-        return client;
-      } catch (err) {
-        this.logger.warn({
-          plugin: this.name,
-          event: 'rabbitmq_init',
-          message:
-            '@linagora/rabbitmq-client unavailable or broker unreachable — AMQP publishes disabled',
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          error: `${err}`,
-        });
-        return null;
-      }
-    })();
-
-    return this.publisherInit;
+  private rabbitmq(): RabbitMq | null {
+    return this.requirePlugin<RabbitMq>('rabbitmq');
   }
 
   private extractId(user: ScimUser): string | null {
@@ -522,66 +471,4 @@ export default class CozyProvision extends DmPlugin {
     }
     return this.cozyDefaultLocale;
   }
-
-  private registerShutdown(): void {
-    const shutdown = (): void => {
-      const pub = this.publisher;
-      // Clear both: a closed client must not be returned by a still-pending
-      // initialisation promise.
-      this.publisher = null;
-      this.publisherInit = null;
-      if (!pub) return;
-      pub.close().catch((err: unknown) => {
-        this.logger.warn({
-          plugin: this.name,
-          event: 'shutdown',
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          error: `${err}`,
-        });
-      });
-    };
-    registerProcessShutdown(shutdown);
-  }
-}
-
-/**
- * Strip credentials from an AMQP URL before logging — `amqp://user:pass@host`
- * becomes `amqp://host`. Falls back to `amqp://[broker]` if the URL cannot
- * be parsed (e.g. malformed config).
- */
-function redactAmqpUrl(url: string): string {
-  try {
-    const u = new URL(url);
-    u.username = '';
-    u.password = '';
-    return u.toString();
-  } catch {
-    return 'amqp://[broker]';
-  }
-}
-
-/**
- * Registers a single SIGTERM/SIGINT handler at the process level. Each plugin
- * instance contributes one callback that fans out from the shared handler, so
- * we don't accumulate per-instance listeners (which would trip
- * MaxListenersExceededWarning when many DM instances are created in tests).
- */
-const shutdownCallbacks: Array<() => void> = [];
-let processShutdownInstalled = false;
-
-function registerProcessShutdown(cb: () => void): void {
-  shutdownCallbacks.push(cb);
-  if (processShutdownInstalled) return;
-  processShutdownInstalled = true;
-  const fanOut = (): void => {
-    for (const fn of shutdownCallbacks.splice(0)) {
-      try {
-        fn();
-      } catch {
-        // Hooks must never throw during shutdown.
-      }
-    }
-  };
-  process.once('SIGTERM', fanOut);
-  process.once('SIGINT', fanOut);
 }

--- a/test/plugins/rabbitmq.test.ts
+++ b/test/plugins/rabbitmq.test.ts
@@ -1,0 +1,176 @@
+import { expect } from 'chai';
+
+import { DM } from '../../src/bin';
+import RabbitMq from '../../src/plugins/rabbitmq';
+
+interface PublishCall {
+  exchange: string;
+  routingKey: string;
+  message: Record<string, unknown>;
+  options?: Record<string, unknown>;
+}
+
+interface SubscribeCall {
+  exchange: string;
+  routingKey: string;
+  queue: string;
+  handler: (m: Record<string, unknown>) => Promise<void>;
+}
+
+class StubClient {
+  publishCalls: PublishCall[] = [];
+  subscribeCalls: SubscribeCall[] = [];
+  unsubscribeCalls: string[] = [];
+  closed = false;
+
+  async init(): Promise<void> {}
+  async publish(
+    exchange: string,
+    routingKey: string,
+    message: Record<string, unknown>,
+    options?: Record<string, unknown>
+  ): Promise<void> {
+    this.publishCalls.push({ exchange, routingKey, message, options });
+  }
+  async subscribe(
+    exchange: string,
+    routingKey: string,
+    queue: string,
+    handler: (m: Record<string, unknown>) => Promise<void>
+  ): Promise<void> {
+    this.subscribeCalls.push({ exchange, routingKey, queue, handler });
+  }
+  async unsubscribe(queue: string): Promise<void> {
+    this.unsubscribeCalls.push(queue);
+  }
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+class TestableRabbitMq extends RabbitMq {
+  stub = new StubClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected async getClient(): Promise<any> {
+    return this.stub;
+  }
+}
+
+/**
+ * Exercises the real getClient() caching/retry policy by stubbing the
+ * connect() seam: the first attempt fails, the second succeeds.
+ */
+class FlakyRabbitMq extends RabbitMq {
+  stub = new StubClient();
+  connectAttempts = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected async connect(): Promise<any> {
+    this.connectAttempts++;
+    if (this.connectAttempts === 1) throw new Error('broker down');
+    return this.stub;
+  }
+}
+
+describe('RabbitMq plugin', () => {
+  describe('with a configured broker URL', () => {
+    let dm: DM;
+    let plugin: TestableRabbitMq;
+
+    beforeEach(async () => {
+      dm = new DM();
+      dm.config.rabbitmq_url = 'amqp://guest:guest@rabbitmq:5672/';
+      await dm.ready;
+      plugin = new TestableRabbitMq(dm);
+    });
+
+    it('reports itself as available', () => {
+      expect(plugin.isAvailable()).to.equal(true);
+    });
+
+    it('delegates publish to the client', async () => {
+      await plugin.publish('auth', 'user.created', { twakeId: 'alice' });
+      expect(plugin.stub.publishCalls).to.have.length(1);
+      const call = plugin.stub.publishCalls[0];
+      expect(call.exchange).to.equal('auth');
+      expect(call.routingKey).to.equal('user.created');
+      expect(call.message).to.deep.equal({ twakeId: 'alice' });
+    });
+
+    it('forwards publish options to the client', async () => {
+      await plugin.publish(
+        'auth',
+        'user.created',
+        { twakeId: 'bob' },
+        { correlationId: 'abc' }
+      );
+      expect(plugin.stub.publishCalls[0].options).to.deep.equal({
+        correlationId: 'abc',
+      });
+    });
+
+    it('delegates subscribe to the client', async () => {
+      const handler = async (): Promise<void> => {};
+      await plugin.subscribe('b2b', 'domain.user.deleted', 'my-queue', handler);
+      expect(plugin.stub.subscribeCalls).to.have.length(1);
+      const call = plugin.stub.subscribeCalls[0];
+      expect(call.exchange).to.equal('b2b');
+      expect(call.routingKey).to.equal('domain.user.deleted');
+      expect(call.queue).to.equal('my-queue');
+      expect(call.handler).to.equal(handler);
+    });
+
+    it('delegates unsubscribe to the client', async () => {
+      await plugin.unsubscribe('my-queue');
+      expect(plugin.stub.unsubscribeCalls).to.deep.equal(['my-queue']);
+    });
+  });
+
+  describe('connection retry', () => {
+    let dm: DM;
+    let plugin: FlakyRabbitMq;
+
+    beforeEach(async () => {
+      dm = new DM();
+      dm.config.rabbitmq_url = 'amqp://guest:guest@rabbitmq:5672/';
+      await dm.ready;
+      plugin = new FlakyRabbitMq(dm);
+    });
+
+    it('retries connecting after an initial failure', async () => {
+      const first = await plugin.getRawClient();
+      expect(first, 'first connect fails → null').to.equal(null);
+
+      const second = await plugin.getRawClient();
+      expect(second, 'second connect succeeds').to.equal(plugin.stub);
+      expect(plugin.connectAttempts).to.equal(2);
+    });
+  });
+
+  describe('with no broker URL configured', () => {
+    let dm: DM;
+    let plugin: RabbitMq;
+
+    beforeEach(async () => {
+      dm = new DM();
+      dm.config.rabbitmq_url = '';
+      await dm.ready;
+      plugin = new RabbitMq(dm);
+    });
+
+    it('reports itself as unavailable', () => {
+      expect(plugin.isAvailable()).to.equal(false);
+    });
+
+    it('no-ops publish without throwing', async () => {
+      await plugin.publish('auth', 'user.created', { twakeId: 'alice' });
+    });
+
+    it('no-ops subscribe without throwing', async () => {
+      await plugin.subscribe('b2b', 'k', 'q', async () => {});
+    });
+
+    it('no-ops unsubscribe without throwing', async () => {
+      await plugin.unsubscribe('q');
+    });
+  });
+});

--- a/test/plugins/twake/cozyProvision.test.ts
+++ b/test/plugins/twake/cozyProvision.test.ts
@@ -11,10 +11,17 @@ interface PublishCall {
   message: Record<string, unknown>;
 }
 
-class StubPublisher {
+/**
+ * Stand-in for the shared `rabbitmq` plugin, injected into the DM's
+ * loaded-plugin registry so cozyProvision publishes through it without a
+ * real broker.
+ */
+class StubRabbitMq {
+  name = 'rabbitmq';
   calls: PublishCall[] = [];
-  closed = false;
-  async init(): Promise<void> {}
+  isAvailable(): boolean {
+    return true;
+  }
   async publish(
     exchange: string,
     routingKey: string,
@@ -22,23 +29,14 @@ class StubPublisher {
   ): Promise<void> {
     this.calls.push({ exchange, routingKey, message });
   }
-  async close(): Promise<void> {
-    this.closed = true;
-  }
-}
-
-class TestableCozyProvision extends CozyProvision {
-  stub = new StubPublisher();
-  protected async getPublisher(): Promise<StubPublisher> {
-    return this.stub;
-  }
 }
 
 const COZY_URL = 'http://cozyt:6060';
 
 describe('CozyProvision plugin', () => {
   let dm: DM;
-  let plugin: TestableCozyProvision;
+  let plugin: CozyProvision;
+  let rabbit: StubRabbitMq;
 
   before(() => {
     nock.disableNetConnect();
@@ -61,7 +59,10 @@ describe('CozyProvision plugin', () => {
     // overrides actual broker access.
     dm.config.rabbitmq_url = 'amqp://guest:guest@rabbitmq:5672/';
     await dm.ready;
-    plugin = new TestableCozyProvision(dm);
+    rabbit = new StubRabbitMq();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    dm.loadedPlugins['rabbitmq'] = rabbit as any;
+    plugin = new CozyProvision(dm);
   });
 
   afterEach(() => {
@@ -102,8 +103,8 @@ describe('CozyProvision plugin', () => {
       await hook(user);
 
       expect(scope.isDone(), 'cozy admin POST + PATCH').to.be.true;
-      expect(plugin.stub.calls).to.have.length(1);
-      const call = plugin.stub.calls[0];
+      expect(rabbit.calls).to.have.length(1);
+      const call = rabbit.calls[0];
       expect(call.exchange).to.equal('auth');
       expect(call.routingKey).to.equal('user.created');
       expect(call.message).to.deep.include({
@@ -117,7 +118,7 @@ describe('CozyProvision plugin', () => {
 
     it('respects cozy_apps override', async () => {
       dm.config.cozy_apps = 'home,drive';
-      const p = new TestableCozyProvision(dm);
+      const p = new CozyProvision(dm);
       const scope = nock(COZY_URL)
         .post('/instances')
         .query(q => q.Apps === 'home,drive')
@@ -139,7 +140,7 @@ describe('CozyProvision plugin', () => {
 
     it('omits Apps query param when cozy_apps is empty', async () => {
       dm.config.cozy_apps = '';
-      const p = new TestableCozyProvision(dm);
+      const p = new CozyProvision(dm);
       const scope = nock(COZY_URL)
         .post('/instances')
         .query(q => !('Apps' in q))
@@ -205,8 +206,8 @@ describe('CozyProvision plugin', () => {
       ) => Promise<void>;
       await hook(user);
 
-      expect(plugin.stub.calls).to.have.length(1);
-      expect(plugin.stub.calls[0].message).to.deep.include({
+      expect(rabbit.calls).to.have.length(1);
+      expect(rabbit.calls[0].message).to.deep.include({
         twakeId: 'grace',
         mobile: '+33600000000',
       });
@@ -229,8 +230,8 @@ describe('CozyProvision plugin', () => {
       await hook(user);
 
       expect(scope.isDone()).to.be.true;
-      expect(plugin.stub.calls).to.have.length(1);
-      expect(plugin.stub.calls[0].routingKey).to.equal('user.created');
+      expect(rabbit.calls).to.have.length(1);
+      expect(rabbit.calls[0].routingKey).to.equal('user.created');
     });
 
     it('does not fail the hook when the onboarding PATCH errors', async () => {
@@ -254,8 +255,8 @@ describe('CozyProvision plugin', () => {
 
       expect(scope.isDone()).to.be.true;
       // Publish still happens — PATCH failure must not abort the flow.
-      expect(plugin.stub.calls).to.have.length(1);
-      expect(plugin.stub.calls[0].routingKey).to.equal('user.created');
+      expect(rabbit.calls).to.have.length(1);
+      expect(rabbit.calls[0].routingKey).to.equal('user.created');
     });
 
     it('skips publish when cozy admin returns a hard error', async () => {
@@ -275,7 +276,7 @@ describe('CozyProvision plugin', () => {
       await hook(user);
 
       expect(scope.isDone()).to.be.true;
-      expect(plugin.stub.calls).to.have.length(0);
+      expect(rabbit.calls).to.have.length(0);
     });
 
     it('uses user.locale when present', async () => {
@@ -310,7 +311,7 @@ describe('CozyProvision plugin', () => {
       ) => Promise<void>;
       await hook(user);
       // No HTTP call expected, no publish either
-      expect(plugin.stub.calls).to.have.length(0);
+      expect(rabbit.calls).to.have.length(0);
     });
   });
 
@@ -326,8 +327,8 @@ describe('CozyProvision plugin', () => {
       await hook('eve');
 
       expect(scope.isDone()).to.equal(true);
-      expect(plugin.stub.calls).to.have.length(1);
-      const call = plugin.stub.calls[0];
+      expect(rabbit.calls).to.have.length(1);
+      const call = rabbit.calls[0];
       expect(call.exchange).to.equal('b2b');
       expect(call.routingKey).to.equal('domain.user.deleted');
       expect(call.message).to.deep.equal({
@@ -347,8 +348,8 @@ describe('CozyProvision plugin', () => {
       await hook('ghost');
 
       expect(scope.isDone()).to.equal(true);
-      expect(plugin.stub.calls).to.have.length(1);
-      expect(plugin.stub.calls[0].routingKey).to.equal('domain.user.deleted');
+      expect(rabbit.calls).to.have.length(1);
+      expect(rabbit.calls[0].routingKey).to.equal('domain.user.deleted');
     });
 
     it('does not publish when the destroy errors', async () => {
@@ -362,7 +363,7 @@ describe('CozyProvision plugin', () => {
       await hook('broken');
 
       expect(scope.isDone()).to.equal(true);
-      expect(plugin.stub.calls).to.have.length(0);
+      expect(rabbit.calls).to.have.length(0);
     });
   });
 
@@ -373,7 +374,10 @@ describe('CozyProvision plugin', () => {
       dm2.config.cozy_org_domain = 'twake.local';
       dm2.config.rabbitmq_url = 'amqp://x';
       await dm2.ready;
-      const p = new TestableCozyProvision(dm2);
+      const rabbit2 = new StubRabbitMq();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dm2.loadedPlugins['rabbitmq'] = rabbit2 as any;
+      const p = new CozyProvision(dm2);
 
       const user: ScimUser = {
         schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
@@ -385,7 +389,7 @@ describe('CozyProvision plugin', () => {
       await hook(user);
 
       // No nock expectation set, no HTTP call attempted; no publish either.
-      expect(p.stub.calls).to.have.length(0);
+      expect(rabbit2.calls).to.have.length(0);
     });
   });
 });


### PR DESCRIPTION
## Problem

- AMQP transport (the client, the lazy optional-dependency import, the broker URL config, log redaction, and shutdown handling) lived entirely inside the `cozyProvision` plugin.
- Any new plugin that needs the broker had to copy all of it, each opening its own connection.
- A failed first connection was cached for the process lifetime, so a broker that was briefly down at the first publish stayed disabled until a restart.

## Solution

A new `rabbitmq` plugin owns one lazily opened connection and exposes `publish`, `subscribe`, and `unsubscribe`. Consumers declare it as a dependency and resolve it through a shared `requirePlugin` helper on the plugin base; `cozyProvision` keeps only its message building and delegates publishing. A failed connection now clears its cached state so the next publish retries, and the broker's own reconnection takes over once connected.
