### PR TITLE
fix(clouderyprovision): skip instance creation when one already exists

### DIFF
--- a/src/plugins/twake/clouderyProvision.ts
+++ b/src/plugins/twake/clouderyProvision.ts
@@ -380,53 +380,90 @@ export default class ClouderyProvision extends DmPlugin {
       slug,
     };
 
-    let instance: ClouderyInstanceResponse;
+    // Idempotency guard. The instance slug is deterministic
+    // (normalizeNickname(userName) + orgId), so its FQDN is `${slug}.${domain}`.
+    // If an instance for that FQDN already exists (e.g. the user is re-imported
+    // after their LDAP entry was recreated while the Cloudery instance survived),
+    // reuse it. Creating unconditionally makes Cloudery mint a numbered
+    // duplicate (slug2). Fail open: if the lookup errors, fall through to create
+    // rather than block provisioning.
+    // Lowercase to the canonical DNS form. Cloudery stores the instance FQDN
+    // lowercased and `normalizeNickname` does not fold case, so a mixed-case
+    // userName would otherwise make this computed key miss the existing instance
+    // (defeating the guard) and, on the reuse path, persist a non-canonical FQDN
+    // that the later deprovision lookup could not resolve.
+    const expectedFqdn = `${slug}.${this.clouderyDomain}`.toLowerCase();
+    let existingUuid: string | null = null;
     try {
-      this.logger.info({
-        ...log,
-        result: 'creating_instance',
-        orgDomain,
-        email,
-        mobile: mobile || undefined,
-      });
-      instance = await this.createInstance({
-        email,
-        publicName,
-        locale: this.extractLocale(user),
-        oidc: slug,
-        phone: mobile || '',
-        slug,
-        public_name: publicName,
-        offer: this.offer,
-        domain: this.clouderyDomain,
-        skip_email_validation: true,
-        internal_email: email,
-        org_domain: orgDomain,
-        org_id: ctx.orgId,
-      });
+      existingUuid = await this.findInstanceUuidByFqdn(expectedFqdn);
     } catch (err) {
-      this.logger.error({
+      this.logger.warn({
         ...log,
-        result: 'error',
+        result: 'existence_lookup_failed',
+        fqdn: expectedFqdn,
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         error: `${err}`,
       });
-      return;
     }
 
-    const ready = instance.workflow
-      ? await this.waitForWorkflow(instance.workflow)
-      : true;
-    if (!ready) {
-      this.logger.error({
+    let fqdn: string;
+    if (existingUuid) {
+      this.logger.info({
         ...log,
-        result: 'workflow_failed',
-        workflow: instance.workflow,
+        result: 'instance_exists',
+        fqdn: expectedFqdn,
+        uuid: existingUuid,
       });
-      return;
-    }
+      fqdn = expectedFqdn;
+    } else {
+      let instance: ClouderyInstanceResponse;
+      try {
+        this.logger.info({
+          ...log,
+          result: 'creating_instance',
+          orgDomain,
+          email,
+          mobile: mobile || undefined,
+        });
+        instance = await this.createInstance({
+          email,
+          publicName,
+          locale: this.extractLocale(user),
+          oidc: slug,
+          phone: mobile || '',
+          slug,
+          public_name: publicName,
+          offer: this.offer,
+          domain: this.clouderyDomain,
+          skip_email_validation: true,
+          internal_email: email,
+          org_domain: orgDomain,
+          org_id: ctx.orgId,
+        });
+      } catch (err) {
+        this.logger.error({
+          ...log,
+          result: 'error',
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          error: `${err}`,
+        });
+        return;
+      }
 
-    const fqdn = instance.fqdn;
+      const ready = instance.workflow
+        ? await this.waitForWorkflow(instance.workflow)
+        : true;
+      if (!ready) {
+        this.logger.error({
+          ...log,
+          result: 'workflow_failed',
+          workflow: instance.workflow,
+        });
+        return;
+      }
+
+      fqdn = instance.fqdn;
+    }
     const dn = `${this.rdnAttribute}=${escapeDnValue(userName)},${ctx.base}`;
     // Role and phones live on the user entry for the admin panel to read; they
     // are not part of the Cloudery create payload. Phones are stored as the JSON

--- a/test/plugins/twake/clouderyProvision.test.ts
+++ b/test/plugins/twake/clouderyProvision.test.ts
@@ -210,6 +210,36 @@ describe('ClouderyProvision plugin', () => {
       });
     });
 
+    it('skips instance creation when an instance for the slug already exists', async () => {
+      // Re-import scenario: the LDAP entry was recreated but the Cloudery
+      // instance for this slug survived. The plugin must reuse it instead of
+      // letting Cloudery mint a numbered duplicate (slug2). Note: no POST
+      // /api/v1/instances is registered, so any create attempt fails the test.
+      const scope = nock(CLOUDERY)
+        .get('/api/v2/instances')
+        .query(q => q.fqdn === 'johndoeacme123.twake.app')
+        .reply(200, { items: [{ _id: 'existing-uuid' }] });
+
+      await create(user, makeReq('acme123'));
+
+      expect(scope.isDone(), 'cloudery existence lookup').to.equal(true);
+
+      // The existing instance's fqdn is written back and the entry announced,
+      // so registration can skip its own creation and downstream stays linked.
+      expect(ldap.modifyCalls).to.have.length(1);
+      expect(ldap.modifyCalls[0].dn).to.equal(`uid=john.doe,${USER_BASE}`);
+      const changes = ldap.modifyCalls[0].changes as {
+        replace: Record<string, unknown>;
+      };
+      expect(changes.replace.twakeWorkspaceUrl).to.equal(
+        'johndoeacme123.twake.app'
+      );
+      expect(rabbit.calls).to.have.length(1);
+      expect(rabbit.calls[0].message.workplaceFqdn).to.equal(
+        'johndoeacme123.twake.app'
+      );
+    });
+
     it('trims whitespace in the email and org id before use', async () => {
       let body: Record<string, unknown> = {};
       const scope = nock(CLOUDERY)


### PR DESCRIPTION
## Context

On a SCIM user create, the plugin provisioned a Cloudery instance unconditionally. When an instance for the computed slug already existed (for example the LDAP entry was recreated while the Cloudery instance survived), Cloudery minted a numbered duplicate (slug2) rather than reusing the existing one.

## Solution

Before creating, look up the instance by its expected FQDN and reuse it when present, creating only when none exists. The lookup uses the canonical lowercase FQDN and falls through to creation if it errors, so provisioning is never blocked by the check.
