### PR TITLE
fix: key app accounts on principal mail, not non-unique uid

### DIFF
--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -210,6 +210,12 @@ export interface Config {
   // Applicative Accounts plugin
   applicative_account_base?: string;
   max_app_accounts?: number;
+  // LDAP attribute used to resolve the `:user` path param of the app-account
+  // endpoints to the principal entry. Defaults to the mail attribute, which is
+  // globally unique (see #88). Set to `uid` to restore the pre-#89 contract
+  // where `:user` is the LDAP uid — only safe when uid is unique directory-wide.
+  // Generated app-account uids are prefixed from this (unique) value, sanitized.
+  app_accounts_user_attribute?: string;
   ldap_operational_attribute?: string[];
 
   // Trash plugin

--- a/src/plugins/twake/appAccountsApi.ts
+++ b/src/plugins/twake/appAccountsApi.ts
@@ -12,7 +12,7 @@ import DmPlugin, { type Role } from '../../abstract/plugin';
 import type { DM } from '../../bin';
 import type { SearchResult } from '../../lib/ldapActions';
 import { wantJson } from '../../lib/expressFormatedResponses';
-import { escapeDnValue } from '../../lib/utils';
+import { escapeDnValue, escapeLdapFilter, isDnInBranch } from '../../lib/utils';
 
 /**
  * @openapi-component
@@ -29,7 +29,8 @@ import { escapeDnValue } from '../../lib/utils';
  *       type: string
  *       description: |
  *         Unique identifier of the app account.  Format:
- *         `<username>_c<8-digits>` (e.g. `alice_c04729183`).
+ *         `<uid>_c<8-digits>`, where `<uid>` is the principal's LDAP uid
+ *         (not the `:user` path param, which is the mail). e.g. `alice_c04729183`.
  *       example: alice_c04729183
  *     name:
  *       type: string
@@ -117,10 +118,11 @@ export default class AppAccountsApi extends DmPlugin {
      * @openapi
      * summary: List app accounts for a user
      * description: |
-     *   Returns all application-specific accounts belonging to `:user`.
-     *   Only entries whose `uid` starts with `<username>_` are included;
-     *   the principal account (whose uid equals the user's mail address)
-     *   is always filtered out.
+     *   Returns all application-specific accounts belonging to `:user`, where
+     *   `:user` is the principal account email (globally unique). Ownership is
+     *   resolved by the mail attribute, not the LDAP `uid`, which may repeat
+     *   under different subtrees of the directory. The principal account
+     *   (whose uid equals the mail address) is always filtered out.
      *
      *   Results are sorted alphabetically by `uid`.
      * responses:
@@ -206,10 +208,11 @@ export default class AppAccountsApi extends DmPlugin {
      * summary: Delete an app account
      * description: |
      *   Deletes the app account identified by `:uid` and removes its
-     *   password from the principal account (`uid=<mail>`).
+     *   password from the principal account (`uid=<mail>`). `:user` is the
+     *   principal account email.
      *
-     *   The `:uid` must start with `<user>_` — attempting to delete an
-     *   account that belongs to a different user returns `403`.
+     *   The target account's mail must match `:user` — attempting to delete an
+     *   account that belongs to a different principal returns `403`.
      *
      *   The operation is **idempotent**: if the account does not exist,
      *   the response is still `200` with the `uid` echoed back.
@@ -244,36 +247,79 @@ export default class AppAccountsApi extends DmPlugin {
   }
 
   /**
+   * Resolve the principal user entry by its (globally unique) mail address.
+   *
+   * App accounts are keyed on the principal mail, never the LDAP `uid`: the
+   * same `uid` may repeat under different subtrees of the directory, so a
+   * `uid`-based lookup could resolve to an arbitrary same-named user.
+   *
+   * On failure (no match, or an ambiguous mail) this writes the HTTP error
+   * response and returns null, so callers can simply `return` when it does.
+   *
+   * @param principalEmail - The principal account email (the `:user` path param)
+   * @param res - The Express response, used to emit error statuses
+   * @param attributes - Optional attribute projection for the search
+   * @returns The single matching LDAP entry, or null when none/ambiguous
+   */
+  private async resolvePrincipal(
+    principalEmail: string,
+    res: Response,
+    attributes?: string[]
+  ): Promise<SearchResult['searchEntries'][number] | null> {
+    const result = await this.server.ldap.search(
+      {
+        scope: 'sub',
+        filter: `(${this.mailAttr}=${escapeLdapFilter(principalEmail)})`,
+        paged: false,
+        ...(attributes ? { attributes } : {}),
+      },
+      this.config.ldap_base || ''
+    );
+
+    // The applicative branch lives under ldap_base and its entries (the
+    // principal account and the app accounts) carry the same mail, so exclude
+    // them: only a real user entry can be the principal.
+    const entries = ((result as SearchResult).searchEntries || []).filter(
+      entry => !isDnInBranch(entry.dn, this.applicativeAccountBase)
+    );
+
+    if (entries.length === 0) {
+      res.status(404).json({ error: `User ${principalEmail} not found` });
+      return null;
+    }
+
+    if (entries.length > 1) {
+      this.logger.error(
+        `${this.name}: Ambiguous principal lookup for ${principalEmail}: ${entries.length} entries share this mail`
+      );
+      res
+        .status(409)
+        .json({ error: `Multiple users share mail ${principalEmail}` });
+      return null;
+    }
+
+    return entries[0];
+  }
+
+  /**
    * List applicative accounts for a user
    */
   private async listAccounts(req: Request, res: Response): Promise<void> {
     if (!wantJson(req, res)) return;
 
-    const username = req.params.user as string;
+    const principalEmail = req.params.user as string;
 
     try {
-      // Get user's mail from LDAP
-      const userResult = await this.server.ldap.search(
-        {
-          scope: 'sub',
-          filter: `(uid=${username})`,
-          paged: false,
-          attributes: [this.mailAttr],
-        },
-        this.config.ldap_base || ''
-      );
-
-      const userEntry = (userResult as SearchResult).searchEntries?.[0];
-      if (!userEntry) {
-        res.status(404).json({ error: `User ${username} not found` });
-        return;
-      }
+      const userEntry = await this.resolvePrincipal(principalEmail, res, [
+        this.mailAttr,
+      ]);
+      if (!userEntry) return;
 
       const mail = userEntry[this.mailAttr];
       if (!mail) {
         res
           .status(400)
-          .json({ error: `User ${username} has no mail attribute` });
+          .json({ error: `User ${principalEmail} has no mail attribute` });
         return;
       }
 
@@ -283,7 +329,7 @@ export default class AppAccountsApi extends DmPlugin {
       const accountsResult = await this.server.ldap.search(
         {
           scope: 'sub',
-          filter: `(${this.mailAttr}=${mailStr})`,
+          filter: `(${this.mailAttr}=${escapeLdapFilter(mailStr)})`,
           paged: false,
         },
         this.applicativeAccountBase
@@ -291,13 +337,14 @@ export default class AppAccountsApi extends DmPlugin {
 
       const accounts = (accountsResult as SearchResult).searchEntries || [];
 
-      // Filter out the principal account (uid=mail) and extract uid and name
+      // Ownership is the (unique) mail match above; the only non-app entry
+      // sharing it is the principal account (uid=mail), dropped here. Compare
+      // case-insensitively, as LDAP uid/mail matching is.
       const appAccounts = accounts
         .filter(entry => {
           const uid = entry.uid;
           const uidStr = Array.isArray(uid) ? String(uid[0]) : String(uid);
-          // Keep only applicative accounts (user_cXXXXXXXX format)
-          return uidStr !== mailStr && uidStr.startsWith(`${username}_`);
+          return uidStr.toLowerCase() !== mailStr.toLowerCase();
         })
         .map(entry => {
           const uid = entry.uid;
@@ -319,7 +366,7 @@ export default class AppAccountsApi extends DmPlugin {
       res.json(appAccounts);
     } catch (error) {
       this.logger.error(
-        `${this.name}: Failed to list accounts for ${username}:`,
+        `${this.name}: Failed to list accounts for ${principalEmail}:`,
         error
       );
       res.status(500).json({ error: 'Internal server error' });
@@ -332,42 +379,43 @@ export default class AppAccountsApi extends DmPlugin {
   private async createAccount(req: Request, res: Response): Promise<void> {
     if (!wantJson(req, res)) return;
 
-    const username = req.params.user as string;
+    const principalEmail = req.params.user as string;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const { name } = req.body || {};
 
     try {
-      // Get user's mail and attributes from LDAP
-      const userResult = await this.server.ldap.search(
-        {
-          scope: 'sub',
-          filter: `(uid=${username})`,
-          paged: false,
-        },
-        this.config.ldap_base || ''
-      );
-
-      const userEntry = (userResult as SearchResult).searchEntries?.[0];
-      if (!userEntry) {
-        res.status(404).json({ error: `User ${username} not found` });
-        return;
-      }
+      const userEntry = await this.resolvePrincipal(principalEmail, res);
+      if (!userEntry) return;
 
       const mail = userEntry[this.mailAttr];
       if (!mail) {
         res
           .status(400)
-          .json({ error: `User ${username} has no mail attribute` });
+          .json({ error: `User ${principalEmail} has no mail attribute` });
         return;
       }
 
       const mailStr = Array.isArray(mail) ? String(mail[0]) : String(mail);
 
-      // Check existing accounts count
+      // The app-account uid keeps the documented `<uid>_c<digits>` format, so
+      // it is prefixed with the principal's short uid resolved from the entry,
+      // not the `:user` path param (which is the mail).
+      const uidAttr = userEntry.uid;
+      if (!uidAttr) {
+        res
+          .status(400)
+          .json({ error: `User ${principalEmail} has no uid attribute` });
+        return;
+      }
+      const shortUid = Array.isArray(uidAttr)
+        ? String(uidAttr[0])
+        : String(uidAttr);
+
+      // Check existing accounts count (scoped by the unique principal mail)
       const accountsResult = await this.server.ldap.search(
         {
           scope: 'sub',
-          filter: `(${this.mailAttr}=${mailStr})`,
+          filter: `(${this.mailAttr}=${escapeLdapFilter(mailStr)})`,
           paged: false,
         },
         this.applicativeAccountBase
@@ -377,7 +425,7 @@ export default class AppAccountsApi extends DmPlugin {
       const existingAppAccounts = accounts.filter(entry => {
         const uid = entry.uid;
         const uidStr = Array.isArray(uid) ? String(uid[0]) : String(uid);
-        return uidStr !== mailStr && uidStr.startsWith(`${username}_`);
+        return uidStr.toLowerCase() !== mailStr.toLowerCase();
       });
 
       if (existingAppAccounts.length >= this.maxAppAccounts) {
@@ -402,11 +450,11 @@ export default class AppAccountsApi extends DmPlugin {
         existingAppAccounts.some(entry => {
           const uid = entry.uid;
           const uidStr = Array.isArray(uid) ? String(uid[0]) : String(uid);
-          return uidStr === `${username}_${accountId}`;
+          return uidStr === `${shortUid}_${accountId}`;
         })
       );
 
-      const newUid = `${username}_${accountId}`;
+      const newUid = `${shortUid}_${accountId}`;
       const newPassword = this.generatePassword();
 
       // Build attributes for new applicative account
@@ -454,7 +502,7 @@ export default class AppAccountsApi extends DmPlugin {
       await this.server.ldap.add(applicativeDn, newAttrs);
 
       this.logger.info(
-        `${this.name}: Created applicative account ${applicativeDn} for user ${username}`
+        `${this.name}: Created applicative account ${applicativeDn} for user ${principalEmail}`
       );
 
       // Add password to principal account (uid=mail)
@@ -476,7 +524,7 @@ export default class AppAccountsApi extends DmPlugin {
       res.json({ uid: newUid, pwd: newPassword, mail: mailStr });
     } catch (error) {
       this.logger.error(
-        `${this.name}: Failed to create account for ${username}:`,
+        `${this.name}: Failed to create account for ${principalEmail}:`,
         error
       );
       res.status(500).json({ error: 'Internal server error' });
@@ -489,23 +537,15 @@ export default class AppAccountsApi extends DmPlugin {
   private async deleteAccount(req: Request, res: Response): Promise<void> {
     if (!wantJson(req, res)) return;
 
-    const username = req.params.user as string;
+    const principalEmail = req.params.user as string;
     const uid = req.params.uid as string;
 
     try {
-      // Validate that uid belongs to this user
-      if (!uid.startsWith(`${username}_`)) {
-        res.status(403).json({
-          error: `Account ${uid} does not belong to user ${username}`,
-        });
-        return;
-      }
-
       // Search for the applicative account
       const accountResult = await this.server.ldap.search(
         {
           scope: 'sub',
-          filter: `(uid=${uid})`,
+          filter: `(uid=${escapeLdapFilter(uid)})`,
           paged: false,
         },
         this.applicativeAccountBase
@@ -521,13 +561,6 @@ export default class AppAccountsApi extends DmPlugin {
         return;
       }
 
-      const userPassword = accountEntry.userPassword;
-      if (!userPassword) {
-        this.logger.warn(
-          `${this.name}: Account ${uid} has no userPassword attribute`
-        );
-      }
-
       // Get mail from account to find principal account
       const mail = accountEntry[this.mailAttr];
       const mailStr = mail
@@ -536,8 +569,25 @@ export default class AppAccountsApi extends DmPlugin {
           : String(mail)
         : null;
 
+      // Ownership: the account's mail must match the principal email. Mail is
+      // the unique owner key; the uid prefix is not, as the same short uid may
+      // repeat under different subtrees of the directory.
+      if (!mailStr || mailStr.toLowerCase() !== principalEmail.toLowerCase()) {
+        res.status(403).json({
+          error: `Account ${uid} does not belong to user ${principalEmail}`,
+        });
+        return;
+      }
+
+      const userPassword = accountEntry.userPassword;
+      if (!userPassword) {
+        this.logger.warn(
+          `${this.name}: Account ${uid} has no userPassword attribute`
+        );
+      }
+
       // Delete password from principal account if available
-      if (mailStr && userPassword) {
+      if (userPassword) {
         const principalDn = `uid=${escapeDnValue(mailStr)},${this.applicativeAccountBase}`;
         try {
           const passwordToDelete = Array.isArray(userPassword)
@@ -566,7 +616,7 @@ export default class AppAccountsApi extends DmPlugin {
       res.json({ uid });
     } catch (error) {
       this.logger.error(
-        `${this.name}: Failed to delete account ${uid} for ${username}:`,
+        `${this.name}: Failed to delete account ${uid} for ${principalEmail}:`,
         error
       );
       res.status(500).json({ error: 'Internal server error' });

--- a/src/plugins/twake/appAccountsApi.ts
+++ b/src/plugins/twake/appAccountsApi.ts
@@ -29,9 +29,10 @@ import { escapeDnValue, escapeLdapFilter, isDnInBranch } from '../../lib/utils';
  *       type: string
  *       description: |
  *         Unique identifier of the app account.  Format:
- *         `<uid>_c<8-digits>`, where `<uid>` is the principal's LDAP uid
- *         (not the `:user` path param, which is the mail). e.g. `alice_c04729183`.
- *       example: alice_c04729183
+ *         `<prefix>_c<8-digits>`, where `<prefix>` is the `:user` path param
+ *         (the resolution value — the mail by default) sanitized into a
+ *         uid-safe token (e.g. `alice@example.com` -> `alice_example_com`).
+ *       example: alice_example_com_c04729183
  *     name:
  *       type: string
  *       description: Human-readable label (stored as LDAP `description`).
@@ -88,6 +89,12 @@ export default class AppAccountsApi extends DmPlugin {
   private applicativeAccountBase: string;
   private maxAppAccounts: number;
   private mailAttr: string;
+  // Attribute used to resolve the `:user` path param to the principal entry.
+  // Defaults to the (unique) mail attribute; set to `uid` for the legacy
+  // pre-#89 contract where `:user` is the LDAP uid. The app-account uid is
+  // prefixed from this (unique) `:user` value, sanitized — so with uid it stays
+  // `<uid>_c<digits>`, and with mail it becomes `<sanitized-mail>_c<digits>`.
+  private userAttr: string;
 
   constructor(server: DM) {
     super(server);
@@ -96,6 +103,8 @@ export default class AppAccountsApi extends DmPlugin {
       .applicative_account_base as string;
     this.maxAppAccounts = (this.config.max_app_accounts as number) || 5;
     this.mailAttr = (this.config.mail_attribute as string) || 'mail';
+    this.userAttr =
+      (this.config.app_accounts_user_attribute as string) || this.mailAttr;
 
     if (!this.applicativeAccountBase) {
       throw new Error(
@@ -104,7 +113,7 @@ export default class AppAccountsApi extends DmPlugin {
     }
 
     this.logger.info(
-      `${this.name}: initialized with applicative_account_base=${this.applicativeAccountBase}, max_app_accounts=${this.maxAppAccounts}`
+      `${this.name}: initialized with applicative_account_base=${this.applicativeAccountBase}, max_app_accounts=${this.maxAppAccounts}, user_attribute=${this.userAttr}`
     );
   }
 
@@ -156,8 +165,8 @@ export default class AppAccountsApi extends DmPlugin {
      * description: |
      *   Creates a new application-specific identity under the configured
      *   applicative-account LDAP branch.  The server generates a random
-     *   uid (`<username>_c<8-digits>`) and a cryptographically secure
-     *   password, then:
+     *   uid (`<prefix>_c<8-digits>`, prefix derived from `:user`) and a
+     *   cryptographically secure password, then:
      *
      *   1. Copies `cn`, `sn`, `givenName`, `mail`, and `displayName` from
      *      the principal user entry.
@@ -247,29 +256,31 @@ export default class AppAccountsApi extends DmPlugin {
   }
 
   /**
-   * Resolve the principal user entry by its (globally unique) mail address.
+   * Resolve the principal user entry from the `:user` path param.
    *
-   * App accounts are keyed on the principal mail, never the LDAP `uid`: the
-   * same `uid` may repeat under different subtrees of the directory, so a
-   * `uid`-based lookup could resolve to an arbitrary same-named user.
+   * `:user` is matched against the configured resolution attribute
+   * (`app_accounts_user_attribute`, default the mail attribute). Mail is
+   * globally unique; resolving by the LDAP `uid` instead is only safe when uid
+   * is unique directory-wide, as the same `uid` may repeat under different
+   * subtrees and resolve to an arbitrary same-named user (see #88).
    *
-   * On failure (no match, or an ambiguous mail) this writes the HTTP error
+   * On failure (no match, or an ambiguous one) this writes the HTTP error
    * response and returns null, so callers can simply `return` when it does.
    *
-   * @param principalEmail - The principal account email (the `:user` path param)
+   * @param principal - The `:user` path param value
    * @param res - The Express response, used to emit error statuses
    * @param attributes - Optional attribute projection for the search
    * @returns The single matching LDAP entry, or null when none/ambiguous
    */
   private async resolvePrincipal(
-    principalEmail: string,
+    principal: string,
     res: Response,
     attributes?: string[]
   ): Promise<SearchResult['searchEntries'][number] | null> {
     const result = await this.server.ldap.search(
       {
         scope: 'sub',
-        filter: `(${this.mailAttr}=${escapeLdapFilter(principalEmail)})`,
+        filter: `(${this.userAttr}=${escapeLdapFilter(principal)})`,
         paged: false,
         ...(attributes ? { attributes } : {}),
       },
@@ -284,17 +295,17 @@ export default class AppAccountsApi extends DmPlugin {
     );
 
     if (entries.length === 0) {
-      res.status(404).json({ error: `User ${principalEmail} not found` });
+      res.status(404).json({ error: `User ${principal} not found` });
       return null;
     }
 
     if (entries.length > 1) {
       this.logger.error(
-        `${this.name}: Ambiguous principal lookup for ${principalEmail}: ${entries.length} entries share this mail`
+        `${this.name}: Ambiguous principal lookup for ${principal}: ${entries.length} entries share ${this.userAttr}`
       );
-      res
-        .status(409)
-        .json({ error: `Multiple users share mail ${principalEmail}` });
+      res.status(409).json({
+        error: `Multiple users share ${this.userAttr} ${principal}`,
+      });
       return null;
     }
 
@@ -307,10 +318,10 @@ export default class AppAccountsApi extends DmPlugin {
   private async listAccounts(req: Request, res: Response): Promise<void> {
     if (!wantJson(req, res)) return;
 
-    const principalEmail = req.params.user as string;
+    const principal = req.params.user as string;
 
     try {
-      const userEntry = await this.resolvePrincipal(principalEmail, res, [
+      const userEntry = await this.resolvePrincipal(principal, res, [
         this.mailAttr,
       ]);
       if (!userEntry) return;
@@ -319,7 +330,7 @@ export default class AppAccountsApi extends DmPlugin {
       if (!mail) {
         res
           .status(400)
-          .json({ error: `User ${principalEmail} has no mail attribute` });
+          .json({ error: `User ${principal} has no mail attribute` });
         return;
       }
 
@@ -366,7 +377,7 @@ export default class AppAccountsApi extends DmPlugin {
       res.json(appAccounts);
     } catch (error) {
       this.logger.error(
-        `${this.name}: Failed to list accounts for ${principalEmail}:`,
+        `${this.name}: Failed to list accounts for ${principal}:`,
         error
       );
       res.status(500).json({ error: 'Internal server error' });
@@ -379,39 +390,32 @@ export default class AppAccountsApi extends DmPlugin {
   private async createAccount(req: Request, res: Response): Promise<void> {
     if (!wantJson(req, res)) return;
 
-    const principalEmail = req.params.user as string;
+    const principal = req.params.user as string;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const { name } = req.body || {};
 
     try {
-      const userEntry = await this.resolvePrincipal(principalEmail, res);
+      const userEntry = await this.resolvePrincipal(principal, res);
       if (!userEntry) return;
 
       const mail = userEntry[this.mailAttr];
       if (!mail) {
         res
           .status(400)
-          .json({ error: `User ${principalEmail} has no mail attribute` });
+          .json({ error: `User ${principal} has no mail attribute` });
         return;
       }
 
       const mailStr = Array.isArray(mail) ? String(mail[0]) : String(mail);
 
-      // The app-account uid keeps the documented `<uid>_c<digits>` format, so
-      // it is prefixed with the principal's short uid resolved from the entry,
-      // not the `:user` path param (which is the mail).
-      const uidAttr = userEntry.uid;
-      if (!uidAttr) {
-        res
-          .status(400)
-          .json({ error: `User ${principalEmail} has no uid attribute` });
-        return;
-      }
-      const shortUid = Array.isArray(uidAttr)
-        ? String(uidAttr[0])
-        : String(uidAttr);
+      // The app-account uid is prefixed from the (unique) `:user` value, not
+      // from the entry's `uid`: the same `uid` may repeat across users, so a
+      // uid-based prefix could collide in the shared applicative branch. The
+      // value is sanitized into a uid-safe token; uniqueness is still enforced
+      // globally below, so a lossy sanitization can never produce a clash.
+      const prefix = this.appUidPrefix(principal);
 
-      // Check existing accounts count (scoped by the unique principal mail)
+      // Enforce the per-user limit, scoped by the unique principal mail.
       const accountsResult = await this.server.ldap.search(
         {
           scope: 'sub',
@@ -435,26 +439,20 @@ export default class AppAccountsApi extends DmPlugin {
         return;
       }
 
-      // Generate unique account ID
-      let accountId: string;
+      // Generate a uid that is unique across the whole applicative branch (not
+      // just within this principal), so distinct principals can never collide.
+      let newUid: string;
       let attempts = 0;
       do {
-        accountId = this.generateAccountId();
+        newUid = `${prefix}_${this.generateAccountId()}`;
         attempts++;
         if (attempts > 100) {
           throw new Error(
             'Failed to generate unique account ID after 100 attempts'
           );
         }
-      } while (
-        existingAppAccounts.some(entry => {
-          const uid = entry.uid;
-          const uidStr = Array.isArray(uid) ? String(uid[0]) : String(uid);
-          return uidStr === `${shortUid}_${accountId}`;
-        })
-      );
+      } while (await this.uidExists(newUid));
 
-      const newUid = `${shortUid}_${accountId}`;
       const newPassword = this.generatePassword();
 
       // Build attributes for new applicative account
@@ -502,7 +500,7 @@ export default class AppAccountsApi extends DmPlugin {
       await this.server.ldap.add(applicativeDn, newAttrs);
 
       this.logger.info(
-        `${this.name}: Created applicative account ${applicativeDn} for user ${principalEmail}`
+        `${this.name}: Created applicative account ${applicativeDn} for user ${principal}`
       );
 
       // Add password to principal account (uid=mail)
@@ -524,11 +522,37 @@ export default class AppAccountsApi extends DmPlugin {
       res.json({ uid: newUid, pwd: newPassword, mail: mailStr });
     } catch (error) {
       this.logger.error(
-        `${this.name}: Failed to create account for ${principalEmail}:`,
+        `${this.name}: Failed to create account for ${principal}:`,
         error
       );
       res.status(500).json({ error: 'Internal server error' });
     }
+  }
+
+  /**
+   * Derive a uid-safe prefix for app-account uids from the (unique) `:user`
+   * value. Characters awkward in a uid/RDN (e.g. `@` and `.` in a mail) are
+   * replaced with `_`. Sanitization may be lossy, but app-account uids are made
+   * unique across the whole branch at creation time, so this never collides.
+   */
+  private appUidPrefix(principal: string): string {
+    return principal.replace(/[^A-Za-z0-9_-]/g, '_');
+  }
+
+  /**
+   * Whether a uid already exists anywhere under the applicative branch.
+   */
+  private async uidExists(uid: string): Promise<boolean> {
+    const result = await this.server.ldap.search(
+      {
+        scope: 'sub',
+        filter: `(uid=${escapeLdapFilter(uid)})`,
+        paged: false,
+        attributes: ['uid'],
+      },
+      this.applicativeAccountBase
+    );
+    return ((result as SearchResult).searchEntries || []).length > 0;
   }
 
   /**
@@ -537,7 +561,7 @@ export default class AppAccountsApi extends DmPlugin {
   private async deleteAccount(req: Request, res: Response): Promise<void> {
     if (!wantJson(req, res)) return;
 
-    const principalEmail = req.params.user as string;
+    const principal = req.params.user as string;
     const uid = req.params.uid as string;
 
     try {
@@ -569,12 +593,35 @@ export default class AppAccountsApi extends DmPlugin {
           : String(mail)
         : null;
 
-      // Ownership: the account's mail must match the principal email. Mail is
-      // the unique owner key; the uid prefix is not, as the same short uid may
-      // repeat under different subtrees of the directory.
-      if (!mailStr || mailStr.toLowerCase() !== principalEmail.toLowerCase()) {
+      // Ownership: the account's mail must match the principal's mail (the
+      // unique owner key — the uid prefix is not, as the same short uid may
+      // repeat under different subtrees). When `:user` is itself the mail we
+      // compare directly; otherwise we resolve `:user` to the principal entry
+      // and read its mail.
+      let principalMail = principal;
+      if (this.userAttr !== this.mailAttr) {
+        const principalEntry = await this.resolvePrincipal(principal, res, [
+          this.mailAttr,
+        ]);
+        if (!principalEntry) return;
+        const pm = principalEntry[this.mailAttr];
+        const pmStr = pm
+          ? Array.isArray(pm)
+            ? String(pm[0])
+            : String(pm)
+          : null;
+        if (!pmStr) {
+          res
+            .status(400)
+            .json({ error: `User ${principal} has no mail attribute` });
+          return;
+        }
+        principalMail = pmStr;
+      }
+
+      if (!mailStr || mailStr.toLowerCase() !== principalMail.toLowerCase()) {
         res.status(403).json({
-          error: `Account ${uid} does not belong to user ${principalEmail}`,
+          error: `Account ${uid} does not belong to user ${principal}`,
         });
         return;
       }
@@ -616,7 +663,7 @@ export default class AppAccountsApi extends DmPlugin {
       res.json({ uid });
     } catch (error) {
       this.logger.error(
-        `${this.name}: Failed to delete account ${uid} for ${principalEmail}:`,
+        `${this.name}: Failed to delete account ${uid} for ${principal}:`,
         error
       );
       res.status(500).json({ error: 'Internal server error' });

--- a/test/plugins/twake/appAccountsApi.test.ts
+++ b/test/plugins/twake/appAccountsApi.test.ts
@@ -12,6 +12,8 @@ describe('App Accounts API Plugin', function () {
   // App-account endpoints key on the principal email (the `:user` path param),
   // not the LDAP uid.
   const principalEmail = `${testUser}@example.com`;
+  // Generated app-account uids are prefixed from the (sanitized) `:user` value.
+  const appUidPrefix = principalEmail.replace(/[^A-Za-z0-9_-]/g, '_');
   let applicativeBase: string;
   let userBase: string;
   let testUserDN: string;
@@ -241,7 +243,7 @@ describe('App Accounts API Plugin', function () {
       expect(res.body).to.have.property('uid');
       expect(res.body).to.have.property('pwd');
       expect(res.body).to.have.property('mail');
-      expect(res.body.uid).to.match(new RegExp(`^${testUser}_c\\d{8}$`));
+      expect(res.body.uid).to.match(new RegExp(`^${appUidPrefix}_c\\d{8}$`));
       expect(res.body.pwd).to.match(
         /^[\w!@#$%]+-[\w!@#$%]+-[\w!@#$%]+-[\w!@#$%]+-[\w!@#$%]+-[\w!@#$%]+$/
       );
@@ -278,7 +280,7 @@ describe('App Accounts API Plugin', function () {
         .send({})
         .expect(200);
 
-      expect(res.body.uid).to.match(new RegExp(`^${testUser}_c\\d{8}$`));
+      expect(res.body.uid).to.match(new RegExp(`^${appUidPrefix}_c\\d{8}$`));
 
       // Verify no description attribute
       const searchRes = await dm.ldap.search(
@@ -654,6 +656,72 @@ describe('App Accounts API Plugin', function () {
         .delete(`/api/v1/users/${mailA}/app-accounts/${b.body.uid}`)
         .set('Authorization', `Bearer ${testToken}`)
         .expect(403);
+    });
+  });
+
+  // Legacy opt-in: app_accounts_user_attribute='uid' restores the pre-#89
+  // contract where `:user` is the LDAP uid and app-uids stay `<uid>_c<digits>`.
+  describe('legacy uid key mode (app_accounts_user_attribute=uid)', () => {
+    let dmUid: DM;
+
+    beforeEach(async function () {
+      this.timeout(10000);
+      if (!process.env.DM_LDAP_BASE) this.skip();
+
+      dmUid = new DM();
+      dmUid.config.ldap_base = process.env.DM_LDAP_BASE;
+      dmUid.config.auth_token = [testToken];
+      dmUid.config.applicative_account_base = applicativeBase;
+      dmUid.config.mail_attribute = 'mail';
+      dmUid.config.app_accounts_user_attribute = 'uid';
+      await dmUid.ready;
+
+      await dmUid.registerPlugin('authToken', new AuthToken(dmUid));
+      await dmUid.registerPlugin('onLdapChange', new OnChange(dmUid));
+      await dmUid.registerPlugin(
+        'appAccountsConsistency',
+        new AppAccountsConsistency(dmUid)
+      );
+      await dmUid.registerPlugin('appAccountsApi', new AppAccountsApi(dmUid));
+
+      await dmUid.ldap.add(testUserDN, {
+        objectClass: 'inetOrgPerson',
+        uid: testUser,
+        cn: 'Test User',
+        sn: 'User',
+        mail: `${testUser}@example.com`,
+      });
+      await new Promise(resolve => setTimeout(resolve, 200));
+    });
+
+    it('resolves :user by uid and keeps the <uid>_c<digits> format', async () => {
+      // The mail is NOT accepted as :user in uid mode.
+      await request(dmUid.app)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({ name: 'Mail device' })
+        .expect(404);
+
+      // The uid is.
+      const created = await request(dmUid.app)
+        .post(`/api/v1/users/${testUser}/app-accounts`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({ name: 'My Device' })
+        .expect(200);
+      expect(created.body.uid).to.match(new RegExp(`^${testUser}_c\\d{8}$`));
+      expect(created.body.mail).to.equal(`${testUser}@example.com`);
+
+      // Listing and deleting work through the uid as well.
+      const list = await request(dmUid.app)
+        .get(`/api/v1/users/${testUser}/app-accounts`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .expect(200);
+      expect(list.body.map((a: any) => a.uid)).to.include(created.body.uid);
+
+      await request(dmUid.app)
+        .delete(`/api/v1/users/${testUser}/app-accounts/${created.body.uid}`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .expect(200);
     });
   });
 

--- a/test/plugins/twake/appAccountsApi.test.ts
+++ b/test/plugins/twake/appAccountsApi.test.ts
@@ -9,6 +9,9 @@ import AuthToken from '../../../src/plugins/auth/token';
 describe('App Accounts API Plugin', function () {
   const timestamp = Date.now();
   const testUser = `testuser-${timestamp}`;
+  // App-account endpoints key on the principal email (the `:user` path param),
+  // not the LDAP uid.
+  const principalEmail = `${testUser}@example.com`;
   let applicativeBase: string;
   let userBase: string;
   let testUserDN: string;
@@ -115,13 +118,13 @@ describe('App Accounts API Plugin', function () {
   describe('GET /api/v1/users/:user/app-accounts', () => {
     it('should return 401 without authorization', async () => {
       const res = await request(dm.app)
-        .get(`/api/v1/users/${testUser}/app-accounts`)
+        .get(`/api/v1/users/${principalEmail}/app-accounts`)
         .expect(401);
     });
 
     it('should return 404 for non-existent user', async () => {
       const res = await request(dm.app)
-        .get('/api/v1/users/nonexistent/app-accounts')
+        .get('/api/v1/users/nonexistent@example.com/app-accounts')
         .set('Authorization', `Bearer ${testToken}`)
         .expect(404);
 
@@ -142,7 +145,7 @@ describe('App Accounts API Plugin', function () {
       await new Promise(resolve => setTimeout(resolve, 100));
 
       const res = await request(dm.app)
-        .get(`/api/v1/users/${testUser}/app-accounts`)
+        .get(`/api/v1/users/${principalEmail}/app-accounts`)
         .set('Authorization', `Bearer ${testToken}`)
         .expect(200);
 
@@ -165,20 +168,20 @@ describe('App Accounts API Plugin', function () {
 
       // Create app accounts via API
       const res1 = await request(dm.app)
-        .post(`/api/v1/users/${testUser}/app-accounts`)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
         .set('Authorization', `Bearer ${testToken}`)
         .send({ name: 'My Phone' })
         .expect(200);
 
       const res2 = await request(dm.app)
-        .post(`/api/v1/users/${testUser}/app-accounts`)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
         .set('Authorization', `Bearer ${testToken}`)
         .send({ name: 'My Laptop' })
         .expect(200);
 
       // List accounts
       const listRes = await request(dm.app)
-        .get(`/api/v1/users/${testUser}/app-accounts`)
+        .get(`/api/v1/users/${principalEmail}/app-accounts`)
         .set('Authorization', `Bearer ${testToken}`)
         .expect(200);
 
@@ -201,14 +204,14 @@ describe('App Accounts API Plugin', function () {
   describe('POST /api/v1/users/:user/app-accounts', () => {
     it('should return 401 without authorization', async () => {
       const res = await request(dm.app)
-        .post(`/api/v1/users/${testUser}/app-accounts`)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
         .send({ name: 'Test' })
         .expect(401);
     });
 
     it('should return 404 for non-existent user', async () => {
       const res = await request(dm.app)
-        .post('/api/v1/users/nonexistent/app-accounts')
+        .post('/api/v1/users/nonexistent@example.com/app-accounts')
         .set('Authorization', `Bearer ${testToken}`)
         .send({ name: 'Test' })
         .expect(404);
@@ -230,7 +233,7 @@ describe('App Accounts API Plugin', function () {
       await new Promise(resolve => setTimeout(resolve, 100));
 
       const res = await request(dm.app)
-        .post(`/api/v1/users/${testUser}/app-accounts`)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
         .set('Authorization', `Bearer ${testToken}`)
         .send({ name: 'My Device' })
         .expect(200);
@@ -270,7 +273,7 @@ describe('App Accounts API Plugin', function () {
       await new Promise(resolve => setTimeout(resolve, 100));
 
       const res = await request(dm.app)
-        .post(`/api/v1/users/${testUser}/app-accounts`)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
         .set('Authorization', `Bearer ${testToken}`)
         .send({})
         .expect(200);
@@ -331,20 +334,20 @@ describe('App Accounts API Plugin', function () {
 
       // Create 2 accounts (should succeed)
       await request(dmTest.app)
-        .post(`/api/v1/users/${testUser}/app-accounts`)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
         .set('Authorization', `Bearer ${testToken}`)
         .send({ name: 'Device 1' })
         .expect(200);
 
       await request(dmTest.app)
-        .post(`/api/v1/users/${testUser}/app-accounts`)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
         .set('Authorization', `Bearer ${testToken}`)
         .send({ name: 'Device 2' })
         .expect(200);
 
       // Third should fail
       const res = await request(dmTest.app)
-        .post(`/api/v1/users/${testUser}/app-accounts`)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
         .set('Authorization', `Bearer ${testToken}`)
         .send({ name: 'Device 3' })
         .expect(400);
@@ -356,17 +359,45 @@ describe('App Accounts API Plugin', function () {
   describe('DELETE /api/v1/users/:user/app-accounts/:uid', () => {
     it('should return 401 without authorization', async () => {
       const res = await request(dm.app)
-        .delete(`/api/v1/users/${testUser}/app-accounts/${testUser}_c12345678`)
+        .delete(
+          `/api/v1/users/${principalEmail}/app-accounts/${testUser}_c12345678`
+        )
         .expect(401);
     });
 
-    it('should return 403 if uid does not belong to user', async () => {
+    it('should return 403 when the account belongs to a different principal', async () => {
+      // Create the user and one app account owned by its principal mail
+      await dm.ldap.add(testUserDN, {
+        objectClass: 'inetOrgPerson',
+        uid: testUser,
+        cn: 'Test User',
+        sn: 'User',
+        mail: `${testUser}@example.com`,
+      });
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const createRes = await request(dm.app)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({ name: 'My Device' })
+        .expect(200);
+
+      const uid = createRes.body.uid;
+
+      // A different principal must not be able to delete it
       const res = await request(dm.app)
-        .delete(`/api/v1/users/${testUser}/app-accounts/otheruser_c12345678`)
+        .delete(`/api/v1/users/intruder@example.com/app-accounts/${uid}`)
         .set('Authorization', `Bearer ${testToken}`)
         .expect(403);
 
       expect(res.body.error).to.match(/does not belong/i);
+
+      // ...and the account must still exist
+      const survivor = await dm.ldap.search(
+        { scope: 'base', paged: false },
+        `uid=${uid},${applicativeBase}`
+      );
+      expect((survivor as any).searchEntries).to.have.lengthOf(1);
     });
 
     it('should delete an app account', async () => {
@@ -383,7 +414,7 @@ describe('App Accounts API Plugin', function () {
 
       // Create app account
       const createRes = await request(dm.app)
-        .post(`/api/v1/users/${testUser}/app-accounts`)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
         .set('Authorization', `Bearer ${testToken}`)
         .send({ name: 'My Device' })
         .expect(200);
@@ -402,7 +433,7 @@ describe('App Accounts API Plugin', function () {
 
       // Delete account
       const deleteRes = await request(dm.app)
-        .delete(`/api/v1/users/${testUser}/app-accounts/${uid}`)
+        .delete(`/api/v1/users/${principalEmail}/app-accounts/${uid}`)
         .set('Authorization', `Bearer ${testToken}`)
         .expect(200);
 
@@ -425,7 +456,9 @@ describe('App Accounts API Plugin', function () {
 
     it('should be idempotent (deleting non-existent account succeeds)', async () => {
       const res = await request(dm.app)
-        .delete(`/api/v1/users/${testUser}/app-accounts/${testUser}_c99999999`)
+        .delete(
+          `/api/v1/users/${principalEmail}/app-accounts/${testUser}_c99999999`
+        )
         .set('Authorization', `Bearer ${testToken}`)
         .expect(200);
 
@@ -449,12 +482,12 @@ describe('App Accounts API Plugin', function () {
 
       // Create two app accounts through the real API
       const created1 = await request(dm.app)
-        .post(`/api/v1/users/${testUser}/app-accounts`)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
         .set('Authorization', `Bearer ${testToken}`)
         .send({ name: 'Phone' })
         .expect(200);
       const created2 = await request(dm.app)
-        .post(`/api/v1/users/${testUser}/app-accounts`)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
         .set('Authorization', `Bearer ${testToken}`)
         .send({ name: 'Laptop' })
         .expect(200);
@@ -464,7 +497,7 @@ describe('App Accounts API Plugin', function () {
 
       // Delete ONLY the first one
       await request(dm.app)
-        .delete(`/api/v1/users/${testUser}/app-accounts/${uid1}`)
+        .delete(`/api/v1/users/${principalEmail}/app-accounts/${uid1}`)
         .set('Authorization', `Bearer ${testToken}`)
         .expect(200);
 
@@ -500,6 +533,127 @@ describe('App Accounts API Plugin', function () {
         (principal as any).searchEntries,
         'principal applicative account must survive a single-account delete'
       ).to.have.lengthOf(1);
+    });
+  });
+
+  // Regression: two users sharing the SAME uid under different subtrees, with
+  // distinct mails. App-account operations key on the unique mail, so they must
+  // resolve to the matching principal and never cross-contaminate.
+  describe('uid collisions across subtrees (regression)', () => {
+    const sharedUid = `collide-${timestamp}`;
+    const mailA = `${sharedUid}-a@example.com`;
+    const mailB = `${sharedUid}-b@example.com`;
+    let ouA: string;
+    let ouB: string;
+    let dnA: string;
+    let dnB: string;
+
+    beforeEach(async function () {
+      if (!process.env.DM_LDAP_BASE) this.skip();
+
+      ouA = `ou=orga-${timestamp},${process.env.DM_LDAP_BASE}`;
+      ouB = `ou=orgb-${timestamp},${process.env.DM_LDAP_BASE}`;
+      dnA = `uid=${sharedUid},${ouA}`;
+      dnB = `uid=${sharedUid},${ouB}`;
+
+      for (const ou of [ouA, ouB]) {
+        try {
+          await dm.ldap.add(ou, {
+            objectClass: ['organizationalUnit', 'top'],
+            ou: ou.split(',')[0].replace('ou=', ''),
+          });
+        } catch (err) {
+          // Ignore if already exists
+        }
+      }
+
+      await dm.ldap.add(dnA, {
+        objectClass: 'inetOrgPerson',
+        uid: sharedUid,
+        cn: 'Collide A',
+        sn: 'A',
+        mail: mailA,
+      });
+      await dm.ldap.add(dnB, {
+        objectClass: 'inetOrgPerson',
+        uid: sharedUid,
+        cn: 'Collide B',
+        sn: 'B',
+        mail: mailB,
+      });
+
+      // Let the consistency plugin create both principal accounts
+      await new Promise(resolve => setTimeout(resolve, 200));
+    });
+
+    afterEach(async () => {
+      try {
+        const result = await dm.ldap.search(
+          {
+            scope: 'sub',
+            filter: `(|(mail=${mailA})(mail=${mailB})(uid=${sharedUid}_*))`,
+            paged: false,
+          },
+          applicativeBase
+        );
+        for (const entry of (result as any).searchEntries || []) {
+          try {
+            await dm.ldap.delete(entry.dn);
+          } catch (e) {
+            // Ignore
+          }
+        }
+      } catch (e) {
+        // Ignore
+      }
+      for (const dn of [dnA, dnB, ouA, ouB]) {
+        try {
+          await dm.ldap.delete(dn);
+        } catch (e) {
+          // Ignore
+        }
+      }
+    });
+
+    it('attaches each app account to the matching principal, not the same-uid user', async () => {
+      const a = await request(dm.app)
+        .post(`/api/v1/users/${mailA}/app-accounts`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({ name: 'A device' })
+        .expect(200);
+
+      const b = await request(dm.app)
+        .post(`/api/v1/users/${mailB}/app-accounts`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({ name: 'B device' })
+        .expect(200);
+
+      // Each app account belongs to its own principal mail
+      expect(a.body.mail).to.equal(mailA);
+      expect(b.body.mail).to.equal(mailB);
+
+      // Listing by one mail never surfaces the other principal's account
+      const listA = await request(dm.app)
+        .get(`/api/v1/users/${mailA}/app-accounts`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .expect(200);
+      const uidsA = listA.body.map((acc: any) => acc.uid);
+      expect(uidsA).to.include(a.body.uid);
+      expect(uidsA).to.not.include(b.body.uid);
+
+      const listB = await request(dm.app)
+        .get(`/api/v1/users/${mailB}/app-accounts`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .expect(200);
+      const uidsB = listB.body.map((acc: any) => acc.uid);
+      expect(uidsB).to.include(b.body.uid);
+      expect(uidsB).to.not.include(a.body.uid);
+
+      // The same-uid principal cannot delete the other's account
+      await request(dm.app)
+        .delete(`/api/v1/users/${mailA}/app-accounts/${b.body.uid}`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .expect(403);
     });
   });
 


### PR DESCRIPTION
## Problem

The app-account endpoints resolved the owning user from the `:user` path param with a subtree `(uid=:user)` search and used the first match. `uid` is not unique across the directory (the same value can exist under different subtrees), so an app account could be created under, listed for, or deleted against the wrong same-named user. The list and delete ownership checks shared the flaw, since they gated on the `<uid>_` prefix.

## Solution

Treat `:user` as the principal email and resolve the user by `(mail=...)`, which is unique, excluding the applicative branch from the match. Scope list and delete ownership by the mail attribute instead of the uid prefix, and reject ambiguous lookups rather than picking the first entry. The generated app-account uid keeps its `<uid>_c<digits>` shape, prefixed from the resolved entry.

Closes #88
