### PR TITLE
feat: cloudery provisioning plugin and header-based scim base

### DIFF
--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -188,6 +188,17 @@ export interface Config {
   cozy_apps?: string;
   cozy_auth_exchange?: string;
   cozy_b2b_exchange?: string;
+  cloudery_manager_url?: string;
+  cloudery_manager_token?: string;
+  cloudery_offer?: string;
+  cloudery_domain?: string;
+  cloudery_user_branch?: string;
+  cloudery_org_id_header?: string;
+  cloudery_fqdn_attribute?: string;
+  cloudery_org_id_attribute?: string;
+  cloudery_default_locale?: string;
+  cloudery_workflow_poll_interval_ms?: number;
+  cloudery_workflow_max_attempts?: number;
   rabbitmq_url?: string;
 
   // Applicative Accounts plugin
@@ -218,6 +229,9 @@ export interface Config {
   scim_group_base?: string;
   scim_user_base_template?: string;
   scim_group_base_template?: string;
+  scim_user_base_header?: string;
+  scim_group_base_header?: string;
+  scim_base_header_root?: string;
   scim_base_map?: string;
   scim_user_object_class?: string[];
   scim_user_rdn_attribute?: string;
@@ -472,6 +486,41 @@ const configArgs: ConfigTemplate = [
   ['--cozy-apps', 'DM_COZY_APPS', 'home,drive,settings,notes,dataproxy'],
   ['--cozy-auth-exchange', 'DM_COZY_AUTH_EXCHANGE', 'auth'],
   ['--cozy-b2b-exchange', 'DM_COZY_B2B_EXCHANGE', 'b2b'],
+
+  // clouderyProvision plugin
+  ['--cloudery-manager-url', 'DM_CLOUDERY_MANAGER_URL', ''],
+  ['--cloudery-manager-token', 'DM_CLOUDERY_MANAGER_TOKEN', ''],
+  ['--cloudery-offer', 'DM_CLOUDERY_OFFER', 'b2b_twake_default'],
+  ['--cloudery-domain', 'DM_CLOUDERY_DOMAIN', ''],
+  ['--cloudery-user-branch', 'DM_CLOUDERY_USER_BRANCH', ''],
+  [
+    '--cloudery-org-id-header',
+    'DM_CLOUDERY_ORG_ID_HEADER',
+    'x-cloudery-org-id',
+  ],
+  [
+    '--cloudery-fqdn-attribute',
+    'DM_CLOUDERY_FQDN_ATTRIBUTE',
+    'twakeWorkspaceUrl',
+  ],
+  [
+    '--cloudery-org-id-attribute',
+    'DM_CLOUDERY_ORG_ID_ATTRIBUTE',
+    'twakeOrganizationId',
+  ],
+  ['--cloudery-default-locale', 'DM_CLOUDERY_DEFAULT_LOCALE', 'en'],
+  [
+    '--cloudery-workflow-poll-interval-ms',
+    'DM_CLOUDERY_WORKFLOW_POLL_INTERVAL_MS',
+    2000,
+    'number',
+  ],
+  [
+    '--cloudery-workflow-max-attempts',
+    'DM_CLOUDERY_WORKFLOW_MAX_ATTEMPTS',
+    60,
+    'number',
+  ],
   ['--rabbitmq-url', 'DM_RABBITMQ_URL', ''],
 
   // Applicative Accounts plugin
@@ -632,6 +681,9 @@ const configArgs: ConfigTemplate = [
   ['--scim-user-base-template', 'DM_SCIM_USER_BASE_TEMPLATE', ''],
   ['--scim-group-base-template', 'DM_SCIM_GROUP_BASE_TEMPLATE', ''],
   ['--scim-base-map', 'DM_SCIM_BASE_MAP', ''],
+  ['--scim-user-base-header', 'DM_SCIM_USER_BASE_HEADER', ''],
+  ['--scim-group-base-header', 'DM_SCIM_GROUP_BASE_HEADER', ''],
+  ['--scim-base-header-root', 'DM_SCIM_BASE_HEADER_ROOT', ''],
   [
     '--scim-user-object-class',
     'DM_SCIM_USER_OBJECT_CLASSES',

--- a/src/plugins/scim/baseResolver.ts
+++ b/src/plugins/scim/baseResolver.ts
@@ -6,19 +6,26 @@
  *
  * Resolution order (user → group identical):
  *   1. Explicit map entry for req.user   (scim_base_map → { "<user>": { userBase, groupBase } })
- *   2. Wildcard map entry "*"            (scim_base_map → { "*": { ... } })
- *   3. Template substitution             (scim_user_base_template / scim_group_base_template)
- *   4. Static config value               (scim_user_base / scim_group_base)
- *   5. Global fallback                   (ldap_base)
+ *   2. Request header                    (scim_user_base_header / scim_group_base_header)
+ *   3. Wildcard map entry "*"            (scim_base_map → { "*": { ... } })
+ *   4. Template substitution             (scim_user_base_template / scim_group_base_template)
+ *   5. Static config value               (scim_user_base / scim_group_base)
+ *   6. Global fallback                   (ldap_base)
  *
  * The `{user}` placeholder in templates is substituted with req.user after
  * `escapeDnValue()` sanitization, to prevent DN-injection.
+ *
+ * A header-supplied base is only honored when `scim_base_header_root` is
+ * explicitly configured AND the value sits at or under that root AND contains
+ * no control characters, so a header cannot redirect operations to an arbitrary
+ * DN or inject into the DN. An explicit per-user map entry still wins over the
+ * header, so identity-based pinning is never silently overridden.
  */
 import fs from 'fs';
 
 import type { Config } from '../../config/args';
 import type { DmRequest } from '../../lib/auth/base';
-import { escapeDnValue } from '../../lib/utils';
+import { escapeDnValue, isChildOf } from '../../lib/utils';
 
 export interface BaseMapEntry {
   userBase?: string;
@@ -32,6 +39,9 @@ export class BaseResolver {
   private readonly userTemplate: string;
   private readonly groupTemplate: string;
   private readonly map: BaseMap | undefined;
+  private readonly userBaseHeader: string;
+  private readonly groupBaseHeader: string;
+  private readonly headerRoot: string;
 
   constructor(config: Config) {
     const fallback = config.ldap_base || '';
@@ -39,6 +49,13 @@ export class BaseResolver {
     this.defaultGroupBase = (config.scim_group_base as string) || fallback;
     this.userTemplate = (config.scim_user_base_template as string) || '';
     this.groupTemplate = (config.scim_group_base_template as string) || '';
+    this.userBaseHeader = (
+      (config.scim_user_base_header as string) || ''
+    ).toLowerCase();
+    this.groupBaseHeader = (
+      (config.scim_group_base_header as string) || ''
+    ).toLowerCase();
+    this.headerRoot = (config.scim_base_header_root as string) || '';
 
     const mapPath = (config.scim_base_map as string) || '';
     if (mapPath) {
@@ -60,6 +77,28 @@ export class BaseResolver {
     return template.replace(/\{user\}/g, safe);
   }
 
+  /** Read a request header by name, tolerating Express req or a plain object. */
+  private readHeader(
+    req: DmRequest | { user?: string } | undefined,
+    name: string
+  ): string | undefined {
+    if (!req || typeof req !== 'object') return undefined;
+    const r = req as {
+      get?: (n: string) => string | undefined;
+      headers?: Record<string, string | string[] | undefined>;
+    };
+    if (typeof r.get === 'function') {
+      const v = r.get(name);
+      if (typeof v === 'string' && v.length > 0) return v;
+    }
+    const h = r.headers?.[name];
+    if (typeof h === 'string' && h.length > 0) return h;
+    if (Array.isArray(h) && typeof h[0] === 'string' && h[0].length > 0) {
+      return h[0];
+    }
+    return undefined;
+  }
+
   private resolve(
     kind: 'user' | 'group',
     req?: DmRequest | { user?: string }
@@ -67,13 +106,30 @@ export class BaseResolver {
     const user =
       req && typeof req === 'object' && 'user' in req ? req.user : undefined;
 
-    // 1. Explicit map entry
+    // 1. Explicit map entry (identity pinning wins over a request header)
     if (this.map && user && this.map[user]) {
       const entry = this.map[user];
       if (kind === 'user' && entry.userBase) return entry.userBase;
       if (kind === 'group' && entry.groupBase) return entry.groupBase;
     }
-    // 2. Wildcard map entry
+    // 2. Request header — only when an explicit root is configured, the value
+    //    is at/under it, and it carries no control characters.
+    const headerName =
+      kind === 'user' ? this.userBaseHeader : this.groupBaseHeader;
+    if (headerName && this.headerRoot) {
+      const fromHeader = this.readHeader(req, headerName)?.trim();
+      if (
+        fromHeader &&
+        // eslint-disable-next-line no-control-regex
+        !/[\u0000-\u001f\u007f]/.test(fromHeader) &&
+        (fromHeader.toLowerCase() === this.headerRoot.toLowerCase() ||
+          isChildOf(fromHeader, this.headerRoot))
+      ) {
+        return fromHeader;
+      }
+      // No root, outside the root, or unsafe value: ignore, fall through.
+    }
+    // 3. Wildcard map entry
     if (this.map && this.map['*']) {
       const entry = this.map['*'];
       if (kind === 'user' && entry.userBase)

--- a/src/plugins/twake/clouderyProvision.ts
+++ b/src/plugins/twake/clouderyProvision.ts
@@ -1,0 +1,615 @@
+/**
+ * @module plugins/twake/clouderyProvision
+ *
+ * B2B sibling of `cozyProvision`. For SCIM users created under a configured
+ * B2B LDAP branch, it provisions a Twake/Cozy instance via the Cloudery
+ * (manager) API, writes the returned FQDN to the `twakeWorkspaceUrl` attribute
+ * (bare FQDN) and the org id to `twakeOrganizationId` (the org id arrives in a
+ * header, so the SCIM body cannot carry it), and publishes the same lifecycle
+ * messages cozyProvision does.
+ *
+ * The org id is carried per-request in a header (single shared B2B token), so
+ * onboarding a new org needs no config change; the org branch is selected by
+ * the core `BaseResolver` (also from a header). The operator supplies the email
+ * in the SCIM body, `org_domain` is its domain, and `slug` = `oidc` =
+ * normalizeNickname(userName) + orgId (dots stripped).
+ */
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import type { Request } from 'express';
+import fetch from 'node-fetch';
+
+import DmPlugin, { type Role, escapeDnValue } from '../../abstract/plugin';
+import type { DM } from '../../bin';
+import { Hooks } from '../../hooks';
+import { isChildOf } from '../../lib/utils';
+import type RabbitMq from '../rabbitmq';
+import { BaseResolver } from '../scim/baseResolver';
+import type { ScimUser } from '../scim/types';
+
+type ReqWithUser = Request & { user?: string };
+
+interface ClouderyInstanceResponse {
+  id: string;
+  fqdn: string;
+  workflow?: string;
+}
+
+interface CreateContext {
+  orgId: string;
+  email: string;
+  base: string;
+  ts: number;
+}
+
+interface DeleteContext {
+  fqdn: string;
+  domain: string;
+}
+
+// A create that fails between the pre- and post-create hooks would otherwise
+// leak its captured context; prune anything older than this.
+const STASH_TTL_MS = 5 * 60 * 1000;
+
+export default class ClouderyProvision extends DmPlugin {
+  name = 'clouderyProvision';
+  roles: Role[] = ['consistency'] as const;
+
+  dependencies = { rabbitmq: 'core/rabbitmq' };
+
+  private readonly managerUrl: string;
+  private readonly managerToken: string;
+  private readonly offer: string;
+  private readonly clouderyDomain: string;
+  private readonly userBranch: string;
+  private readonly orgIdHeader: string;
+  private readonly fqdnAttribute: string;
+  private readonly orgIdAttribute: string;
+  private readonly defaultLocale: string;
+  private readonly rdnAttribute: string;
+  private readonly authExchange: string;
+  private readonly b2bExchange: string;
+  private readonly pollIntervalMs: number;
+  private readonly maxPollAttempts: number;
+
+  private readonly baseResolver: BaseResolver;
+
+  // pre-create hook (has req) → post-create hook (no req). Keyed by the
+  // primary email (unique per user/tenant); userName alone collides across org
+  // branches, which would let one tenant's create overwrite another's context.
+  private readonly createStash = new Map<string, CreateContext>();
+  // pre-delete hook (entry still exists) → post-delete hook; keyed by id.
+  private readonly deleteStash = new Map<string, DeleteContext>();
+
+  constructor(server: DM) {
+    super(server);
+    const cfg = this.config;
+
+    this.managerUrl = ((cfg.cloudery_manager_url as string) || '').replace(
+      /\/$/,
+      ''
+    );
+    this.managerToken = (cfg.cloudery_manager_token as string) || '';
+    this.offer = (cfg.cloudery_offer as string) || 'b2b_twake_default';
+    this.clouderyDomain = (cfg.cloudery_domain as string) || '';
+    this.userBranch = (cfg.cloudery_user_branch as string) || '';
+    this.orgIdHeader = (
+      (cfg.cloudery_org_id_header as string) || 'x-cloudery-org-id'
+    ).toLowerCase();
+    this.fqdnAttribute =
+      (cfg.cloudery_fqdn_attribute as string) || 'twakeWorkspaceUrl';
+    this.orgIdAttribute =
+      (cfg.cloudery_org_id_attribute as string) || 'twakeOrganizationId';
+    this.defaultLocale = (cfg.cloudery_default_locale as string) || 'en';
+    this.rdnAttribute = (cfg.scim_user_rdn_attribute as string) || 'uid';
+    this.authExchange = (cfg.cozy_auth_exchange as string) || 'auth';
+    this.b2bExchange = (cfg.cozy_b2b_exchange as string) || 'b2b';
+    this.pollIntervalMs =
+      Number(cfg.cloudery_workflow_poll_interval_ms) || 2000;
+    this.maxPollAttempts = Number(cfg.cloudery_workflow_max_attempts) || 60;
+
+    this.baseResolver = new BaseResolver(this.config);
+
+    if (!this.managerUrl) {
+      this.logger.warn(
+        `${this.name}: cloudery_manager_url is empty — instance provisioning will be skipped`
+      );
+    }
+    if (!this.userBranch) {
+      this.logger.warn(
+        `${this.name}: cloudery_user_branch is empty — no users will be provisioned`
+      );
+    }
+  }
+
+  hooks: Hooks = {
+    scimusercreate: (
+      args: [ScimUser, ReqWithUser?]
+    ): [ScimUser, ReqWithUser?] => {
+      this.captureCreate(args[0], args[1]);
+      return args;
+    },
+    scimusercreatedone: async (user: ScimUser): Promise<void> => {
+      await this.provision(user);
+    },
+    scimuserdelete: async (
+      args: [string, ReqWithUser?]
+    ): Promise<[string, ReqWithUser?]> => {
+      await this.captureDelete(args[0], args[1]);
+      return args;
+    },
+    scimuserdeletedone: async (id: string): Promise<void> => {
+      await this.deprovision(id);
+    },
+  };
+
+  /** Pre-create: stash the request-derived context for the post-create hook. */
+  private captureCreate(user: ScimUser, req?: ReqWithUser): void {
+    this.pruneStash();
+    if (!this.managerUrl || !this.userBranch) return;
+    const userName = this.extractId(user);
+    if (!userName) return;
+
+    const base = this.baseResolver.userBase(req);
+    if (!this.isAtOrUnder(base, this.userBranch)) return;
+
+    const orgId = this.readHeader(req, this.orgIdHeader);
+    if (!orgId) {
+      this.logger.warn({
+        plugin: this.name,
+        event: 'captureCreate',
+        userName,
+        message: `B2B branch create without ${this.orgIdHeader} — skipping provisioning`,
+      });
+      return;
+    }
+
+    // org_domain is the email domain (as in signup), so the email must be in
+    // the body; the core maps it to `mail`.
+    const email = this.extractPrimaryEmail(user);
+    if (!email) {
+      this.logger.warn({
+        plugin: this.name,
+        event: 'captureCreate',
+        userName,
+        message:
+          'B2B branch create without a primary email — skipping provisioning',
+      });
+      return;
+    }
+
+    // Trim what we stash: leading/trailing whitespace in the email or org id
+    // would otherwise leak into org_domain / internal_email / slug downstream.
+    const cleanEmail = email.trim();
+    this.createStash.set(cleanEmail.toLowerCase(), {
+      orgId: orgId.trim(),
+      email: cleanEmail,
+      base,
+      ts: Date.now(),
+    });
+  }
+
+  /**
+   * Post-create: provision via Cloudery, wait for the workflow, then write the
+   * FQDN back and publish user.created. Gated on workflow success so nothing is
+   * emitted for an instance that does not exist yet.
+   */
+  private async provision(user: ScimUser): Promise<void> {
+    const userName = this.extractId(user);
+    if (!userName) return;
+    const lookupEmail = this.extractPrimaryEmail(user);
+    if (!lookupEmail) return;
+    const key = lookupEmail.trim().toLowerCase();
+    const ctx = this.createStash.get(key);
+    if (!ctx) return;
+    this.createStash.delete(key);
+
+    const email = ctx.email;
+    const orgDomain = emailDomain(email);
+    const slug = normalizeNickname(userName) + ctx.orgId;
+    const mobile = this.extractPrimaryPhone(user);
+    const publicName = this.extractPublicName(user) || userName;
+
+    const log = {
+      plugin: this.name,
+      event: 'provision',
+      userName,
+      orgId: ctx.orgId,
+      slug,
+    };
+
+    let instance: ClouderyInstanceResponse;
+    try {
+      instance = await this.createInstance({
+        email,
+        publicName,
+        locale: this.extractLocale(user),
+        oidc: slug,
+        phone: mobile || '',
+        slug,
+        public_name: publicName,
+        offer: this.offer,
+        domain: this.clouderyDomain,
+        skip_email_validation: true,
+        internal_email: email,
+        org_domain: orgDomain,
+        org_id: ctx.orgId,
+      });
+    } catch (err) {
+      this.logger.error({
+        ...log,
+        result: 'error',
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        error: `${err}`,
+      });
+      return;
+    }
+
+    const ready = instance.workflow
+      ? await this.waitForWorkflow(instance.workflow)
+      : true;
+    if (!ready) {
+      this.logger.error({
+        ...log,
+        result: 'workflow_failed',
+        workflow: instance.workflow,
+      });
+      return;
+    }
+
+    const fqdn = instance.fqdn;
+    const dn = `${this.rdnAttribute}=${escapeDnValue(userName)},${ctx.base}`;
+    try {
+      await this.server.ldap.modify(dn, {
+        replace: {
+          [this.fqdnAttribute]: fqdn,
+          [this.orgIdAttribute]: ctx.orgId,
+        },
+      });
+    } catch (err) {
+      // Instance exists, so still publish; the write failure would break the
+      // later delete lookup, so surface it.
+      this.logger.error({
+        ...log,
+        event: 'writeFqdn',
+        dn,
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        error: `${err}`,
+      });
+    }
+
+    await this.publishUserCreated({
+      twakeId: userName,
+      orgDomain,
+      orgId: ctx.orgId,
+      fqdn,
+      email,
+      mobile,
+    });
+    this.logger.info({ ...log, result: 'success', fqdn });
+  }
+
+  /**
+   * Pre-delete: read the stored FQDN (and domain from mail) while the entry
+   * still exists, so the post-delete hook can tear the instance down. No stored
+   * FQDN means this user was not provisioned here.
+   */
+  private async captureDelete(id: string, req?: ReqWithUser): Promise<void> {
+    if (!this.managerUrl || !this.userBranch) return;
+    const base = this.baseResolver.userBase(req);
+    if (!this.isAtOrUnder(base, this.userBranch)) return;
+
+    const dn = `${this.rdnAttribute}=${escapeDnValue(id)},${base}`;
+    try {
+      const res = (await this.server.ldap.search(
+        {
+          paged: false,
+          scope: 'base',
+          attributes: [this.fqdnAttribute, 'mail'],
+        },
+        dn
+      )) as { searchEntries?: Record<string, unknown>[] };
+      const entry = res.searchEntries?.[0];
+      const stored = entry ? firstValue(entry[this.fqdnAttribute]) : undefined;
+      const fqdn = stored ? extractFqdn(stored) : undefined;
+      if (!fqdn) return;
+      const mail = entry ? firstValue(entry.mail) : undefined;
+      this.deleteStash.set(id, {
+        fqdn,
+        domain: mail ? emailDomain(mail) : '',
+      });
+    } catch (err) {
+      this.logger.warn({
+        plugin: this.name,
+        event: 'captureDelete',
+        id,
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        error: `${err}`,
+      });
+    }
+  }
+
+  /** Post-delete: delete the Cloudery instance by FQDN and publish the event. */
+  private async deprovision(id: string): Promise<void> {
+    const ctx = this.deleteStash.get(id);
+    if (!ctx) return;
+    this.deleteStash.delete(id);
+
+    const log = {
+      plugin: this.name,
+      event: 'deprovision',
+      id,
+      fqdn: ctx.fqdn,
+    };
+    let deleted = false;
+    try {
+      const uuid = await this.findInstanceUuidByFqdn(ctx.fqdn);
+      if (uuid) {
+        await this.deleteInstance(uuid);
+        deleted = true;
+        this.logger.info({ ...log, result: 'deleted', uuid });
+      } else {
+        this.logger.warn({ ...log, result: 'not_found' });
+      }
+    } catch (err) {
+      this.logger.error({
+        ...log,
+        result: 'error',
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        error: `${err}`,
+      });
+    }
+
+    // Only announce the deletion once the instance is actually destroyed, so a
+    // failed lookup/delete never notifies downstream of a teardown that did not
+    // happen (matching cozyProvision).
+    if (deleted) {
+      await this.publishUserDeleted(ctx.fqdn, ctx.domain);
+    }
+  }
+
+  /* ----------------------------- Cloudery API ----------------------------- */
+
+  private async createInstance(
+    payload: Record<string, unknown>
+  ): Promise<ClouderyInstanceResponse> {
+    const res = await fetch(`${this.managerUrl}/api/v1/instances`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.managerToken}`,
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      throw new Error(`Cloudery createInstance HTTP ${res.status}`);
+    }
+    return (await res.json()) as ClouderyInstanceResponse;
+  }
+
+  /** Poll the workflow until it succeeds. Returns false on failure/timeout. */
+  private async waitForWorkflow(workflowId: string): Promise<boolean> {
+    for (let attempt = 1; attempt <= this.maxPollAttempts; attempt++) {
+      try {
+        const res = await fetch(
+          `${this.managerUrl}/api/v1/workflows/${encodeURIComponent(
+            workflowId
+          )}`,
+          { headers: { Authorization: `Bearer ${this.managerToken}` } }
+        );
+        if (res.ok) {
+          const data = (await res.json()) as { status?: string };
+          if (data.status === 'succeeded') return true;
+          if (data.status === 'failed' || data.status === 'error') {
+            return false;
+          }
+        }
+      } catch (err) {
+        this.logger.warn({
+          plugin: this.name,
+          event: 'waitForWorkflow',
+          workflow: workflowId,
+          attempt,
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          error: `${err}`,
+        });
+      }
+      if (attempt < this.maxPollAttempts) await sleep(this.pollIntervalMs);
+    }
+    return false;
+  }
+
+  private async findInstanceUuidByFqdn(fqdn: string): Promise<string | null> {
+    const url = new URL(`${this.managerUrl}/api/v2/instances`);
+    url.searchParams.set('fqdn', fqdn);
+    url.searchParams.append('only', '_id');
+    url.searchParams.set('limit', '1');
+    const res = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${this.managerToken}` },
+    });
+    if (!res.ok) throw new Error(`Cloudery searchInstances HTTP ${res.status}`);
+    const data = (await res.json()) as { items?: { _id: string }[] };
+    return data.items && data.items.length > 0 ? data.items[0]._id : null;
+  }
+
+  private async deleteInstance(uuid: string): Promise<void> {
+    const url = new URL(
+      `${this.managerUrl}/api/v1/instances/${encodeURIComponent(uuid)}`
+    );
+    url.searchParams.set('user_request', 'true');
+    const res = await fetch(url.toString(), {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${this.managerToken}` },
+    });
+    if (!res.ok) throw new Error(`Cloudery deleteInstance HTTP ${res.status}`);
+  }
+
+  /* ------------------------------ Publishing ------------------------------ */
+
+  private async publishUserCreated(p: {
+    twakeId: string;
+    orgDomain: string;
+    orgId: string;
+    fqdn: string;
+    email: string | null;
+    mobile: string | null;
+  }): Promise<void> {
+    const rabbitmq = this.requirePlugin<RabbitMq>('rabbitmq');
+    if (!rabbitmq) return;
+
+    const message: Record<string, unknown> = {
+      twakeId: p.twakeId,
+      domain: p.orgDomain,
+      organizationDomain: p.orgDomain,
+      workplaceFqdn: p.fqdn,
+      organizationId: p.orgId,
+    };
+    if (p.email) message.internalEmail = p.email;
+    if (p.mobile) message.mobile = p.mobile;
+
+    try {
+      await rabbitmq.publish(this.authExchange, 'user.created', message);
+    } catch (err) {
+      this.logger.error({
+        plugin: this.name,
+        event: 'publishUserCreated',
+        twakeId: p.twakeId,
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        error: `${err}`,
+      });
+    }
+  }
+
+  private async publishUserDeleted(
+    fqdn: string,
+    domain: string
+  ): Promise<void> {
+    const rabbitmq = this.requirePlugin<RabbitMq>('rabbitmq');
+    if (!rabbitmq) return;
+    try {
+      await rabbitmq.publish(this.b2bExchange, 'domain.user.deleted', {
+        workplaceFqdn: fqdn,
+        domain,
+      });
+    } catch (err) {
+      this.logger.error({
+        plugin: this.name,
+        event: 'publishUserDeleted',
+        workplaceFqdn: fqdn,
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        error: `${err}`,
+      });
+    }
+  }
+
+  /* ------------------------------- Helpers -------------------------------- */
+
+  /** Read a request header by name, falling back to a query parameter. */
+  private readHeader(
+    req: ReqWithUser | undefined,
+    name: string
+  ): string | undefined {
+    if (!req) return undefined;
+    const fromHeader = req.get ? req.get(name) : undefined;
+    if (typeof fromHeader === 'string' && fromHeader.length > 0) {
+      return fromHeader;
+    }
+    const q = req.query?.[name];
+    return typeof q === 'string' && q.length > 0 ? q : undefined;
+  }
+
+  private isAtOrUnder(dn: string, parent: string): boolean {
+    return (
+      dn.trim().toLowerCase() === parent.trim().toLowerCase() ||
+      isChildOf(dn, parent)
+    );
+  }
+
+  private pruneStash(): void {
+    const cutoff = Date.now() - STASH_TTL_MS;
+    for (const [key, ctx] of this.createStash) {
+      if (ctx.ts < cutoff) this.createStash.delete(key);
+    }
+  }
+
+  private extractId(user: ScimUser): string | null {
+    if (typeof user.userName === 'string' && user.userName.length > 0) {
+      return user.userName;
+    }
+    if (typeof user.id === 'string' && user.id.length > 0) return user.id;
+    return null;
+  }
+
+  private extractPrimaryEmail(user: ScimUser): string | null {
+    const emails = user.emails;
+    if (!emails || emails.length === 0) return null;
+    const primary = emails.find(e => e.primary);
+    const value = (primary || emails[0]).value;
+    return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+
+  private extractPrimaryPhone(user: ScimUser): string | null {
+    const phones = user.phoneNumbers;
+    if (!phones || phones.length === 0) return null;
+    const primary = phones.find(p => p.primary);
+    const value = (primary || phones[0]).value;
+    return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+
+  private extractPublicName(user: ScimUser): string | null {
+    if (
+      typeof user.displayName === 'string' &&
+      user.displayName.trim().length > 0
+    ) {
+      return user.displayName.trim();
+    }
+    const formatted = user.name?.formatted;
+    if (typeof formatted === 'string' && formatted.trim().length > 0) {
+      return formatted.trim();
+    }
+    const given = user.name?.givenName?.trim() ?? '';
+    const family = user.name?.familyName?.trim() ?? '';
+    const composed = `${given} ${family}`.trim();
+    return composed.length > 0 ? composed : null;
+  }
+
+  private extractLocale(user: ScimUser): string {
+    if (typeof user.locale === 'string' && user.locale.length > 0) {
+      return user.locale;
+    }
+    if (
+      typeof user.preferredLanguage === 'string' &&
+      user.preferredLanguage.length > 0
+    ) {
+      return user.preferredLanguage;
+    }
+    return this.defaultLocale;
+  }
+}
+
+/** Strip dots from the nickname to form the slug/oidc identifier. */
+function normalizeNickname(nickname: string): string {
+  return nickname.replace(/\./g, '');
+}
+
+function emailDomain(email: string): string {
+  const at = email.lastIndexOf('@');
+  return at >= 0 ? email.slice(at + 1) : '';
+}
+
+/** Reduce a stored workspace value to a bare FQDN, tolerating a protocol/path. */
+function extractFqdn(value: string): string {
+  return value
+    .trim()
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, '')
+    .split('/')[0];
+}
+
+/** LDAP attribute values come back as a scalar or an array. */
+function firstValue(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    const v: unknown = value[0];
+    return typeof v === 'string' ? v : undefined;
+  }
+  return typeof value === 'string' ? value : undefined;
+}

--- a/test/plugins/scim/baseResolver.test.ts
+++ b/test/plugins/scim/baseResolver.test.ts
@@ -83,6 +83,116 @@ describe('SCIM baseResolver', () => {
     }
   });
 
+  describe('header-based base', () => {
+    function reqWithHeader(name: string, value: string): { user?: string } {
+      const headers: Record<string, string> = { [name.toLowerCase()]: value };
+      return {
+        get(n: string): string | undefined {
+          return headers[n.toLowerCase()];
+        },
+      } as unknown as { user?: string };
+    }
+
+    it('honors a header base under the allowed root', () => {
+      const br = new BaseResolver(
+        cfg({
+          scim_user_base: 'ou=users,dc=example,dc=com',
+          scim_user_base_header: 'x-org-base',
+          scim_base_header_root: 'ou=b2b,dc=example,dc=com',
+        })
+      );
+      const req = reqWithHeader(
+        'x-org-base',
+        'ou=users,ou=acme,ou=b2b,dc=example,dc=com'
+      );
+      expect(br.userBase(req)).to.equal(
+        'ou=users,ou=acme,ou=b2b,dc=example,dc=com'
+      );
+    });
+
+    it('ignores a header base outside the allowed root', () => {
+      const br = new BaseResolver(
+        cfg({
+          scim_user_base: 'ou=users,dc=example,dc=com',
+          scim_user_base_header: 'x-org-base',
+          scim_base_header_root: 'ou=b2b,dc=example,dc=com',
+        })
+      );
+      const req = reqWithHeader('x-org-base', 'ou=evil,dc=other,dc=com');
+      expect(br.userBase(req)).to.equal('ou=users,dc=example,dc=com');
+    });
+
+    it('ignores the header when no root is configured', () => {
+      const br = new BaseResolver(
+        cfg({
+          scim_user_base: 'ou=b2b,dc=example,dc=com',
+          scim_user_base_header: 'x-org-base',
+          // no scim_base_header_root → header path disabled
+        })
+      );
+      const req = reqWithHeader('x-org-base', 'ou=acme,ou=b2b,dc=example,dc=com');
+      expect(br.userBase(req)).to.equal('ou=b2b,dc=example,dc=com');
+    });
+
+    it('ignores a header value containing control characters', () => {
+      const br = new BaseResolver(
+        cfg({
+          scim_user_base: 'ou=users,dc=example,dc=com',
+          scim_user_base_header: 'x-org-base',
+          scim_base_header_root: 'ou=b2b,dc=example,dc=com',
+        })
+      );
+      const req = reqWithHeader(
+        'x-org-base',
+        'ou=a\u0000x,ou=b2b,dc=example,dc=com'
+      );
+      expect(br.userBase(req)).to.equal('ou=users,dc=example,dc=com');
+    });
+
+    it('an explicit map entry wins over the header', () => {
+      const mapFile = path.join(
+        os.tmpdir(),
+        `scim-base-map-hdr-${Date.now()}.json`
+      );
+      fs.writeFileSync(
+        mapFile,
+        JSON.stringify({ alice: { userBase: 'ou=pinned,ou=b2b,dc=example,dc=com' } })
+      );
+      try {
+        const br = new BaseResolver(
+          cfg({
+            scim_user_base: 'ou=b2b,dc=example,dc=com',
+            scim_user_base_header: 'x-org-base',
+            scim_base_header_root: 'ou=b2b,dc=example,dc=com',
+            scim_base_map: mapFile,
+          })
+        );
+        const req = reqWithHeader(
+          'x-org-base',
+          'ou=acme,ou=b2b,dc=example,dc=com'
+        );
+        (req as { user?: string }).user = 'alice';
+        expect(br.userBase(req)).to.equal('ou=pinned,ou=b2b,dc=example,dc=com');
+      } finally {
+        fs.unlinkSync(mapFile);
+      }
+    });
+
+    it('takes precedence over the template', () => {
+      const br = new BaseResolver(
+        cfg({
+          scim_user_base: 'ou=b2b,dc=example,dc=com',
+          scim_user_base_template: 'ou={user},dc=example,dc=com',
+          scim_user_base_header: 'x-org-base',
+          scim_base_header_root: 'ou=b2b,dc=example,dc=com',
+        })
+      );
+      const req = reqWithHeader('x-org-base', 'ou=acme,ou=b2b,dc=example,dc=com');
+      (req as { user?: string }).user = 'tenant1';
+      expect(br.userBase(req)).to.equal('ou=acme,ou=b2b,dc=example,dc=com');
+    });
+  });
+
   it('resolution order: map > template > static', () => {
     const mapFile = path.join(
       os.tmpdir(),

--- a/test/plugins/twake/clouderyProvision.test.ts
+++ b/test/plugins/twake/clouderyProvision.test.ts
@@ -1,0 +1,373 @@
+import nock from 'nock';
+import { expect } from 'chai';
+
+import { DM } from '../../../src/bin';
+import ClouderyProvision from '../../../src/plugins/twake/clouderyProvision';
+import type { ScimUser } from '../../../src/plugins/scim/types';
+
+const CLOUDERY = 'http://cloudery.test';
+const B2B_BRANCH = 'ou=b2b,dc=twake,dc=local';
+const USER_BASE = 'ou=users,ou=b2b,dc=twake,dc=local';
+
+interface PublishCall {
+  exchange: string;
+  routingKey: string;
+  message: Record<string, unknown>;
+}
+
+class StubRabbitMq {
+  name = 'rabbitmq';
+  calls: PublishCall[] = [];
+  isAvailable(): boolean {
+    return true;
+  }
+  async publish(
+    exchange: string,
+    routingKey: string,
+    message: Record<string, unknown>
+  ): Promise<void> {
+    this.calls.push({ exchange, routingKey, message });
+  }
+}
+
+interface ModifyCall {
+  dn: string;
+  changes: Record<string, unknown>;
+}
+
+/** Minimal stand-in for this.server.ldap used by the plugin. */
+class StubLdap {
+  modifyCalls: ModifyCall[] = [];
+  // entry returned by a base-scope search keyed by dn
+  entries: Record<string, Record<string, unknown>> = {};
+  async modify(
+    dn: string,
+    changes: Record<string, unknown>
+  ): Promise<boolean> {
+    this.modifyCalls.push({ dn, changes });
+    return true;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async search(_opts: any, base: string): Promise<any> {
+    const entry = this.entries[base];
+    return { searchEntries: entry ? [entry] : [] };
+  }
+}
+
+// Express-like request stub: carries the org id / base headers and the token.
+function makeReq(orgId?: string, orgBase?: string): unknown {
+  const headers: Record<string, string> = {};
+  if (orgId) headers['x-cloudery-org-id'] = orgId;
+  if (orgBase) headers['x-cloudery-org-base'] = orgBase;
+  return {
+    user: 'b2b-token',
+    headers,
+    query: {},
+    get(name: string): string | undefined {
+      return headers[name.toLowerCase()];
+    },
+  };
+}
+
+function configure(dm: DM): void {
+  dm.config.cloudery_manager_url = CLOUDERY;
+  dm.config.cloudery_manager_token = 'tok';
+  dm.config.cloudery_offer = 'b2b_twake_default';
+  dm.config.cloudery_domain = 'twake.app';
+  dm.config.cloudery_user_branch = B2B_BRANCH;
+  dm.config.cloudery_fqdn_attribute = 'twakeWorkspaceUrl';
+  dm.config.cloudery_default_locale = 'en';
+  dm.config.cloudery_workflow_poll_interval_ms = 1;
+  dm.config.cloudery_workflow_max_attempts = 5;
+  dm.config.scim_user_base = USER_BASE;
+  dm.config.scim_user_base_header = 'x-cloudery-org-base';
+  dm.config.scim_base_header_root = B2B_BRANCH;
+  dm.config.scim_user_rdn_attribute = 'uid';
+  dm.config.rabbitmq_url = 'amqp://x';
+}
+
+describe('ClouderyProvision plugin', () => {
+  let dm: DM;
+  let plugin: ClouderyProvision;
+  let rabbit: StubRabbitMq;
+  let ldap: StubLdap;
+
+  before(() => nock.disableNetConnect());
+  after(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  beforeEach(async () => {
+    dm = new DM();
+    configure(dm);
+    await dm.ready;
+    rabbit = new StubRabbitMq();
+    ldap = new StubLdap();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    dm.loadedPlugins['rabbitmq'] = rabbit as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    dm.ldap = ldap as any;
+    plugin = new ClouderyProvision(dm);
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  // Drive a full create: awaited pre-hook then the (normally fire-and-forget)
+  // done hook, both awaited here so assertions see the finished work.
+  async function create(user: ScimUser, req: unknown): Promise<void> {
+    const pre = plugin.hooks?.scimusercreate as (
+      a: [ScimUser, unknown]
+    ) => Promise<unknown>;
+    await pre([user, req]);
+    const done = plugin.hooks?.scimusercreatedone as (
+      u: ScimUser
+    ) => Promise<void>;
+    await done(user);
+  }
+
+  async function remove(id: string, req: unknown): Promise<void> {
+    const pre = plugin.hooks?.scimuserdelete as (
+      a: [string, unknown]
+    ) => Promise<unknown>;
+    await pre([id, req]);
+    const done = plugin.hooks?.scimuserdeletedone as (
+      i: string
+    ) => Promise<void>;
+    await done(id);
+  }
+
+  const user: ScimUser = {
+    schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+    userName: 'john.doe',
+    emails: [{ value: 'john.doe@acme.com', primary: true }],
+    phoneNumbers: [{ value: '+33600000000', primary: true }],
+    displayName: 'John Doe',
+  };
+
+  describe('create', () => {
+    it('provisions via Cloudery, writes the fqdn, and publishes user.created', async () => {
+      let body: Record<string, unknown> = {};
+      const scope = nock(CLOUDERY)
+        .post('/api/v1/instances', b => {
+          body = b as Record<string, unknown>;
+          return true;
+        })
+        .matchHeader('authorization', 'Bearer tok')
+        .reply(200, {
+          id: 'inst-1',
+          fqdn: 'johndoeacme123.twake.app',
+          workflow: 'wf-1',
+        })
+        .get('/api/v1/workflows/wf-1')
+        .reply(200, { status: 'succeeded' });
+
+      await create(user, makeReq('acme123'));
+
+      expect(scope.isDone(), 'cloudery POST + workflow poll').to.equal(true);
+
+      // slug = oidc = normalizeNickname(userName) + orgId (dots stripped)
+      expect(body.slug).to.equal('johndoeacme123');
+      expect(body.oidc).to.equal('johndoeacme123');
+      expect(body.org_id).to.equal('acme123');
+      expect(body.org_domain).to.equal('acme.com');
+      expect(body.offer).to.equal('b2b_twake_default');
+      expect(body.domain).to.equal('twake.app');
+      expect(body.email).to.equal('john.doe@acme.com');
+
+      // fqdn written back to the dedicated attribute on the user entry
+      expect(ldap.modifyCalls).to.have.length(1);
+      expect(ldap.modifyCalls[0].dn).to.equal(
+        `uid=john.doe,${USER_BASE}`
+      );
+      expect(ldap.modifyCalls[0].changes).to.deep.equal({
+        replace: {
+          twakeWorkspaceUrl: 'johndoeacme123.twake.app',
+          twakeOrganizationId: 'acme123',
+        },
+      });
+
+      // published on the same contract as cozyProvision (+ organizationId)
+      expect(rabbit.calls).to.have.length(1);
+      const call = rabbit.calls[0];
+      expect(call.exchange).to.equal('auth');
+      expect(call.routingKey).to.equal('user.created');
+      expect(call.message).to.deep.equal({
+        twakeId: 'john.doe',
+        domain: 'acme.com',
+        organizationDomain: 'acme.com',
+        workplaceFqdn: 'johndoeacme123.twake.app',
+        organizationId: 'acme123',
+        internalEmail: 'john.doe@acme.com',
+        mobile: '+33600000000',
+      });
+    });
+
+    it('trims whitespace in the email and org id before use', async () => {
+      let body: Record<string, unknown> = {};
+      const scope = nock(CLOUDERY)
+        .post('/api/v1/instances', b => {
+          body = b as Record<string, unknown>;
+          return true;
+        })
+        .reply(200, {
+          id: 'inst-1',
+          fqdn: 'johndoeacme123.twake.app',
+          workflow: 'wf-1',
+        })
+        .get('/api/v1/workflows/wf-1')
+        .reply(200, { status: 'succeeded' });
+
+      const spacedUser: ScimUser = {
+        ...user,
+        emails: [{ value: '  john.doe@acme.com  ', primary: true }],
+      };
+      await create(spacedUser, makeReq('  acme123  '));
+
+      expect(scope.isDone()).to.equal(true);
+      expect(body.email).to.equal('john.doe@acme.com');
+      expect(body.internal_email).to.equal('john.doe@acme.com');
+      expect(body.org_domain).to.equal('acme.com');
+      expect(body.org_id).to.equal('acme123');
+      expect(body.slug).to.equal('johndoeacme123');
+      expect(ldap.modifyCalls[0].changes).to.deep.equal({
+        replace: {
+          twakeWorkspaceUrl: 'johndoeacme123.twake.app',
+          twakeOrganizationId: 'acme123',
+        },
+      });
+    });
+
+    it('inserts under the org branch supplied by the base header', async () => {
+      const orgBase = `ou=users,ou=acme123,${B2B_BRANCH}`;
+      nock(CLOUDERY)
+        .post('/api/v1/instances')
+        .reply(200, {
+          id: 'inst-1',
+          fqdn: 'johndoeacme123.twake.app',
+          workflow: 'wf-1',
+        })
+        .get('/api/v1/workflows/wf-1')
+        .reply(200, { status: 'succeeded' });
+
+      await create(user, makeReq('acme123', orgBase));
+
+      expect(ldap.modifyCalls).to.have.length(1);
+      expect(ldap.modifyCalls[0].dn).to.equal(`uid=john.doe,${orgBase}`);
+    });
+
+    it('is inert for users outside the configured B2B branch', async () => {
+      dm.config.scim_user_base = 'ou=users,dc=twake,dc=local'; // not under b2b
+      const p = new ClouderyProvision(dm);
+      const pre = p.hooks?.scimusercreate as (
+        a: [ScimUser, unknown]
+      ) => Promise<unknown>;
+      await pre([user, makeReq('acme123')]);
+      const done = p.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await done(user);
+      // No HTTP intercept registered → a call would throw; none happens.
+      expect(rabbit.calls).to.have.length(0);
+      expect(ldap.modifyCalls).to.have.length(0);
+    });
+
+    it('skips provisioning when the org id header is missing', async () => {
+      await create(user, makeReq(undefined));
+      expect(rabbit.calls).to.have.length(0);
+      expect(ldap.modifyCalls).to.have.length(0);
+    });
+
+    it('does not write fqdn or publish when the workflow fails', async () => {
+      const scope = nock(CLOUDERY)
+        .post('/api/v1/instances')
+        .reply(200, { id: 'inst-1', fqdn: 'x.twake.app', workflow: 'wf-2' })
+        .get('/api/v1/workflows/wf-2')
+        .reply(200, { status: 'failed' });
+
+      await create(user, makeReq('acme123'));
+
+      expect(scope.isDone()).to.equal(true);
+      expect(ldap.modifyCalls).to.have.length(0);
+      expect(rabbit.calls).to.have.length(0);
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes the Cloudery instance and publishes domain.user.deleted', async () => {
+      const dn = `uid=john.doe,${USER_BASE}`;
+      ldap.entries[dn] = {
+        twakeWorkspaceUrl: 'johndoeacme123.twake.app',
+        mail: 'john.doe@acme.com',
+      };
+
+      const scope = nock(CLOUDERY)
+        .get('/api/v2/instances')
+        .query(q => q.fqdn === 'johndoeacme123.twake.app')
+        .reply(200, { items: [{ _id: 'uuid-1' }] })
+        .delete('/api/v1/instances/uuid-1')
+        .query(q => q.user_request === 'true')
+        .reply(200, { workflow: 'wf-del' });
+
+      await remove('john.doe', makeReq('acme123'));
+
+      expect(scope.isDone(), 'search + delete').to.equal(true);
+      expect(rabbit.calls).to.have.length(1);
+      const call = rabbit.calls[0];
+      expect(call.exchange).to.equal('b2b');
+      expect(call.routingKey).to.equal('domain.user.deleted');
+      expect(call.message).to.deep.equal({
+        workplaceFqdn: 'johndoeacme123.twake.app',
+        domain: 'acme.com',
+      });
+    });
+
+    it('does not publish when the Cloudery instance is not found', async () => {
+      const dn = `uid=john.doe,${USER_BASE}`;
+      ldap.entries[dn] = {
+        twakeWorkspaceUrl: 'johndoeacme123.twake.app',
+        mail: 'john.doe@acme.com',
+      };
+
+      const scope = nock(CLOUDERY)
+        .get('/api/v2/instances')
+        .query(q => q.fqdn === 'johndoeacme123.twake.app')
+        .reply(200, { items: [] });
+
+      await remove('john.doe', makeReq('acme123'));
+
+      expect(scope.isDone(), 'lookup attempted').to.equal(true);
+      // teardown did not happen → downstream must not be told it did
+      expect(rabbit.calls).to.have.length(0);
+    });
+
+    it('strips a protocol from a stored workspace url before lookup', async () => {
+      const dn = `uid=john.doe,${USER_BASE}`;
+      ldap.entries[dn] = {
+        twakeWorkspaceUrl: 'https://johndoeacme123.twake.app',
+        mail: 'john.doe@acme.com',
+      };
+
+      const scope = nock(CLOUDERY)
+        .get('/api/v2/instances')
+        .query(q => q.fqdn === 'johndoeacme123.twake.app')
+        .reply(200, { items: [{ _id: 'uuid-1' }] })
+        .delete('/api/v1/instances/uuid-1')
+        .query(q => q.user_request === 'true')
+        .reply(200, { workflow: 'wf-del' });
+
+      await remove('john.doe', makeReq('acme123'));
+
+      expect(scope.isDone(), 'bare fqdn used for lookup').to.equal(true);
+      expect(rabbit.calls[0].message).to.deep.equal({
+        workplaceFqdn: 'johndoeacme123.twake.app',
+        domain: 'acme.com',
+      });
+    });
+
+    it('skips when the entry has no stored fqdn (not ours)', async () => {
+      await remove('jane.doe', makeReq('acme123'));
+      expect(rabbit.calls).to.have.length(0);
+    });
+  });
+});


### PR DESCRIPTION
## Context
- ldap-rest can create B2B users over SCIM, but nothing then provisions their instances in the cloudery / stack or notifies downstream services when a user is created or removed.
- Serving several organizations from one ldap-rest required a separate auth token per organization, because the SCIM insertion branch was derived only from the token identity.

## Solution
- Add the `clouderyProvision` plugin: on SCIM user create/delete under a configured B2B branch, it provisions or tears down the Cloudery instance, writes the returned workspace FQDN and organization id onto the entry, and publishes the `user.created` and `domain.user.deleted` messages.
- Resolve the SCIM insertion branch from a request header, gated to a configured root and never overriding an explicit per-user map entry, so one shared token can serve every organization.
- Expose the plugin settings and the header options as standard config and env keys.
