### PR TITLE
feat: configurable rabbitmq routing keys for provisioning plugins

### DIFF
--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -188,6 +188,8 @@ export interface Config {
   cozy_apps?: string;
   cozy_auth_exchange?: string;
   cozy_b2b_exchange?: string;
+  cozy_user_created_routing_key?: string;
+  cozy_user_deleted_routing_key?: string;
   cloudery_manager_url?: string;
   cloudery_manager_token?: string;
   cloudery_offer?: string;
@@ -486,6 +488,16 @@ const configArgs: ConfigTemplate = [
   ['--cozy-apps', 'DM_COZY_APPS', 'home,drive,settings,notes,dataproxy'],
   ['--cozy-auth-exchange', 'DM_COZY_AUTH_EXCHANGE', 'auth'],
   ['--cozy-b2b-exchange', 'DM_COZY_B2B_EXCHANGE', 'b2b'],
+  [
+    '--cozy-user-created-routing-key',
+    'DM_COZY_USER_CREATED_ROUTING_KEY',
+    'user.created',
+  ],
+  [
+    '--cozy-user-deleted-routing-key',
+    'DM_COZY_USER_DELETED_ROUTING_KEY',
+    'domain.user.deleted',
+  ],
 
   // clouderyProvision plugin
   ['--cloudery-manager-url', 'DM_CLOUDERY_MANAGER_URL', ''],

--- a/src/plugins/twake/clouderyProvision.ts
+++ b/src/plugins/twake/clouderyProvision.ts
@@ -69,6 +69,8 @@ export default class ClouderyProvision extends DmPlugin {
   private readonly rdnAttribute: string;
   private readonly authExchange: string;
   private readonly b2bExchange: string;
+  private readonly userCreatedRoutingKey: string;
+  private readonly userDeletedRoutingKey: string;
   private readonly pollIntervalMs: number;
   private readonly maxPollAttempts: number;
 
@@ -104,6 +106,10 @@ export default class ClouderyProvision extends DmPlugin {
     this.rdnAttribute = (cfg.scim_user_rdn_attribute as string) || 'uid';
     this.authExchange = (cfg.cozy_auth_exchange as string) || 'auth';
     this.b2bExchange = (cfg.cozy_b2b_exchange as string) || 'b2b';
+    this.userCreatedRoutingKey =
+      (cfg.cozy_user_created_routing_key as string) || 'user.created';
+    this.userDeletedRoutingKey =
+      (cfg.cozy_user_deleted_routing_key as string) || 'domain.user.deleted';
     this.pollIntervalMs =
       Number(cfg.cloudery_workflow_poll_interval_ms) || 2000;
     this.maxPollAttempts = Number(cfg.cloudery_workflow_max_attempts) || 60;
@@ -468,7 +474,11 @@ export default class ClouderyProvision extends DmPlugin {
     if (p.mobile) message.mobile = p.mobile;
 
     try {
-      await rabbitmq.publish(this.authExchange, 'user.created', message);
+      await rabbitmq.publish(
+        this.authExchange,
+        this.userCreatedRoutingKey,
+        message
+      );
     } catch (err) {
       this.logger.error({
         plugin: this.name,
@@ -487,7 +497,7 @@ export default class ClouderyProvision extends DmPlugin {
     const rabbitmq = this.requirePlugin<RabbitMq>('rabbitmq');
     if (!rabbitmq) return;
     try {
-      await rabbitmq.publish(this.b2bExchange, 'domain.user.deleted', {
+      await rabbitmq.publish(this.b2bExchange, this.userDeletedRoutingKey, {
         workplaceFqdn: fqdn,
         domain,
       });

--- a/src/plugins/twake/cozyProvision.ts
+++ b/src/plugins/twake/cozyProvision.ts
@@ -43,6 +43,8 @@ export default class CozyProvision extends DmPlugin {
   private readonly cozyApps: string;
   private readonly authExchange: string;
   private readonly b2bExchange: string;
+  private readonly userCreatedRoutingKey: string;
+  private readonly userDeletedRoutingKey: string;
   private readonly cozyAdminAuthHeader: string;
 
   constructor(server: DM) {
@@ -64,6 +66,11 @@ export default class CozyProvision extends DmPlugin {
     this.cozyApps = (this.config.cozy_apps as string) ?? '';
     this.authExchange = (this.config.cozy_auth_exchange as string) || 'auth';
     this.b2bExchange = (this.config.cozy_b2b_exchange as string) || 'b2b';
+    this.userCreatedRoutingKey =
+      (this.config.cozy_user_created_routing_key as string) || 'user.created';
+    this.userDeletedRoutingKey =
+      (this.config.cozy_user_deleted_routing_key as string) ||
+      'domain.user.deleted';
     this.cozyAdminAuthHeader = `Basic ${Buffer.from(
       `${this.cozyAdminUser}:${this.cozyAdminPassphrase}`
     ).toString('base64')}`;
@@ -333,13 +340,17 @@ export default class CozyProvision extends DmPlugin {
     if (mobile) message.mobile = mobile;
 
     try {
-      await rabbitmq.publish(this.authExchange, 'user.created', message);
+      await rabbitmq.publish(
+        this.authExchange,
+        this.userCreatedRoutingKey,
+        message
+      );
       this.logger.info({
         plugin: this.name,
         event: 'publishUserCreated',
         result: 'success',
         exchange: this.authExchange,
-        routingKey: 'user.created',
+        routingKey: this.userCreatedRoutingKey,
         twakeId: id,
       });
     } catch (err) {
@@ -377,13 +388,17 @@ export default class CozyProvision extends DmPlugin {
     };
 
     try {
-      await rabbitmq.publish(this.b2bExchange, 'domain.user.deleted', message);
+      await rabbitmq.publish(
+        this.b2bExchange,
+        this.userDeletedRoutingKey,
+        message
+      );
       this.logger.info({
         plugin: this.name,
         event: 'publishUserDeleted',
         result: 'success',
         exchange: this.b2bExchange,
-        routingKey: 'domain.user.deleted',
+        routingKey: this.userDeletedRoutingKey,
         workplaceFqdn: message.workplaceFqdn,
       });
     } catch (err) {

--- a/test/plugins/twake/clouderyProvision.test.ts
+++ b/test/plugins/twake/clouderyProvision.test.ts
@@ -251,6 +251,31 @@ describe('ClouderyProvision plugin', () => {
       expect(ldap.modifyCalls[0].dn).to.equal(`uid=john.doe,${orgBase}`);
     });
 
+    it('publishes with a configured routing key', async () => {
+      dm.config.cozy_user_created_routing_key = 'custom.user.created';
+      const p = new ClouderyProvision(dm);
+      nock(CLOUDERY)
+        .post('/api/v1/instances')
+        .reply(200, {
+          id: 'inst-1',
+          fqdn: 'johndoeacme123.twake.app',
+          workflow: 'wf-1',
+        })
+        .get('/api/v1/workflows/wf-1')
+        .reply(200, { status: 'succeeded' });
+
+      const pre = p.hooks?.scimusercreate as (
+        a: [ScimUser, unknown]
+      ) => Promise<unknown>;
+      await pre([user, makeReq('acme123')]);
+      const done = p.hooks?.scimusercreatedone as (u: ScimUser) => Promise<void>;
+      await done(user);
+
+      expect(rabbit.calls).to.have.length(1);
+      expect(rabbit.calls[0].exchange).to.equal('auth');
+      expect(rabbit.calls[0].routingKey).to.equal('custom.user.created');
+    });
+
     it('is inert for users outside the configured B2B branch', async () => {
       dm.config.scim_user_base = 'ou=users,dc=twake,dc=local'; // not under b2b
       const p = new ClouderyProvision(dm);

--- a/test/plugins/twake/cozyProvision.test.ts
+++ b/test/plugins/twake/cozyProvision.test.ts
@@ -116,6 +116,33 @@ describe('CozyProvision plugin', () => {
       });
     });
 
+    it('publishes with a configured routing key', async () => {
+      dm.config.cozy_user_created_routing_key = 'custom.user.created';
+      const p = new CozyProvision(dm);
+      const scope = nock(COZY_URL)
+        .post('/instances')
+        .query(true)
+        .reply(201, { ok: true })
+        .patch('/instances/ivy.twake.local')
+        .query({ OnboardingFinished: 'true' })
+        .reply(200, { ok: true });
+
+      const user: ScimUser = {
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: 'ivy',
+      };
+
+      const hook = p.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await hook(user);
+
+      expect(scope.isDone()).to.be.true;
+      expect(rabbit.calls).to.have.length(1);
+      expect(rabbit.calls[0].exchange).to.equal('auth');
+      expect(rabbit.calls[0].routingKey).to.equal('custom.user.created');
+    });
+
     it('respects cozy_apps override', async () => {
       dm.config.cozy_apps = 'home,drive';
       const p = new CozyProvision(dm);


### PR DESCRIPTION
## Context
- Both provisioning plugins publish lifecycle events to RabbitMQ, but the routing keys `user.created` and `domain.user.deleted` were hardcoded.
- A deployment whose broker expects different routing keys had no way to adapt without patching the plugins.

## Solution
- Add two shared config keys (`DM_COZY_USER_CREATED_ROUTING_KEY`, `DM_COZY_USER_DELETED_ROUTING_KEY`) defaulting to the current values.
- Both `cozyProvision` and `clouderyProvision` read them, so they stay in sync and behavior is unchanged unless overridden. Exchanges remain on the existing `DM_COZY_*` keys.
