### PR TITLE
feat: mark provisioned b2b users as invited in ldap

### DIFF
--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -202,6 +202,7 @@ export interface Config {
   cloudery_org_id_attribute?: string;
   cloudery_org_role_attribute?: string;
   cloudery_phones_attribute?: string;
+  cloudery_invited_attribute?: string;
   cloudery_default_locale?: string;
   cloudery_workflow_poll_interval_ms?: number;
   cloudery_workflow_max_attempts?: number;
@@ -545,6 +546,11 @@ const configArgs: ConfigTemplate = [
     '--cloudery-phones-attribute',
     'DM_CLOUDERY_PHONES_ATTRIBUTE',
     'twakePhones',
+  ],
+  [
+    '--cloudery-invited-attribute',
+    'DM_CLOUDERY_INVITED_ATTRIBUTE',
+    'twakeInvited',
   ],
   ['--cloudery-default-locale', 'DM_CLOUDERY_DEFAULT_LOCALE', 'en'],
   [

--- a/src/plugins/twake/clouderyProvision.ts
+++ b/src/plugins/twake/clouderyProvision.ts
@@ -82,6 +82,7 @@ export default class ClouderyProvision extends DmPlugin {
   private readonly orgIdAttribute: string;
   private readonly orgRoleAttribute: string;
   private readonly phonesAttribute: string;
+  private readonly invitedAttribute: string;
   private readonly defaultLocale: string;
   private readonly rdnAttribute: string;
   private readonly authExchange: string;
@@ -142,6 +143,8 @@ export default class ClouderyProvision extends DmPlugin {
       (cfg.cloudery_org_role_attribute as string) || 'twakeOrganizationRole';
     this.phonesAttribute =
       (cfg.cloudery_phones_attribute as string) || 'twakePhones';
+    this.invitedAttribute =
+      (cfg.cloudery_invited_attribute as string) || 'twakeInvited';
     this.defaultLocale = (cfg.cloudery_default_locale as string) || 'en';
     this.rdnAttribute = (cfg.scim_user_rdn_attribute as string) || 'uid';
     this.authExchange = (cfg.cozy_auth_exchange as string) || 'auth';
@@ -310,10 +313,14 @@ export default class ClouderyProvision extends DmPlugin {
     // Role and phones live on the user entry for the admin panel to read; they
     // are not part of the Cloudery create payload. Phones are stored as the JSON
     // the panel expects ([{ number, primary }]) and only when present.
+    // twakeInvited marks the member as pending invitation (the string "TRUE",
+    // its schema is a Directory String); the registration app clears it to
+    // "FALSE" once onboarding completes.
     const replace: Record<string, string> = {
       [this.fqdnAttribute]: fqdn,
       [this.orgIdAttribute]: ctx.orgId,
       [this.orgRoleAttribute]: ctx.role,
+      [this.invitedAttribute]: 'TRUE',
     };
     if (phones.length > 0) {
       replace[this.phonesAttribute] = JSON.stringify(phones);

--- a/test/plugins/twake/clouderyProvision.test.ts
+++ b/test/plugins/twake/clouderyProvision.test.ts
@@ -186,6 +186,7 @@ describe('ClouderyProvision plugin', () => {
           twakeWorkspaceUrl: 'johndoeacme123.twake.app',
           twakeOrganizationId: 'acme123',
           twakeOrganizationRole: 'member',
+          twakeInvited: 'TRUE',
           twakePhones: JSON.stringify([
             { number: '+33600000000', primary: true },
           ]),
@@ -240,11 +241,62 @@ describe('ClouderyProvision plugin', () => {
           twakeWorkspaceUrl: 'johndoeacme123.twake.app',
           twakeOrganizationId: 'acme123',
           twakeOrganizationRole: 'member',
+          twakeInvited: 'TRUE',
           twakePhones: JSON.stringify([
             { number: '+33600000000', primary: true },
           ]),
         },
       });
+    });
+
+    it('marks the user as invited (twakeInvited=TRUE) on the entry', async () => {
+      const scope = nock(CLOUDERY)
+        .post('/api/v1/instances')
+        .reply(200, {
+          id: 'inst-1',
+          fqdn: 'johndoeacme123.twake.app',
+          workflow: 'wf-1',
+        })
+        .get('/api/v1/workflows/wf-1')
+        .reply(200, { status: 'succeeded' });
+
+      await create(user, makeReq('acme123'));
+
+      expect(scope.isDone()).to.equal(true);
+      const changes = ldap.modifyCalls[0].changes as {
+        replace: Record<string, unknown>;
+      };
+      expect(changes.replace.twakeInvited).to.equal('TRUE');
+    });
+
+    it('uses the configured attribute name for the invited flag', async () => {
+      dm.config.cloudery_invited_attribute = 'customInvited';
+      const p = new ClouderyProvision(dm);
+      const scope = nock(CLOUDERY)
+        .post('/api/v1/instances')
+        .reply(200, {
+          id: 'inst-1',
+          fqdn: 'johndoeacme123.twake.app',
+          workflow: 'wf-1',
+        })
+        .get('/api/v1/workflows/wf-1')
+        .reply(200, { status: 'succeeded' });
+
+      const pre = p.hooks?.scimusercreate as (
+        a: [ScimUser, unknown]
+      ) => Promise<unknown>;
+      await pre([user, makeReq('acme123')]);
+      const done = p.hooks?.scimusercreatedone as (
+        u: ScimUser
+      ) => Promise<void>;
+      await done(user);
+
+      expect(scope.isDone()).to.equal(true);
+      const changes = ldap.modifyCalls[0].changes as {
+        replace: Record<string, unknown>;
+      };
+      expect(changes.replace.customInvited).to.equal('TRUE');
+      expect(changes.replace).to.not.have.property('twakeInvited');
     });
 
     it('omits twakePhones when the user has no phone numbers', async () => {


### PR DESCRIPTION
## Context
B2B members carry an invitation flag in LDAP (the `twakeInvited` attribute) that the registration app reads to know whether onboarding is still pending. Nothing on the provisioning side was setting it, so newly provisioned members were never marked as invited.

## Solution
When the cloudery provision plugin stamps a provisioned B2B user's entry, it now also writes `twakeInvited: "TRUE"` (the attribute is a Directory String, so the value is the literal string). The registration app clears it to `FALSE` once onboarding completes. The attribute name is configurable via `--cloudery-invited-attribute`.

## Worth knowing
The flag shares the same atomic modify as the workspace URL write, so the `twakeInvited` schema must exist on the directory before this rolls out.
