### PR TITLE
ci: publish to npm and cut a github release on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+# Tag-driven release: publish to npm (via OIDC Trusted Publishing) and cut a
+# matching GitHub Release. Push a `vX.Y.Z` tag and both happen. The GitHub
+# Release is gated on a successful npm publish, so the two can never disagree.
+on:
+  push:
+    tags:
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+
+# Serialize releases: a later tag must not race an in-flight publish and win
+# the `latest` dist-tag. Never cancel a publish mid-flight.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # id-token: write authenticates to npm through OIDC (Trusted Publishing):
+    # no long-lived NPM_TOKEN to store or rotate, and a provenance attestation
+    # is attached to every release for free.
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+      # registry-url is intentionally omitted: it makes setup-node write an
+      # .npmrc carrying a dummy auth token that can shadow OIDC. npmjs.org is
+      # already the default registry, so OIDC publishing works without it.
+
+      # Trusted Publishing requires npm >= 11.5.1, newer than the version
+      # bundled with Node 22.
+      - name: Update npm for Trusted Publishing
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build package
+        run: npm run build
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "Tag v$TAG does not match package.json version $PKG."
+            echo "Bump the version in package.json before pushing the tag."
+            exit 1
+          fi
+          echo "Tag matches package.json version: $PKG"
+
+      - name: Verify package entry points exist
+        run: |
+          node -e '
+            const fs = require("fs");
+            const p = require("./package.json");
+            const files = new Set();
+            for (const v of Object.values(p.exports || {})) {
+              if (v && typeof v === "object") {
+                if (v.import) files.add(v.import);
+                if (v.types) files.add(v.types);
+              }
+            }
+            for (const b of Object.values(p.bin || {})) files.add(b);
+            const missing = [...files].filter((f) => !fs.existsSync(f));
+            if (missing.length) {
+              console.error("Missing entry files:\n  " + missing.join("\n  "));
+              process.exit(1);
+            }
+            console.log("Verified " + files.size + " package entry files");
+          '
+
+      - name: Pack tarball
+        run: npm pack
+
+      - name: Publish to npm
+        run: |
+          # Keep prereleases (e.g. v1.2.3-rc.1) off the `latest` dist-tag.
+          case "$GITHUB_REF_NAME" in
+            *-*) NPM_TAG=next ;;
+            *)   NPM_TAG=latest ;;
+          esac
+          npm publish --access public --tag "$NPM_TAG"
+
+      - name: Upload release tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-tarball
+          path: ldap-rest-*.tgz
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Download release tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-tarball
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: ldap-rest-*.tgz


### PR DESCRIPTION
## Context

New versions reach npm through a manual `npm publish` by a single maintainer, so releases depend on one person and the state of their local machine, and the published version can drift from the git tag. Closes #97.

## Solution

A tag matching `vX.Y.Z` now runs one gated pipeline: it tests, builds, checks that the tag equals the `package.json` version and that every published entry point exists, then publishes to npm and cuts a GitHub Release with the exact tarball attached. The Release job only runs after a successful publish, so npm and GitHub cannot disagree. Authentication uses npm OIDC Trusted Publishing, so there is no token to store and every release gets a provenance attestation. Prereleases (a version with a suffix like `rc.1`) go to the `next` dist-tag instead of `latest`.

## One-time setup
guide: https://docs.npmjs.com/trusted-publishers

Publishing fails until a package owner registers this workflow as a Trusted Publisher on npm. The package already exists on npm, so OIDC is available. On npmjs.com open the `ldap-rest` package, go to Settings, then Trusted Publisher, and add a GitHub Actions publisher with:

- Organization or user: `linagora`
- Repository: `ldap-rest`
- Workflow filename: `release.yml`
- Environment: leave empty

After that, bump `package.json`, push a matching `vX.Y.Z` tag, and the release runs on its own.
