### PR TITLE
feat: set org role and phones on cloudery-provisioned users

### DIFF
--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -196,8 +196,12 @@ export interface Config {
   cloudery_domain?: string;
   cloudery_user_branch?: string;
   cloudery_org_id_header?: string;
+  cloudery_org_role_header?: string;
+  cloudery_default_org_role?: string;
   cloudery_fqdn_attribute?: string;
   cloudery_org_id_attribute?: string;
+  cloudery_org_role_attribute?: string;
+  cloudery_phones_attribute?: string;
   cloudery_default_locale?: string;
   cloudery_workflow_poll_interval_ms?: number;
   cloudery_workflow_max_attempts?: number;
@@ -511,6 +515,12 @@ const configArgs: ConfigTemplate = [
     'x-cloudery-org-id',
   ],
   [
+    '--cloudery-org-role-header',
+    'DM_CLOUDERY_ORG_ROLE_HEADER',
+    'x-cloudery-org-role',
+  ],
+  ['--cloudery-default-org-role', 'DM_CLOUDERY_DEFAULT_ORG_ROLE', 'member'],
+  [
     '--cloudery-fqdn-attribute',
     'DM_CLOUDERY_FQDN_ATTRIBUTE',
     'twakeWorkspaceUrl',
@@ -519,6 +529,16 @@ const configArgs: ConfigTemplate = [
     '--cloudery-org-id-attribute',
     'DM_CLOUDERY_ORG_ID_ATTRIBUTE',
     'twakeOrganizationId',
+  ],
+  [
+    '--cloudery-org-role-attribute',
+    'DM_CLOUDERY_ORG_ROLE_ATTRIBUTE',
+    'twakeOrganizationRole',
+  ],
+  [
+    '--cloudery-phones-attribute',
+    'DM_CLOUDERY_PHONES_ATTRIBUTE',
+    'twakePhones',
   ],
   ['--cloudery-default-locale', 'DM_CLOUDERY_DEFAULT_LOCALE', 'en'],
   [

--- a/src/plugins/twake/clouderyProvision.ts
+++ b/src/plugins/twake/clouderyProvision.ts
@@ -13,6 +13,14 @@
  * the core `BaseResolver` (also from a header). The operator supplies the email
  * in the SCIM body, `org_domain` is its domain, and `slug` = `oidc` =
  * normalizeNickname(userName) + orgId (dots stripped).
+ *
+ * Alongside the FQDN, the post-create write stamps two attributes the admin
+ * panel reads off the user entry: `twakeOrganizationRole` and (when present)
+ * `twakePhones`. The role is per-request via a header, so a single batch import
+ * can be all members and the next all admins; it accepts `admin`, `owner`, or
+ * `member` and falls back to `cloudery_default_org_role` (`member`) when the
+ * header is absent or unknown. `twakePhones` holds the SCIM phone numbers as the
+ * JSON the panel expects: `[{ "number": "+33...", "primary": true }]`.
  */
 import { setTimeout as sleep } from 'node:timers/promises';
 
@@ -38,6 +46,7 @@ interface ClouderyInstanceResponse {
 interface CreateContext {
   orgId: string;
   email: string;
+  role: string;
   base: string;
   ts: number;
 }
@@ -51,6 +60,10 @@ interface DeleteContext {
 // leak its captured context; prune anything older than this.
 const STASH_TTL_MS = 5 * 60 * 1000;
 
+// Roles the admin panel recognises for the `twakeOrganizationRole` attribute;
+// anything else from the header is rejected in favour of the configured default.
+const VALID_ORG_ROLES = new Set(['admin', 'owner', 'member']);
+
 export default class ClouderyProvision extends DmPlugin {
   name = 'clouderyProvision';
   roles: Role[] = ['consistency'] as const;
@@ -63,8 +76,12 @@ export default class ClouderyProvision extends DmPlugin {
   private readonly clouderyDomain: string;
   private readonly userBranch: string;
   private readonly orgIdHeader: string;
+  private readonly orgRoleHeader: string;
+  private readonly defaultOrgRole: string;
   private readonly fqdnAttribute: string;
   private readonly orgIdAttribute: string;
+  private readonly orgRoleAttribute: string;
+  private readonly phonesAttribute: string;
   private readonly defaultLocale: string;
   private readonly rdnAttribute: string;
   private readonly authExchange: string;
@@ -98,10 +115,33 @@ export default class ClouderyProvision extends DmPlugin {
     this.orgIdHeader = (
       (cfg.cloudery_org_id_header as string) || 'x-cloudery-org-id'
     ).toLowerCase();
+    this.orgRoleHeader = (
+      (cfg.cloudery_org_role_header as string) || 'x-cloudery-org-role'
+    ).toLowerCase();
+    // The default is the fallback for an absent/unknown header, so it must be a
+    // valid, lower-cased role itself; otherwise a misconfigured default would
+    // bypass the same validation resolveRole() applies to header values.
+    const configuredRole =
+      (cfg.cloudery_default_org_role as string) || 'member';
+    const normalizedRole = configuredRole.trim().toLowerCase();
+    if (VALID_ORG_ROLES.has(normalizedRole)) {
+      this.defaultOrgRole = normalizedRole;
+    } else {
+      this.defaultOrgRole = 'member';
+      this.logger.warn(
+        `${this.name}: cloudery_default_org_role "${configuredRole}" is not one of ${[
+          ...VALID_ORG_ROLES,
+        ].join(', ')} — using "member"`
+      );
+    }
     this.fqdnAttribute =
       (cfg.cloudery_fqdn_attribute as string) || 'twakeWorkspaceUrl';
     this.orgIdAttribute =
       (cfg.cloudery_org_id_attribute as string) || 'twakeOrganizationId';
+    this.orgRoleAttribute =
+      (cfg.cloudery_org_role_attribute as string) || 'twakeOrganizationRole';
+    this.phonesAttribute =
+      (cfg.cloudery_phones_attribute as string) || 'twakePhones';
     this.defaultLocale = (cfg.cloudery_default_locale as string) || 'en';
     this.rdnAttribute = (cfg.scim_user_rdn_attribute as string) || 'uid';
     this.authExchange = (cfg.cozy_auth_exchange as string) || 'auth';
@@ -190,6 +230,7 @@ export default class ClouderyProvision extends DmPlugin {
     this.createStash.set(cleanEmail.toLowerCase(), {
       orgId: orgId.trim(),
       email: cleanEmail,
+      role: this.resolveRole(req, userName),
       base,
       ts: Date.now(),
     });
@@ -214,6 +255,7 @@ export default class ClouderyProvision extends DmPlugin {
     const orgDomain = emailDomain(email);
     const slug = normalizeNickname(userName) + ctx.orgId;
     const mobile = this.extractPrimaryPhone(user);
+    const phones = this.extractPhones(user);
     const publicName = this.extractPublicName(user) || userName;
 
     const log = {
@@ -265,13 +307,19 @@ export default class ClouderyProvision extends DmPlugin {
 
     const fqdn = instance.fqdn;
     const dn = `${this.rdnAttribute}=${escapeDnValue(userName)},${ctx.base}`;
+    // Role and phones live on the user entry for the admin panel to read; they
+    // are not part of the Cloudery create payload. Phones are stored as the JSON
+    // the panel expects ([{ number, primary }]) and only when present.
+    const replace: Record<string, string> = {
+      [this.fqdnAttribute]: fqdn,
+      [this.orgIdAttribute]: ctx.orgId,
+      [this.orgRoleAttribute]: ctx.role,
+    };
+    if (phones.length > 0) {
+      replace[this.phonesAttribute] = JSON.stringify(phones);
+    }
     try {
-      await this.server.ldap.modify(dn, {
-        replace: {
-          [this.fqdnAttribute]: fqdn,
-          [this.orgIdAttribute]: ctx.orgId,
-        },
-      });
+      await this.server.ldap.modify(dn, { replace });
     } catch (err) {
       // Instance exists, so still publish; the write failure would break the
       // later delete lookup, so surface it.
@@ -528,6 +576,27 @@ export default class ClouderyProvision extends DmPlugin {
     return typeof q === 'string' && q.length > 0 ? q : undefined;
   }
 
+  /**
+   * Per-request org role from the header (so one batch import can be all admins
+   * and the next all members), validated against {@link VALID_ORG_ROLES}. An
+   * absent or unknown role falls back to the configured default rather than
+   * failing the import.
+   */
+  private resolveRole(req: ReqWithUser | undefined, userName: string): string {
+    const raw = this.readHeader(req, this.orgRoleHeader)?.trim().toLowerCase();
+    if (!raw) return this.defaultOrgRole;
+    if (!VALID_ORG_ROLES.has(raw)) {
+      this.logger.warn({
+        plugin: this.name,
+        event: 'captureCreate',
+        userName,
+        message: `Unknown ${this.orgRoleHeader} "${raw}" — falling back to ${this.defaultOrgRole}`,
+      });
+      return this.defaultOrgRole;
+    }
+    return raw;
+  }
+
   private isAtOrUnder(dn: string, parent: string): boolean {
     return (
       dn.trim().toLowerCase() === parent.trim().toLowerCase() ||
@@ -564,6 +633,17 @@ export default class ClouderyProvision extends DmPlugin {
     const primary = phones.find(p => p.primary);
     const value = (primary || phones[0]).value;
     return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+
+  /** All phone numbers, shaped for the `twakePhones` attribute the panel reads. */
+  private extractPhones(
+    user: ScimUser
+  ): { number: string; primary: boolean }[] {
+    const phones = user.phoneNumbers;
+    if (!phones || phones.length === 0) return [];
+    return phones
+      .filter(p => typeof p.value === 'string' && p.value.trim().length > 0)
+      .map(p => ({ number: p.value.trim(), primary: Boolean(p.primary) }));
   }
 
   private extractPublicName(user: ScimUser): string | null {

--- a/test/plugins/twake/clouderyProvision.test.ts
+++ b/test/plugins/twake/clouderyProvision.test.ts
@@ -52,10 +52,11 @@ class StubLdap {
 }
 
 // Express-like request stub: carries the org id / base headers and the token.
-function makeReq(orgId?: string, orgBase?: string): unknown {
+function makeReq(orgId?: string, orgBase?: string, role?: string): unknown {
   const headers: Record<string, string> = {};
   if (orgId) headers['x-cloudery-org-id'] = orgId;
   if (orgBase) headers['x-cloudery-org-base'] = orgBase;
+  if (role) headers['x-cloudery-org-role'] = role;
   return {
     user: 'b2b-token',
     headers,
@@ -172,13 +173,22 @@ describe('ClouderyProvision plugin', () => {
       expect(body.domain).to.equal('twake.app');
       expect(body.email).to.equal('john.doe@acme.com');
 
-      // fqdn written back to the dedicated attribute on the user entry
+      // role/phones are NOT sent to Cloudery; they are stamped on the entry
+      expect(body).to.not.have.property('twakeOrganizationRole');
+      expect(body).to.not.have.property('twakePhones');
+
+      // fqdn, org id, role (default member) and phones written to the entry for
+      // the admin panel to read
       expect(ldap.modifyCalls).to.have.length(1);
       expect(ldap.modifyCalls[0].dn).to.equal(`uid=john.doe,${USER_BASE}`);
       expect(ldap.modifyCalls[0].changes).to.deep.equal({
         replace: {
           twakeWorkspaceUrl: 'johndoeacme123.twake.app',
           twakeOrganizationId: 'acme123',
+          twakeOrganizationRole: 'member',
+          twakePhones: JSON.stringify([
+            { number: '+33600000000', primary: true },
+          ]),
         },
       });
 
@@ -229,8 +239,129 @@ describe('ClouderyProvision plugin', () => {
         replace: {
           twakeWorkspaceUrl: 'johndoeacme123.twake.app',
           twakeOrganizationId: 'acme123',
+          twakeOrganizationRole: 'member',
+          twakePhones: JSON.stringify([
+            { number: '+33600000000', primary: true },
+          ]),
         },
       });
+    });
+
+    it('omits twakePhones when the user has no phone numbers', async () => {
+      const scope = nock(CLOUDERY)
+        .post('/api/v1/instances')
+        .reply(200, {
+          id: 'inst-1',
+          fqdn: 'johndoeacme123.twake.app',
+          workflow: 'wf-1',
+        })
+        .get('/api/v1/workflows/wf-1')
+        .reply(200, { status: 'succeeded' });
+
+      const { phoneNumbers: _omitted, ...noPhoneUser } = user;
+      await create(noPhoneUser as ScimUser, makeReq('acme123'));
+
+      expect(scope.isDone()).to.equal(true);
+      const changes = ldap.modifyCalls[0].changes as {
+        replace: Record<string, unknown>;
+      };
+      expect(changes.replace.twakeOrganizationRole).to.equal('member');
+      expect(changes.replace).to.not.have.property('twakePhones');
+    });
+
+    it('uses the role from the request header when supplied', async () => {
+      const scope = nock(CLOUDERY)
+        .post('/api/v1/instances')
+        .reply(200, {
+          id: 'inst-1',
+          fqdn: 'johndoeacme123.twake.app',
+          workflow: 'wf-1',
+        })
+        .get('/api/v1/workflows/wf-1')
+        .reply(200, { status: 'succeeded' });
+
+      await create(user, makeReq('acme123', undefined, 'owner'));
+
+      expect(scope.isDone()).to.equal(true);
+      const changes = ldap.modifyCalls[0].changes as {
+        replace: Record<string, unknown>;
+      };
+      expect(changes.replace.twakeOrganizationRole).to.equal('owner');
+    });
+
+    it('falls back to the default role for an unknown header value', async () => {
+      const scope = nock(CLOUDERY)
+        .post('/api/v1/instances')
+        .reply(200, {
+          id: 'inst-1',
+          fqdn: 'johndoeacme123.twake.app',
+          workflow: 'wf-1',
+        })
+        .get('/api/v1/workflows/wf-1')
+        .reply(200, { status: 'succeeded' });
+
+      await create(user, makeReq('acme123', undefined, 'superuser'));
+
+      expect(scope.isDone()).to.equal(true);
+      const changes = ldap.modifyCalls[0].changes as {
+        replace: Record<string, unknown>;
+      };
+      expect(changes.replace.twakeOrganizationRole).to.equal('member');
+    });
+
+    it('normalises an invalid configured default role to member', async () => {
+      dm.config.cloudery_default_org_role = 'Administrator';
+      const p = new ClouderyProvision(dm);
+      nock(CLOUDERY)
+        .post('/api/v1/instances')
+        .reply(200, {
+          id: 'inst-1',
+          fqdn: 'johndoeacme123.twake.app',
+          workflow: 'wf-1',
+        })
+        .get('/api/v1/workflows/wf-1')
+        .reply(200, { status: 'succeeded' });
+
+      const pre = p.hooks?.scimusercreate as (
+        a: [ScimUser, unknown]
+      ) => Promise<unknown>;
+      await pre([user, makeReq('acme123')]);
+      const done = p.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await done(user);
+
+      const changes = ldap.modifyCalls[0].changes as {
+        replace: Record<string, unknown>;
+      };
+      expect(changes.replace.twakeOrganizationRole).to.equal('member');
+    });
+
+    it('trims whitespace and casing from a header role and phone numbers', async () => {
+      const scope = nock(CLOUDERY)
+        .post('/api/v1/instances')
+        .reply(200, {
+          id: 'inst-1',
+          fqdn: 'johndoeacme123.twake.app',
+          workflow: 'wf-1',
+        })
+        .get('/api/v1/workflows/wf-1')
+        .reply(200, { status: 'succeeded' });
+
+      const spacedUser: ScimUser = {
+        ...user,
+        phoneNumbers: [{ value: '  +33600000000  ', primary: true }],
+      };
+      await create(spacedUser, makeReq('acme123', undefined, '  ADMIN  '));
+
+      expect(scope.isDone()).to.equal(true);
+      const changes = ldap.modifyCalls[0].changes as {
+        replace: Record<string, unknown>;
+      };
+      expect(changes.replace.twakeOrganizationRole).to.equal('admin');
+      expect(changes.replace.twakePhones).to.equal(
+        JSON.stringify([{ number: '+33600000000', primary: true }])
+      );
     });
 
     it('inserts under the org branch supplied by the base header', async () => {
@@ -268,7 +399,9 @@ describe('ClouderyProvision plugin', () => {
         a: [ScimUser, unknown]
       ) => Promise<unknown>;
       await pre([user, makeReq('acme123')]);
-      const done = p.hooks?.scimusercreatedone as (u: ScimUser) => Promise<void>;
+      const done = p.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
       await done(user);
 
       expect(rabbit.calls).to.have.length(1);


### PR DESCRIPTION
## Problem

- B2B users provisioned through the cloudery plugin had no organization role stored on their entry, so the admin panel could not distinguish members from admins or owners.
- Phone numbers sent in the SCIM request were not exposed in the structured form the panel reads.

## Solution

- Stamp `twakeOrganizationRole` and (when present) `twakePhones` onto the user entry alongside the existing FQDN and org id.
- Set the role per request from the `x-cloudery-org-role` header, so one batch import can be all members and the next all admins. It accepts `admin`, `owner`, or `member` and falls back to a configurable default, with both the header value and the default trimmed, lower cased, and validated so an invalid value can never reach LDAP.
- Store phones as the JSON the panel expects, trimming each number.

The header names, default role, and target attributes are all configurable.