### PR TITLE
fix: drop unused token-auth dependency in appAccountsApi (#83)

### DIFF
--- a/src/plugins/twake/appAccountsApi.ts
+++ b/src/plugins/twake/appAccountsApi.ts
@@ -81,7 +81,6 @@ export default class AppAccountsApi extends DmPlugin {
   name = 'appAccountsApi';
   roles: Role[] = ['api', 'configurable'] as const;
   dependencies = {
-    authToken: 'core/auth/token',
     appAccountsConsistency: 'core/twake/appAccountsConsistency',
   };
 


### PR DESCRIPTION
## Context

Closes #83. The app-accounts endpoints (`core/twake/appAccountsApi`) are consumed by backend services that authenticate to ldap-rest with HMAC (`core/auth/hmac`), like every other endpoint.

## Root cause

`appAccountsApi` declared `dependencies = { authToken: 'core/auth/token' }`. Dependencies are auto-loaded, and auth plugins register global middleware in load order, so `core/auth/token` ended up registered just before the app-accounts routes. A request carrying a valid HMAC `Authorization` header (and no Bearer token) then got `401` on `/api/v1/users/:user/app-accounts`, while every other endpoint succeeded with the same credentials.

The plugin never reads `req.user` or the token, so this dependency enabled nothing — it only blocked HMAC-only deployments. Every other API plugin (`groups`, `organizations`, `scim`) declares no auth dependency and relies on the deployment's configured auth.

## Change

- **`appAccountsApi`**: drop the unused `authToken: 'core/auth/token'` dependency (the `appAccountsConsistency` dependency is kept).

## Verification

- `npm run check:ts`: OK.
- No reference to `authToken` / the token anywhere else in the plugin.
- The app-accounts endpoints now fall under the deployment's configured authentication (HMAC, token, …) like the rest of the API.

Affected version: 0.3.9.
