### PR TITLE
fix: set cn to userName for cloudery-provisioned B2B users

### DIFF
--- a/src/plugins/twake/clouderyProvision.ts
+++ b/src/plugins/twake/clouderyProvision.ts
@@ -439,6 +439,9 @@ export default class ClouderyProvision extends DmPlugin {
       [this.orgIdAttribute]: ctx.orgId,
       [this.orgRoleAttribute]: ctx.role,
       [this.invitedAttribute]: 'TRUE',
+      // Force cn to the userName for B2B provisioning; the core SCIM mapping
+      // sets cn from name.formatted, which is not what we want here.
+      cn: userName,
     };
     if (phones.length > 0) {
       replace[this.phonesAttribute] = JSON.stringify(phones);

--- a/test/plugins/twake/clouderyProvision.test.ts
+++ b/test/plugins/twake/clouderyProvision.test.ts
@@ -187,6 +187,7 @@ describe('ClouderyProvision plugin', () => {
           twakeOrganizationId: 'acme123',
           twakeOrganizationRole: 'member',
           twakeInvited: 'TRUE',
+          cn: 'john.doe',
           twakePhones: JSON.stringify([
             { number: '+33600000000', primary: true },
           ]),
@@ -242,6 +243,7 @@ describe('ClouderyProvision plugin', () => {
           twakeOrganizationId: 'acme123',
           twakeOrganizationRole: 'member',
           twakeInvited: 'TRUE',
+          cn: 'john.doe',
           twakePhones: JSON.stringify([
             { number: '+33600000000', primary: true },
           ]),


### PR DESCRIPTION
## Problem

For B2B users provisioned through the cloudery plugin, the LDAP `cn` was taking whatever the core SCIM mapping produced (`name.formatted`, and `displayName` in that table), so the common name did not match the account's username.

## Solution

The post-create modify already stamps the entry with the workspace URL, org id, role and invite flag; it now also replaces `cn` with the SCIM `userName`. This is scoped to the cloudery provisioning path, so the global SCIM mapping is untouched.