### PR TITLE
fix: ignore appAccounts consistency events from the applicative branch

### DIFF
--- a/src/plugins/twake/appAccountsConsistency.ts
+++ b/src/plugins/twake/appAccountsConsistency.ts
@@ -81,6 +81,30 @@ export default class AppAccountsConsistency extends DmPlugin {
     return this.operationalAttributes.includes(key);
   }
 
+  /**
+   * Whether a DN belongs to the applicative branch this plugin manages.
+   *
+   * Entries under `applicative_account_base` are *outputs* of this plugin
+   * (principal and app accounts), never source users. Since every LDAP write
+   * re-fires the change hooks — including our own writes — we must ignore
+   * events originating in this branch. Otherwise creating/renaming/deleting an
+   * applicative entry would re-enter `onLdapMailChange` and cause spurious
+   * `AlreadyExists` attempts or a re-entrant deletion cascade during a mail
+   * change.
+   *
+   * @param dn - The DN that changed
+   * @returns true if `dn` is the applicative base itself or sits below it
+   */
+  private isInApplicativeBranch(dn: string): boolean {
+    // Loose DN normalisation: lowercase and collapse the optional whitespace
+    // around RDN separators so `uid=x, ou=AppAccounts ,dc=stg` still matches.
+    const norm = (s: string): string =>
+      s.toLowerCase().replace(/\s*,\s*/g, ',').trim();
+    const base = norm(this.applicativeAccountBase);
+    const target = norm(dn);
+    return target === base || target.endsWith(`,${base}`);
+  }
+
   hooks: Hooks = {
     /**
      * Handle mail changes, including creation (null → mail) and deletion (mail → null)
@@ -90,6 +114,17 @@ export default class AppAccountsConsistency extends DmPlugin {
       oldMail: AttributeValue | null,
       newMail: AttributeValue | null
     ) => {
+      // Ignore changes on our own applicative entries: they are managed by
+      // this plugin, never source users. This prevents re-entrant hook firing
+      // (idempotent AlreadyExists churn, or a deletion cascade during a mail
+      // change) when the applicative branch sits under `ldap_base`.
+      if (this.isInApplicativeBranch(dn)) {
+        this.logger.debug(
+          `${this.name}: Ignoring mail change for ${dn} (in applicative branch)`
+        );
+        return;
+      }
+
       try {
         const oldMailStr =
           oldMail !== null && oldMail !== undefined

--- a/src/plugins/twake/appAccountsConsistency.ts
+++ b/src/plugins/twake/appAccountsConsistency.ts
@@ -120,7 +120,7 @@ export default class AppAccountsConsistency extends DmPlugin {
       // change) when the applicative branch sits under `ldap_base`.
       if (this.isInApplicativeBranch(dn)) {
         this.logger.debug(
-          `${this.name}: Ignoring mail change for ${dn} (in applicative branch)`
+          `${this.name}: Ignoring mail change event originating in the applicative branch`
         );
         return;
       }

--- a/test/plugins/twake/appAccountsConsistency.test.ts
+++ b/test/plugins/twake/appAccountsConsistency.test.ts
@@ -674,6 +674,64 @@ describe('App Accounts Consistency Plugin', function () {
     });
   });
 
+  describe('Re-entrance guard', () => {
+    it('should ignore mail-change events originating in the applicative branch (no cascade)', async function () {
+      this.timeout(10000);
+
+      // Create user → principal applicative account is auto-created
+      await dm.ldap.add(testUserDN, {
+        objectClass: 'inetOrgPerson',
+        uid: `testuser-${timestamp}`,
+        cn: 'Test User',
+        sn: 'User',
+        mail: `testuser-${timestamp}@example.com`,
+      });
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      // Create two app accounts directly, as the API plugin would
+      const appAccount1DN = `uid=testuser-${timestamp}_c11111111,${applicativeBase}`;
+      const appAccount2DN = `uid=testuser-${timestamp}_c22222222,${applicativeBase}`;
+      const appAccounts: [string, string][] = [
+        [appAccount1DN, `testuser-${timestamp}_c11111111`],
+        [appAccount2DN, `testuser-${timestamp}_c22222222`],
+      ];
+      for (const [dn, uid] of appAccounts) {
+        await dm.ldap.add(dn, {
+          objectClass: 'inetOrgPerson',
+          uid,
+          cn: 'Test User',
+          sn: 'User',
+          mail: `testuser-${timestamp}@example.com`,
+          userPassword: 'A1b2@-C3d4$-E5f6!-G7h8#-J9k0%-L1m2@',
+        });
+      }
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Simulate the hook firing for a DELETE on the principal account, whose DN
+      // sits in the applicative branch. Without the guard this would call
+      // deleteApplicativeAccount(mail) and cascade-delete every entry matching
+      // the mail (principal + both app accounts).
+      await appAccountsConsistency.hooks.onLdapMailChange!(
+        testApplicativeDN,
+        `testuser-${timestamp}@example.com`,
+        null
+      );
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // The guard must have made it a no-op: all entries are still present.
+      for (const dn of [testApplicativeDN, appAccount1DN, appAccount2DN]) {
+        const result = await dm.ldap.search(
+          { scope: 'base', paged: false },
+          dn
+        );
+        expect(
+          (result as any).searchEntries,
+          `${dn} should still exist (no cascade)`
+        ).to.have.lengthOf(1);
+      }
+    });
+  });
+
   describe('Configuration', () => {
     it('should throw error if applicative_account_base is not configured', () => {
       const dmTest = new DM();


### PR DESCRIPTION
## Problème

Les hooks `onLdap*` se déclenchent sur **toute** écriture LDAP, y compris celles que `appAccountsConsistency` effectue lui-même dans la branche applicative (`applicative_account_base`).

Quand `applicative_account_base` se trouve **sous `ldap_base`**, ces écritures internes ré-entrent dans `onLdapMailChange`, ce qui provoque :
- du bruit `AlreadyExists` idempotent (création de comptes) ;
- surtout, lors d'un **changement de mail**, une **cascade de suppressions ré-entrante** : le premier `ldap.delete` du principal déclenche `deleteApplicativeAccount(mail)` qui supprime toutes les entrées restantes `(mail=…)`, pouvant faire perdre les comptes applicatifs d'un utilisateur.

Les hooks étant lancés en *fire-and-forget* (`void launchHooks`), cette ré-entrance s'exécute en concurrence de l'opération d'origine.

## Correctif (ciblé)

Garde en tête de `onLdapMailChange` : si le DN de l'événement appartient à la branche applicative (`isInApplicativeBranch(dn)`), on ignore l'événement. Ces entrées sont des **sorties** du plugin, jamais des utilisateurs source.

- `isInApplicativeBranch(dn)` normalise les DN (minuscules + espaces autour des virgules) et teste l'égalité avec la base ou l'appartenance au sous-arbre.

## Tests

- Nouveau test déterministe `Re-entrance guard` : crée un user (→ principal) + 2 comptes applicatifs, simule `onLdapMailChange(principal, mail → null)` (delete dans la branche cible) et vérifie qu'aucune entrée n'est supprimée.
- Vérifié anti-faux-positif : en neutralisant le garde, le test échoue avec `NoSuchObjectError` (cascade).
- `appAccountsConsistency` : 13 passing — `appAccountsApi` : 14 passing (pas de régression).

## Note

`james.ts` et `drive.ts` écoutent aussi `onLdapMailChange` et restent susceptibles de réagir aux écritures dans la branche applicative. Si nécessaire, on pourra généraliser le filtrage au niveau de `onChange` (option non retenue ici pour rester minimal).