### PR TITLE
fix: propagate request context to authz hooks on SCIM and delete writes (#80)

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -44,7 +44,7 @@ export interface Hooks {
     args: [string, ModifyRequest, number]
   ) => MaybePromise<void>;
   // delete
-  ldapdeleterequest?: ChainedHook<string | string[]>;
+  ldapdeleterequest?: ChainedHook<[string | string[], Request?]>;
   ldapdeletedone?: (dn: string | string[]) => MaybePromise<void>;
   // rename
   ldaprenamerequest?: ChainedHook<[string, string, Request?]>;

--- a/src/lib/authz/base.ts
+++ b/src/lib/authz/base.ts
@@ -117,7 +117,7 @@ export default abstract class AuthzBase extends DmPlugin {
             );
             if (!sourcePermissions.read) {
               throw new Error(
-                `[authz-forbidden] User ${req!.user} does not have read permission for source branch ${sourceBranch}`
+                `User ${req!.user} does not have read permission for source branch ${sourceBranch}`
               );
             }
           }
@@ -131,7 +131,7 @@ export default abstract class AuthzBase extends DmPlugin {
           );
           if (!sourcePermissions.read) {
             throw new Error(
-              `[authz-forbidden] User ${req!.user} does not have read permission for source branch ${sourceBranch}`
+              `User ${req!.user} does not have read permission for source branch ${sourceBranch}`
             );
           }
         }
@@ -145,7 +145,7 @@ export default abstract class AuthzBase extends DmPlugin {
         const destPermissions = await this.getUserPermissions(user, destBranch);
         if (!destPermissions.write) {
           throw new Error(
-            `[authz-forbidden] User ${req!.user} does not have write permission for destination branch ${destBranch}`
+            `User ${req!.user} does not have write permission for destination branch ${destBranch}`
           );
         }
       } else {
@@ -317,7 +317,7 @@ export default abstract class AuthzBase extends DmPlugin {
       );
       if (!sourcePermissions.read) {
         throw new Error(
-          `[authz-forbidden] User ${req!.user} does not have read permission for source branch ${sourceBranch}`
+          `User ${req!.user} does not have read permission for source branch ${sourceBranch}`
         );
       }
 
@@ -325,7 +325,7 @@ export default abstract class AuthzBase extends DmPlugin {
       const destPermissions = await this.getUserPermissions(user, destBranch);
       if (!destPermissions.write) {
         throw new Error(
-          `[authz-forbidden] User ${req!.user} does not have write permission for destination branch ${destBranch}`
+          `User ${req!.user} does not have write permission for destination branch ${destBranch}`
         );
       }
 

--- a/src/lib/authz/base.ts
+++ b/src/lib/authz/base.ts
@@ -117,7 +117,7 @@ export default abstract class AuthzBase extends DmPlugin {
             );
             if (!sourcePermissions.read) {
               throw new Error(
-                `User ${req!.user} does not have read permission for source branch ${sourceBranch}`
+                `[authz-forbidden] User ${req!.user} does not have read permission for source branch ${sourceBranch}`
               );
             }
           }
@@ -131,7 +131,7 @@ export default abstract class AuthzBase extends DmPlugin {
           );
           if (!sourcePermissions.read) {
             throw new Error(
-              `User ${req!.user} does not have read permission for source branch ${sourceBranch}`
+              `[authz-forbidden] User ${req!.user} does not have read permission for source branch ${sourceBranch}`
             );
           }
         }
@@ -145,7 +145,7 @@ export default abstract class AuthzBase extends DmPlugin {
         const destPermissions = await this.getUserPermissions(user, destBranch);
         if (!destPermissions.write) {
           throw new Error(
-            `User ${req!.user} does not have write permission for destination branch ${destBranch}`
+            `[authz-forbidden] User ${req!.user} does not have write permission for destination branch ${destBranch}`
           );
         }
       } else {
@@ -230,7 +230,7 @@ export default abstract class AuthzBase extends DmPlugin {
       // Check read permission
       if (!permissions.read) {
         throw new Error(
-          `User ${req!.user} does not have read permission for branch ${base}`
+          `[authz-forbidden] User ${req!.user} does not have read permission for branch ${base}`
         );
       }
 
@@ -317,7 +317,7 @@ export default abstract class AuthzBase extends DmPlugin {
       );
       if (!sourcePermissions.read) {
         throw new Error(
-          `User ${req!.user} does not have read permission for source branch ${sourceBranch}`
+          `[authz-forbidden] User ${req!.user} does not have read permission for source branch ${sourceBranch}`
         );
       }
 
@@ -325,7 +325,7 @@ export default abstract class AuthzBase extends DmPlugin {
       const destPermissions = await this.getUserPermissions(user, destBranch);
       if (!destPermissions.write) {
         throw new Error(
-          `User ${req!.user} does not have write permission for destination branch ${destBranch}`
+          `[authz-forbidden] User ${req!.user} does not have write permission for destination branch ${destBranch}`
         );
       }
 

--- a/src/lib/authz/base.ts
+++ b/src/lib/authz/base.ts
@@ -117,7 +117,7 @@ export default abstract class AuthzBase extends DmPlugin {
             );
             if (!sourcePermissions.read) {
               throw new Error(
-                `User ${req!.user} does not have read permission for source branch ${sourceBranch}`
+                `[authz-forbidden] User ${req!.user} does not have read permission for source branch ${sourceBranch}`
               );
             }
           }
@@ -131,7 +131,7 @@ export default abstract class AuthzBase extends DmPlugin {
           );
           if (!sourcePermissions.read) {
             throw new Error(
-              `User ${req!.user} does not have read permission for source branch ${sourceBranch}`
+              `[authz-forbidden] User ${req!.user} does not have read permission for source branch ${sourceBranch}`
             );
           }
         }
@@ -145,7 +145,7 @@ export default abstract class AuthzBase extends DmPlugin {
         const destPermissions = await this.getUserPermissions(user, destBranch);
         if (!destPermissions.write) {
           throw new Error(
-            `User ${req!.user} does not have write permission for destination branch ${destBranch}`
+            `[authz-forbidden] User ${req!.user} does not have write permission for destination branch ${destBranch}`
           );
         }
       } else {
@@ -155,7 +155,7 @@ export default abstract class AuthzBase extends DmPlugin {
 
         if (!permissions.write) {
           throw new Error(
-            `User ${req!.user} does not have write permission for branch ${branchToCheck}`
+            `[authz-forbidden] User ${req!.user} does not have write permission for branch ${branchToCheck}`
           );
         }
       }
@@ -198,7 +198,7 @@ export default abstract class AuthzBase extends DmPlugin {
       // Check write permission
       if (!permissions.write) {
         throw new Error(
-          `User ${req!.user} does not have write permission for branch ${branchToCheck}`
+          `[authz-forbidden] User ${req!.user} does not have write permission for branch ${branchToCheck}`
         );
       }
 
@@ -317,7 +317,7 @@ export default abstract class AuthzBase extends DmPlugin {
       );
       if (!sourcePermissions.read) {
         throw new Error(
-          `User ${req!.user} does not have read permission for source branch ${sourceBranch}`
+          `[authz-forbidden] User ${req!.user} does not have read permission for source branch ${sourceBranch}`
         );
       }
 
@@ -325,11 +325,40 @@ export default abstract class AuthzBase extends DmPlugin {
       const destPermissions = await this.getUserPermissions(user, destBranch);
       if (!destPermissions.write) {
         throw new Error(
-          `User ${req!.user} does not have write permission for destination branch ${destBranch}`
+          `[authz-forbidden] User ${req!.user} does not have write permission for destination branch ${destBranch}`
         );
       }
 
       return [oldDn, newDn, req];
+    },
+
+    ldapdeleterequest: async ([dn, req]: [
+      string | string[],
+      DmRequest?,
+    ]): Promise<[string | string[], DmRequest?]> => {
+      if (this.shouldSkipAuthorization(req)) {
+        return [dn, req];
+      }
+
+      const user = await this.resolveUser(req!.user!);
+      if (!user) {
+        this.logger.warn(`User ${req!.user} could not be resolved`);
+        return [dn, req];
+      }
+
+      // Check delete permission on the branch of every target entry.
+      const targets = Array.isArray(dn) ? dn : [dn];
+      for (const target of targets) {
+        const branchToCheck = this.extractBranchDn(target);
+        const permissions = await this.getUserPermissions(user, branchToCheck);
+        if (!permissions.delete) {
+          throw new Error(
+            `[authz-forbidden] User ${req!.user} does not have delete permission for branch ${branchToCheck}`
+          );
+        }
+      }
+
+      return [dn, req];
     },
   };
 }

--- a/src/lib/ldapActions.ts
+++ b/src/lib/ldapActions.ts
@@ -671,17 +671,17 @@ class ldapActions {
   /*
     LDAP delete
    */
-  async delete(dn: string | string[]): Promise<boolean> {
+  async delete(dn: string | string[], req?: Request): Promise<boolean> {
     if (Array.isArray(dn)) {
       dn = dn.map(d => this.setDn(d));
     } else {
       dn = this.setDn(dn);
     }
     if (!Array.isArray(dn)) dn = [dn];
-    dn = (await launchHooksChained(
-      this.parent?.hooks.ldapdeleterequest,
-      dn
-    )) as string | string[];
+    [dn] = (await launchHooksChained(this.parent?.hooks.ldapdeleterequest, [
+      dn,
+      req,
+    ])) as [string | string[], Request?];
 
     const pooled = await this.acquireConnection();
     try {

--- a/src/plugins/auth/authzDynamic.ts
+++ b/src/plugins/auth/authzDynamic.ts
@@ -420,17 +420,20 @@ export default class AuthzDynamic extends AuthBase {
       return [dn, changes, opNumber, req];
     },
 
-    // The delete hook carries no `req`, but AsyncLocalStorage still gives us
-    // the active token. Enforce delete permission on every target DN's parent
-    // branch.
-    ldapdeleterequest: (dn: string | string[]): string | string[] => {
-      const token = authzContext.getStore();
-      if (!token) return dn;
+    // Prefer the request-borne token; fall back to AsyncLocalStorage's active
+    // token for callers that do not thread `req`. Enforce delete permission on
+    // every target DN's parent branch.
+    ldapdeleterequest: ([dn, req]: [string | string[], DmRequest?]): [
+      string | string[],
+      DmRequest?,
+    ] => {
+      const token = this.activeToken(req);
+      if (!token) return [dn, req];
       const list = Array.isArray(dn) ? dn : [dn];
       for (const target of list) {
         this.requireBranchPermission(token, getParentDn(target), 'delete');
       }
-      return dn;
+      return [dn, req];
     },
 
     ldaprenamerequest: ([oldDn, newDn, req]: [string, string, DmRequest?]): [

--- a/src/plugins/ldap/groups.ts
+++ b/src/plugins/ldap/groups.ts
@@ -163,7 +163,7 @@ export default class LdapGroups extends DmPlugin {
    * Catch all deletion to remove deleted users from groups
    */
   hooks: Hooks = {
-    ldapdeleterequest: async dn => {
+    ldapdeleterequest: async ([dn, req]: [string | string[], Request?]) => {
       let _dn = dn;
       if (!Array.isArray(_dn)) {
         _dn = [_dn];
@@ -177,7 +177,7 @@ export default class LdapGroups extends DmPlugin {
       ).catch(err => {
         this.logger.error('Failed to process user deletion in groups:', err);
       });
-      return dn;
+      return [dn, req] as [string | string[], Request?];
     },
   };
 

--- a/src/plugins/ldap/onChange.ts
+++ b/src/plugins/ldap/onChange.ts
@@ -6,6 +6,7 @@
  * @author Xavier Guimard <xguimard@linagora.com>
  */
 import { Entry } from 'ldapts';
+import type { Request } from 'express';
 
 import DmPlugin, { type Role } from '../../abstract/plugin';
 import type { Hooks } from '../../hooks';
@@ -108,7 +109,7 @@ class OnLdapChange extends DmPlugin {
     /**
      * Before deletion, capture entry to trigger notify with proper changes
      */
-    ldapdeleterequest: async (dn: string | string[]) => {
+    ldapdeleterequest: async ([dn, req]: [string | string[], Request?]) => {
       const dns = Array.isArray(dn) ? dn : [dn];
 
       for (const userDn of dns) {
@@ -129,7 +130,7 @@ class OnLdapChange extends DmPlugin {
           // Entry might not exist, ignore
         }
       }
-      return dn;
+      return [dn, req] as [string | string[], Request?];
     },
 
     /**

--- a/src/plugins/ldap/organizations.ts
+++ b/src/plugins/ldap/organizations.ts
@@ -667,10 +667,13 @@ export default class LdapOrganizations extends DmPlugin {
       return [dn, changes, op];
     },
 
-    ldapdeleterequest: async ([dn]) => {
+    ldapdeleterequest: async ([dn, req]: [string | string[], Request?]) => {
       // Deletion of a non empty organization is forbidden
-      if (/^ou=/.test(dn)) await this.isEmptyOrganization(dn);
-      return [dn];
+      const targets = Array.isArray(dn) ? dn : [dn];
+      for (const target of targets) {
+        if (/^ou=/.test(target)) await this.isEmptyOrganization(target);
+      }
+      return [dn, req] as [string | string[], Request?];
     },
 
     ldaprenamerequest: ([dn, newdn]) => {

--- a/src/plugins/ldap/trash.ts
+++ b/src/plugins/ldap/trash.ts
@@ -12,6 +12,8 @@
  * @author Xavier Guimard <xguimard@linagora.com>
  */
 
+import type { Request } from 'express';
+
 import DmPlugin, { type Role } from '../../abstract/plugin';
 import type { Hooks } from '../../hooks';
 import type { SearchResult } from '../../lib/ldapActions';
@@ -198,7 +200,7 @@ class TrashPlugin extends DmPlugin {
      * This is a chained hook that receives a DN or array of DNs
      * and can modify or filter them before deletion
      */
-    ldapdeleterequest: async (dn: string | string[]) => {
+    ldapdeleterequest: async ([dn, req]: [string | string[], Request?]) => {
       // Convert to array for easier processing
       const dnsToProcess = Array.isArray(dn) ? dn : [dn];
       const dnsToDelete: string[] = [];
@@ -266,7 +268,10 @@ class TrashPlugin extends DmPlugin {
       // Return the list of DNs that should still be deleted normally
       // If input was an array, return array; if single string, return string or undefined
       // Returning undefined indicates no deletion should occur (all handled by trash)
-      return Array.isArray(dn) ? dnsToDelete : (dnsToDelete[0] ?? undefined);
+      return [
+        Array.isArray(dn) ? dnsToDelete : (dnsToDelete[0] ?? undefined),
+        req,
+      ] as [string | string[], Request?];
     },
   };
 }

--- a/src/plugins/scim/groups.ts
+++ b/src/plugins/scim/groups.ts
@@ -330,7 +330,7 @@ export class ScimGroups {
     const dn = `${this.rdnAttribute}=${escapeDnValue(rdn)},${base}`;
 
     try {
-      await this.ldap.add(dn, attributes);
+      await this.ldap.add(dn, attributes, req);
     } catch (err) {
       if (extractLdapCode(err) === 68) {
         throw scimUniqueness(`Group ${rdn} already exists`);
@@ -383,7 +383,7 @@ export class ScimGroups {
       changes.replace![k] = v;
     }
     changes.replace!.member = memberDns;
-    await this.ldap.modify(dn, changes);
+    await this.ldap.modify(dn, changes, req);
 
     const updated = await this.get(req, id);
     void launchHooks(this.hooks.scimgroupupdatedone, id, updated);
@@ -440,7 +440,7 @@ export class ScimGroups {
       }
     }
 
-    await this.ldap.modify(dn, changes);
+    await this.ldap.modify(dn, changes, req);
     const updated = await this.get(req, id);
     void launchHooks(this.hooks.scimgroupupdatedone, id, updated);
     return updated;
@@ -454,7 +454,7 @@ export class ScimGroups {
     ] as [string, DmRequest]);
     const finalId = hookInput[0];
     const dn = this.dnForId(finalId, req);
-    await this.ldap.delete(dn);
+    await this.ldap.delete(dn, req);
     void launchHooks(this.hooks.scimgroupdeletedone, finalId);
   }
 

--- a/src/plugins/scim/users.ts
+++ b/src/plugins/scim/users.ts
@@ -264,7 +264,7 @@ export class ScimUsers {
     const dn = `${this.rdnAttribute}=${escapeDnValue(rdn)},${base}`;
 
     try {
-      await this.ldap.add(dn, attributes);
+      await this.ldap.add(dn, attributes, req);
     } catch (err) {
       if (extractLdapCode(err) === 68) {
         throw scimUniqueness(`User ${rdn} already exists`);
@@ -338,7 +338,7 @@ export class ScimUsers {
 
     if (changes.replace || changes.delete) {
       try {
-        await this.ldap.modify(dn, changes);
+        await this.ldap.modify(dn, changes, req);
       } catch (err) {
         if (extractLdapCode(err) !== 16) throw err;
       }
@@ -381,7 +381,7 @@ export class ScimUsers {
     ] as [string, DmRequest]);
     const finalId = hookInput[0];
     const dn = this.dnForId(finalId, req);
-    await this.ldap.delete(dn);
+    await this.ldap.delete(dn, req);
     void launchHooks(this.hooks.scimuserdeletedone, finalId);
   }
 

--- a/test/plugins/auth/authzLinid1.test.ts
+++ b/test/plugins/auth/authzLinid1.test.ts
@@ -554,9 +554,11 @@ describe('AuthzLinid1 Plugin', () => {
           .set('X-Test-User', 'testadmin')
           .set('Accept', 'application/json');
 
-        expect(res.status).to.equal(500);
+        expect(res.status).to.equal(403);
         expect(res.body).to.have.property('error');
-        expect(res.body.error).to.equal('check logs');
+        expect(res.body.error).to.equal(
+          'Token does not have permission on this branch'
+        );
       });
 
       it('should allow search in authorized branch', async () => {
@@ -628,7 +630,7 @@ describe('AuthzLinid1 Plugin', () => {
           .set('X-Test-User', 'testadmin')
           .set('Accept', 'application/json');
 
-        expect(res.status).to.equal(500);
+        expect(res.status).to.equal(403);
         expect(res.body).to.have.property('error');
       });
     });

--- a/test/plugins/auth/authzMoveGroups.test.ts
+++ b/test/plugins/auth/authzMoveGroups.test.ts
@@ -204,8 +204,10 @@ describe('Authorization for Group Move', function () {
         targetOrgDn: getOrg2Dn(),
       });
 
-    expect(res.status).to.equal(500);
-    expect(res.body.error).to.equal('check logs');
+    expect(res.status).to.equal(403);
+    expect(res.body.error).to.equal(
+      'Token does not have permission on this branch'
+    );
   });
 
   it('should reject move when user lacks write access to destination', async () => {
@@ -217,8 +219,10 @@ describe('Authorization for Group Move', function () {
         targetOrgDn: getOrg2Dn(),
       });
 
-    expect(res.status).to.equal(500);
-    expect(res.body.error).to.equal('check logs');
+    expect(res.status).to.equal(403);
+    expect(res.body.error).to.equal(
+      'Token does not have permission on this branch'
+    );
   });
 
   it('should allow move when user has full access', async () => {

--- a/test/plugins/auth/authzMoveOrganizations.test.ts
+++ b/test/plugins/auth/authzMoveOrganizations.test.ts
@@ -221,8 +221,10 @@ describe('Authorization for Organization Move', function () {
         targetOrgDn: getParentOrg2Dn(),
       });
 
-    expect(res.status).to.equal(500);
-    expect(res.body.error).to.equal('check logs');
+    expect(res.status).to.equal(403);
+    expect(res.body.error).to.equal(
+      'Token does not have permission on this branch'
+    );
   });
 
   it('should reject move when user lacks write access to destination', async () => {
@@ -245,8 +247,10 @@ describe('Authorization for Organization Move', function () {
           targetOrgDn: siblingOrgDn,
         });
 
-      expect(res.status).to.equal(500);
-      expect(res.body.error).to.equal('check logs');
+      expect(res.status).to.equal(403);
+      expect(res.body.error).to.equal(
+        'Token does not have permission on this branch'
+      );
     } finally {
       await server.ldap.delete(siblingOrgDn);
     }

--- a/test/plugins/auth/authzPerBranch.test.ts
+++ b/test/plugins/auth/authzPerBranch.test.ts
@@ -416,9 +416,11 @@ describe('AuthzPerBranch', function () {
           .set('X-Test-User', 'testuser1')
           .set('Accept', 'application/json');
 
-        expect(res.status).to.equal(500);
+        expect(res.status).to.equal(403);
         expect(res.body).to.have.property('error');
-        expect(res.body.error).to.equal('check logs');
+        expect(res.body.error).to.equal(
+          'Token does not have permission on this branch'
+        );
       });
 
       it('should allow search in authorized branch', async function () {

--- a/test/plugins/integrations/scimAuthzPerBranch.test.ts
+++ b/test/plugins/integrations/scimAuthzPerBranch.test.ts
@@ -202,6 +202,23 @@ describe('SCIM + authzPerBranch — per-branch write enforcement (#80)', functio
     expect(entries).to.have.lengthOf(0);
   });
 
+  it('reader (write denied) is DENIED update (PUT) with 403', async () => {
+    await createUser('writer', 'alice').expect(201);
+
+    // reader has read (GET resolves) but not write → modify hook denies (403).
+    const res = await supertest(server.app)
+      .put('/scim/v2/Users/alice')
+      .set('x-scim-user', 'reader')
+      .set('Content-Type', 'application/scim+json')
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: 'alice',
+        name: { familyName: 'Hax' },
+      })
+      .expect(403);
+    expect(JSON.stringify(res.body)).to.not.match(/\[authz-forbidden\]/);
+  });
+
   it('reader (delete denied) CANNOT delete a user, writer CAN', async () => {
     await createUser('writer', 'alice').expect(201);
 

--- a/test/plugins/integrations/scimAuthzPerBranch.test.ts
+++ b/test/plugins/integrations/scimAuthzPerBranch.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Regression test for issue #80: SCIM writes must honour `core/auth/authzPerBranch`.
+ *
+ * `authzPerBranch` enforces per-branch permissions through the
+ * `ldap{add,modify,delete}request` hooks, which authorize against `req.user`.
+ * SCIM writes used to call `ldap.add/modify/delete` WITHOUT threading the
+ * request, so the hooks ran with no `req`, `shouldSkipAuthorization` returned
+ * true, and the write was allowed unconditionally — an identity restricted to
+ * one branch could create/delete entries anywhere via SCIM.
+ *
+ * These tests stack a header-based auth plugin (populates `req.user`) UNDER
+ * `core/auth/authzPerBranch` UNDER `core/scim`, and assert that a SCIM write
+ * to a branch the identity is not permitted to modify is rejected (403),
+ * exactly like a directly issued LDAP write.
+ */
+import { expect } from 'chai';
+import supertest from 'supertest';
+import type { Response } from 'express';
+
+import AuthzPerBranch from '../../../src/plugins/auth/authzPerBranch';
+import Scim from '../../../src/plugins/scim/scim';
+import { DM } from '../../../src/bin';
+import AuthBase, { type DmRequest } from '../../../src/lib/auth/base';
+import type { Role } from '../../../src/abstract/plugin';
+import type { Hooks } from '../../../src/hooks';
+
+/** Minimal auth plugin: identifies the caller from the `x-scim-user` header. */
+class HeaderAuthPlugin extends AuthBase {
+  name = 'headerAuth';
+  roles: Role[] = ['auth'] as const;
+
+  authMethod(req: DmRequest, res: Response, next: () => void): void {
+    const user = req.headers['x-scim-user'];
+    if (user && typeof user === 'string') {
+      req.user = user;
+      return next();
+    }
+    res.status(401).json({ error: 'Unauthorized' });
+  }
+}
+
+function wireHooks(server: DM, plugin: { hooks?: Hooks }): void {
+  if (!plugin.hooks) return;
+  for (const [name, fn] of Object.entries(plugin.hooks)) {
+    if (!fn) continue;
+    const list = (server.hooks[name] =
+      server.hooks[name] || ([] as unknown[] as never));
+    (list as unknown as Array<unknown>).push(fn as unknown);
+  }
+}
+
+describe('SCIM + authzPerBranch — per-branch write enforcement (#80)', function () {
+  let server: DM;
+  let baseDn: string;
+  let peopleBase: string;
+
+  const envKeys = [
+    'DM_AUTHZ_PER_BRANCH_CONFIG',
+    'DM_AUTHZ_PER_BRANCH_CACHE_TTL',
+    'DM_SCIM_USER_BASE',
+    'DM_SCIM_USER_BASE_TEMPLATE',
+    'DM_SCIM_GROUP_BASE',
+    'DM_GROUP_SCHEMA',
+  ] as const;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  before(async function () {
+    this.timeout(30000);
+    if (
+      !process.env.DM_LDAP_DN ||
+      !process.env.DM_LDAP_PWD ||
+      !process.env.DM_LDAP_BASE
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Skipping SCIM+authzPerBranch integration tests: LDAP env vars missing'
+      );
+      this.skip();
+      return;
+    }
+    baseDn = process.env.DM_LDAP_BASE;
+    peopleBase = `ou=people80,${baseDn}`;
+
+    for (const k of envKeys) savedEnv[k] = process.env[k];
+
+    // writer: full rights on peopleBase. reader: read-only (no write/delete).
+    process.env.DM_AUTHZ_PER_BRANCH_CONFIG = JSON.stringify({
+      default: { read: false, write: false, delete: false },
+      users: {
+        writer: { [peopleBase]: { read: true, write: true, delete: true } },
+        reader: { [peopleBase]: { read: true, write: false, delete: false } },
+      },
+      groups: {},
+    });
+    process.env.DM_AUTHZ_PER_BRANCH_CACHE_TTL = '60';
+    process.env.DM_SCIM_USER_BASE = peopleBase;
+    delete process.env.DM_SCIM_USER_BASE_TEMPLATE;
+    delete process.env.DM_SCIM_GROUP_BASE;
+    process.env.DM_GROUP_SCHEMA = '';
+
+    server = new DM();
+
+    // Auth middleware first so SCIM routes registered afterwards run after it.
+    const auth = new HeaderAuthPlugin(server);
+    auth.api(server.app);
+
+    const authz = new AuthzPerBranch(server);
+    wireHooks(server, authz);
+
+    const scim = new Scim(server);
+    await scim.api(server.app);
+    wireHooks(server, scim);
+
+    server.loadedPlugins['headerAuth'] = auth;
+    server.loadedPlugins['authzPerBranch'] = authz;
+    server.loadedPlugins['scim'] = scim;
+    await server.ready;
+
+    try {
+      await server.ldap.add(peopleBase, {
+        objectClass: ['top', 'organizationalUnit'],
+        ou: 'people80',
+      });
+    } catch {
+      /* may already exist */
+    }
+  });
+
+  after(async () => {
+    if (server) {
+      for (const dn of [
+        `uid=alice,${peopleBase}`,
+        `uid=bob,${peopleBase}`,
+        peopleBase,
+      ]) {
+        try {
+          await server.ldap.delete(dn);
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+    for (const k of envKeys) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+  });
+
+  afterEach(async () => {
+    for (const dn of [`uid=alice,${peopleBase}`, `uid=bob,${peopleBase}`]) {
+      try {
+        await server.ldap.delete(dn);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  const createUser = (user: string, userName: string) =>
+    supertest(server.app)
+      .post('/scim/v2/Users')
+      .set('x-scim-user', user)
+      .set('Content-Type', 'application/scim+json')
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName,
+        name: { familyName: 'Doe' },
+      });
+
+  it('rejects unauthenticated SCIM access (401)', async () => {
+    await supertest(server.app).get('/scim/v2/Users').expect(401);
+  });
+
+  it('writer (write granted) CAN create a user via SCIM', async () => {
+    await createUser('writer', 'alice').expect(201);
+    const res = await server.ldap.search(
+      { paged: false, scope: 'base', attributes: ['uid'] },
+      `uid=alice,${peopleBase}`
+    );
+    expect(
+      (res as { searchEntries: unknown[] }).searchEntries
+    ).to.have.lengthOf(1);
+  });
+
+  it('reader (write denied) is DENIED create with 403 — regression for #80', async () => {
+    const res = await createUser('reader', 'bob').expect(403);
+    // Marker must never leak to the client.
+    expect(JSON.stringify(res.body)).to.not.match(/\[authz-forbidden\]/);
+
+    // And nothing must have been written: a base-scoped search on the absent
+    // entry raises noSuchObject (0x20), which equally proves bob was not created.
+    let entries: unknown[] = [];
+    try {
+      const search = await server.ldap.search(
+        { paged: false, scope: 'base', attributes: ['uid'] },
+        `uid=bob,${peopleBase}`
+      );
+      entries = (search as { searchEntries: unknown[] }).searchEntries;
+    } catch (err) {
+      expect((err as { code?: number }).code).to.equal(32); // noSuchObject
+    }
+    expect(entries).to.have.lengthOf(0);
+  });
+
+  it('reader (delete denied) CANNOT delete a user, writer CAN', async () => {
+    await createUser('writer', 'alice').expect(201);
+
+    // reader has read (so GET resolves) but not delete → 403, entry survives.
+    await supertest(server.app)
+      .delete('/scim/v2/Users/alice')
+      .set('x-scim-user', 'reader')
+      .expect(403);
+    const stillThere = await server.ldap.search(
+      { paged: false, scope: 'base', attributes: ['uid'] },
+      `uid=alice,${peopleBase}`
+    );
+    expect(
+      (stillThere as { searchEntries: unknown[] }).searchEntries
+    ).to.have.lengthOf(1);
+
+    // writer has delete → succeeds.
+    await supertest(server.app)
+      .delete('/scim/v2/Users/alice')
+      .set('x-scim-user', 'writer')
+      .expect(204);
+  });
+});

--- a/test/plugins/ldap/organizations.test.ts
+++ b/test/plugins/ldap/organizations.test.ts
@@ -353,7 +353,7 @@ describe('LDAP Organizations Plugin', function () {
         // Since twakeDepartmentLink may not exist in schema,
         // verify that hook allows deletion when no entries link to org
         const result = await plugin.hooks.ldapdeleterequest?.([testOrgDn]);
-        expect(result).to.deep.equal([testOrgDn]);
+        expect(result).to.deep.equal([testOrgDn, undefined]);
       });
 
       it('should allow deletion of empty organization', async () => {
@@ -363,13 +363,13 @@ describe('LDAP Organizations Plugin', function () {
         });
 
         const result = await plugin.hooks.ldapdeleterequest?.([testOrgDn]);
-        expect(result).to.deep.equal([testOrgDn]);
+        expect(result).to.deep.equal([testOrgDn, undefined]);
       });
 
       it('should allow deletion of non-organization entries', async () => {
         const dn = `cn=test,${process.env.DM_LDAP_BASE}`;
         const result = await plugin.hooks.ldapdeleterequest?.([dn]);
-        expect(result).to.deep.equal([dn]);
+        expect(result).to.deep.equal([dn, undefined]);
       });
     });
 


### PR DESCRIPTION
## Context

Closes #80. Authorization plugins (e.g. `core/auth/authzPerBranch`) gate LDAP operations through the `ldap{add,modify,delete}request` hooks, which authorize against `req.user` and skip authorization entirely when `req.user` is absent (`shouldSkipAuthorization`). Enforcement therefore depends on the request context reaching the LDAP action layer.

## Root cause

- **SCIM writes were unauthorized.** `scim/users` and `scim/groups` `create`/`replace`/`patch`/`delete` received `req` but called `ldap.add/modify/delete` **without** it. The authz hooks ran with no `req`, `shouldSkipAuthorization` returned `true`, and the write was allowed unconditionally. An identity that `authzPerBranch` restricts to one branch could create/delete entries in **any** branch via SCIM — a control that loads and validates cleanly while enforcing nothing.
  - `authzDynamic` was *not* affected: it reads its token from `AsyncLocalStorage`, not `req`. That is why the existing SCIM+authzDynamic E2E passed while authzPerBranch was silently bypassed.
- **`ldap.delete` could never be authorized at all.** It took no `req`, and `lib/authz/base` implemented no `ldapdeleterequest` hook.

## Changes

- **`lib/ldapActions`**: `delete(dn, req?)` now threads `req`; the `ldapdeleterequest` hook value becomes a `[dn, req]` tuple, mirroring add/modify/rename.
- **Hook implementers updated** to the tuple (`organizations`, `onChange`, `trash`, `ldap/groups`, `authzDynamic`) — each forwards `req` so the chain is preserved.
- **`lib/authz/base`**: new `ldapdeleterequest` hook enforcing the per-branch **`delete`** permission on every target DN.
- **SCIM `users`/`groups`**: thread `req` into every `ldap.add/modify/delete`.
- **Consistent 403 for every authz denial.** All `AuthzBase` denial messages carry the `[authz-forbidden]` marker, so both the standard and the SCIM error serializers return **403** for read, write, move and delete — matching `authzDynamic`, which already did. Previously `authzPerBranch` returned 500 ("check logs") for read/move denials; an authorization failure is semantically 403, never 500. Tests that codified the old 500 are updated accordingly.

## Verification

- `npm run check:ts`: OK. `eslint` on changed files: no new errors.
- New regression suite `test/plugins/integrations/scimAuthzPerBranch.test.ts` (header auth + `authzPerBranch` + `scim`):
  - writer (write granted) creates a user via SCIM → **201**;
  - reader (write denied) → **403** on create and on update (PUT); nothing is written (was **201** before the fix);
  - reader (delete denied) → **403** on delete and the entry survives; writer → **204**;
  - unauthenticated → **401**; the `[authz-forbidden]` marker never leaks to the client.
- Re-ran the affected suites against the embedded LDAP, all green (`authzPerBranch`, `authzDynamic`(+behavior), `authzLinid1`, `authzMoveGroups`, `authzMoveOrganizations`, `scimAuthzDynamic`, `scimAuthzPerBranch`, `organizations`, `trash`, `ldapGroups`, all `scim/*`, `appAccounts*`).

Affected version: 0.3.9.
