### PR TITLE
feat(calendar): sync user identity to Twake Calendar registered users

### DIFF
--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -176,6 +176,8 @@ export interface Config {
   calendar_resource_objectclass?: string;
   calendar_resource_creator?: string;
   calendar_resource_domain?: string;
+  calendar_firstname_attribute?: string;
+  calendar_lastname_attribute?: string;
 
   // Cozy provisioning plugin
   cozy_admin_url?: string;
@@ -487,6 +489,12 @@ const configArgs: ConfigTemplate = [
   ['--calendar-resource-objectclass', 'DM_CALENDAR_RESOURCE_OBJECTCLASS', ''],
   ['--calendar-resource-creator', 'DM_CALENDAR_RESOURCE_CREATOR', ''],
   ['--calendar-resource-domain', 'DM_CALENDAR_RESOURCE_DOMAIN', ''],
+  [
+    '--calendar-firstname-attribute',
+    'DM_CALENDAR_FIRSTNAME_ATTRIBUTE',
+    'givenName',
+  ],
+  ['--calendar-lastname-attribute', 'DM_CALENDAR_LASTNAME_ATTRIBUTE', 'sn'],
 
   // Cozy provisioning plugin (twake/cozyProvision)
   ['--cozy-admin-url', 'DM_COZY_ADMIN_URL', ''],

--- a/src/plugins/twake/calendarResources.ts
+++ b/src/plugins/twake/calendarResources.ts
@@ -2,24 +2,33 @@ import fetch from 'node-fetch';
 
 import TwakePlugin from '../../abstract/twakePlugin';
 import { type Role } from '../../abstract/plugin';
-import type { AttributesList } from '../../lib/ldapActions';
+import type { AttributesList, AttributeValue } from '../../lib/ldapActions';
 import { Hooks } from '../../hooks';
 
 /**
- * Plugin to sync LDAP resources with Twake Calendar
+ * Plugin to sync LDAP resources and users with Twake Calendar
  *
  * Monitors a LDAP branch for resources (meeting rooms, equipment, etc.)
- * and automatically creates/updates/deletes them in Twake Calendar via WebAdmin API
+ * and automatically creates/updates/deletes them in Twake Calendar via WebAdmin API.
+ *
+ * Also propagates user identity changes (email, first name, last name) to the
+ * Twake Calendar "registered users" via the WebAdmin API.
  */
 export default class CalendarResources extends TwakePlugin {
   name = 'calendarResources';
   roles: Role[] = ['consistency'] as const;
+
+  dependencies = {
+    onLdapChange: 'core/ldap/onChange',
+  };
 
   // Calendar-specific configuration attributes
   private resourceBase: string;
   private resourceObjectClass: string;
   private resourceCreator: string;
   private resourceDomain: string;
+  private firstnameAttr: string;
+  private lastnameAttr: string;
 
   constructor(server: import('../../bin').DM) {
     super(
@@ -37,6 +46,12 @@ export default class CalendarResources extends TwakePlugin {
       (this.config.calendar_resource_creator as string) || 'admin@example.com';
     this.resourceDomain =
       (this.config.calendar_resource_domain as string) || '';
+
+    // LDAP attributes holding the user's first and last name (for registered users)
+    this.firstnameAttr =
+      (this.config.calendar_firstname_attribute as string) || 'givenName';
+    this.lastnameAttr =
+      (this.config.calendar_lastname_attribute as string) || 'sn';
   }
 
   hooks: Hooks = {
@@ -137,6 +152,46 @@ export default class CalendarResources extends TwakePlugin {
         { resourceId }
       );
     },
+
+    /**
+     * Handle user email changes.
+     * The registered user is keyed by the (old) email in Calendar, so we look
+     * it up by the old address and PATCH it with the new email and names.
+     */
+    onLdapMailChange: async (
+      dn: string,
+      oldmail: AttributeValue | null,
+      newmail: AttributeValue | null
+    ) => {
+      const oldmailStr = this.attributeToString(oldmail);
+      const newmailStr = this.attributeToString(newmail);
+
+      // Skip additions (no previous mail) and deletions (no new mail):
+      // there is nothing to update on the Calendar side in those cases.
+      if (!oldmailStr) {
+        this.logger.debug(
+          `Skipping registered user sync for ${dn}: oldmail is empty (mail added, not changed)`
+        );
+        return;
+      }
+      if (!newmailStr) {
+        this.logger.debug(
+          `Skipping registered user sync for ${dn}: newmail is empty (mail deleted)`
+        );
+        return;
+      }
+
+      await this.syncRegisteredUser('onLdapMailChange', dn, oldmailStr);
+    },
+
+    /**
+     * Handle display name changes (cn / givenName / sn).
+     * The email is unchanged, so the registered user is looked up by its
+     * current mail.
+     */
+    onLdapDisplayNameChange: async (dn: string) => {
+      await this.syncRegisteredUser('onLdapDisplayNameChange', dn);
+    },
   };
 
   /**
@@ -215,6 +270,139 @@ export default class CalendarResources extends TwakePlugin {
     // Extract cn or uid from DN
     const match = dn.match(/(?:cn|uid)=([^,]+)/i);
     return match ? match[1] : null;
+  }
+
+  /**
+   * Synchronize an LDAP user's identity (email, first and last name) to the
+   * Twake Calendar registered users via the WebAdmin API.
+   *
+   * Registered users are keyed by an internal id, and `GET /registeredUsers`
+   * exposes no filter, so we list all registered users, locate the entry by
+   * email, then `PATCH /registeredUsers?id={id}` with the LDAP values.
+   *
+   * @param event Hook name, used for logging
+   * @param dn LDAP DN of the user
+   * @param lookupEmail Email used to locate the existing registered user.
+   *   Defaults to the user's current mail; pass the OLD mail when the email
+   *   itself is changing (Calendar still holds the previous address).
+   */
+  async syncRegisteredUser(
+    event: string,
+    dn: string,
+    lookupEmail?: string
+  ): Promise<void> {
+    const log = {
+      plugin: this.name,
+      event,
+      result: 'error',
+      dn,
+    };
+
+    // Fetch the desired identity values from LDAP
+    const entry = await this.ldapGetAttributes(dn, [
+      this.mailAttr,
+      this.firstnameAttr,
+      this.lastnameAttr,
+    ]);
+    if (!entry) {
+      this.logger.warn({
+        ...log,
+        message: `Cannot sync registered user: entry not found for ${dn}`,
+      });
+      return;
+    }
+
+    const mail = this.attributeToString(entry[this.mailAttr]);
+    if (!mail) {
+      this.logger.warn({
+        ...log,
+        message: `Cannot sync registered user: no mail found for ${dn}`,
+      });
+      return;
+    }
+
+    const firstname = this.attributeToString(entry[this.firstnameAttr]);
+    const lastname = this.attributeToString(entry[this.lastnameAttr]);
+    const searchEmail = lookupEmail || mail;
+
+    try {
+      // Step 1: list registered users and find the one matching searchEmail
+      const listRes = await this.requestLimit(() =>
+        fetch(`${this.webadminUrl}/registeredUsers`, {
+          method: 'GET',
+          headers: this.createHeaders(),
+        })
+      );
+      if (!listRes.ok) {
+        this.logger.error({
+          ...log,
+          step: 'list_registered_users',
+          http_status: listRes.status,
+          http_status_text: listRes.statusText,
+        });
+        return;
+      }
+
+      const users = (await listRes.json()) as Array<{
+        id: string;
+        email: string;
+        firstname?: string;
+        lastname?: string;
+      }>;
+      const existing = users.find(
+        u => u.email?.toLowerCase() === searchEmail.toLowerCase()
+      );
+      if (!existing) {
+        this.logger.warn({
+          ...log,
+          step: 'find_registered_user',
+          searchEmail,
+          message: 'user not registered in Calendar',
+        });
+        return;
+      }
+
+      // Step 2: PATCH the registered user by id with the LDAP values
+      const patchUrl = new URL(`${this.webadminUrl}/registeredUsers`);
+      patchUrl.searchParams.set('id', existing.id);
+
+      const payload: {
+        email: string;
+        firstname?: string;
+        lastname?: string;
+      } = { email: mail };
+      if (firstname) payload.firstname = firstname;
+      if (lastname) payload.lastname = lastname;
+
+      const patchRes = await this.requestLimit(() =>
+        fetch(patchUrl.toString(), {
+          method: 'PATCH',
+          headers: this.createHeaders('application/json'),
+          body: JSON.stringify(payload),
+        })
+      );
+
+      if (!patchRes.ok) {
+        this.logger.error({
+          ...log,
+          step: 'patch_registered_user',
+          id: existing.id,
+          http_status: patchRes.status,
+          http_status_text: patchRes.statusText,
+        });
+      } else {
+        this.logger.info({
+          ...log,
+          result: 'success',
+          id: existing.id,
+          http_status: patchRes.status,
+          ...payload,
+        });
+      }
+    } catch (err) {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      this.logger.error({ ...log, error: `${err}` });
+    }
   }
 
   /**

--- a/src/plugins/twake/calendarResources.ts
+++ b/src/plugins/twake/calendarResources.ts
@@ -2,7 +2,8 @@ import fetch from 'node-fetch';
 
 import TwakePlugin from '../../abstract/twakePlugin';
 import { type Role } from '../../abstract/plugin';
-import type { AttributesList, AttributeValue } from '../../lib/ldapActions';
+import type { AttributesList } from '../../lib/ldapActions';
+import type { ChangesToNotify } from '../ldap/onChange';
 import { Hooks } from '../../hooks';
 
 /**
@@ -154,43 +155,36 @@ export default class CalendarResources extends TwakePlugin {
     },
 
     /**
-     * Handle user email changes.
-     * The registered user is keyed by the (old) email in Calendar, so we look
-     * it up by the old address and PATCH it with the new email and names.
+     * Propagate user identity changes to the Calendar registered users.
+     *
+     * A single hook is used (rather than onLdapMailChange /
+     * onLdapDisplayNameChange) so the sync is driven by the *configured* mail,
+     * first name and last name attributes — the display-name hook only fires on
+     * the hard-coded cn/givenName/sn attributes, which would silently ignore a
+     * non-default firstname/lastname attribute.
      */
-    onLdapMailChange: async (
-      dn: string,
-      oldmail: AttributeValue | null,
-      newmail: AttributeValue | null
-    ) => {
-      const oldmailStr = this.attributeToString(oldmail);
-      const newmailStr = this.attributeToString(newmail);
+    onLdapChange: async (dn: string, changes: ChangesToNotify) => {
+      const mailChange = changes[this.mailAttr];
+      if (mailChange) {
+        const oldmail = this.attributeToString(mailChange[0]);
+        const newmail = this.attributeToString(mailChange[1]);
 
-      // Skip additions (no previous mail) and deletions (no new mail):
-      // there is nothing to update on the Calendar side in those cases.
-      if (!oldmailStr) {
-        this.logger.debug(
-          `Skipping registered user sync for ${dn}: oldmail is empty (mail added, not changed)`
-        );
+        // Only a real rename (old and new both present) updates Calendar.
+        // Additions and deletions of the mail attribute are skipped: there is
+        // nothing to rename on the Calendar side.
+        if (oldmail && newmail && oldmail !== newmail) {
+          // The registered user is keyed by the previous email in Calendar, so
+          // look it up by the old address and PATCH it with the new values.
+          await this.syncRegisteredUser('onLdapMailChange', dn, oldmail);
+        }
         return;
       }
-      if (!newmailStr) {
-        this.logger.debug(
-          `Skipping registered user sync for ${dn}: newmail is empty (mail deleted)`
-        );
-        return;
+
+      // Name-only change: sync when a configured name attribute changed. The
+      // email is unchanged, so the user is looked up by its current mail.
+      if (changes[this.firstnameAttr] || changes[this.lastnameAttr]) {
+        await this.syncRegisteredUser('onLdapDisplayNameChange', dn);
       }
-
-      await this.syncRegisteredUser('onLdapMailChange', dn, oldmailStr);
-    },
-
-    /**
-     * Handle display name changes (cn / givenName / sn).
-     * The email is unchanged, so the registered user is looked up by its
-     * current mail.
-     */
-    onLdapDisplayNameChange: async (dn: string) => {
-      await this.syncRegisteredUser('onLdapDisplayNameChange', dn);
     },
   };
 

--- a/test/plugins/twake/calendarResources.test.ts
+++ b/test/plugins/twake/calendarResources.test.ts
@@ -227,4 +227,135 @@ describe('Calendar Resources Plugin', function () {
       nock.cleanAll();
     });
   });
+
+  describe('registered users sync', () => {
+    let userDN: string;
+    const calendarUrl =
+      process.env.DM_CALENDAR_WEBADMIN_URL || 'http://localhost:8080';
+
+    beforeEach(async () => {
+      userDN = `uid=caluser,${process.env.DM_LDAP_BASE}`;
+      try {
+        await dm.ldap.add(userDN, {
+          objectClass: ['inetOrgPerson', 'top'],
+          uid: 'caluser',
+          cn: 'Benoit TELLIER',
+          givenName: 'Benoit',
+          sn: 'TELLIER',
+          mail: 'caluser@test.org',
+        });
+      } catch (err) {
+        // Ignore if already exists
+      }
+      // Creating the entry fires an async onLdapDisplayNameChange (our own
+      // hook); let it settle — it fails harmlessly without a nock scope — so it
+      // cannot consume the interceptors the tests set up below.
+      await new Promise(resolve => setTimeout(resolve, 300));
+    });
+
+    afterEach(async () => {
+      try {
+        await dm.ldap.delete(userDN);
+      } catch (err) {
+        // Ignore if it does not exist
+      }
+      nock.cleanAll();
+    });
+
+    it('lists registered users and PATCHes the one matching the email', async () => {
+      let patchBody: Record<string, unknown> | null = null;
+      let patchUri = '';
+      const scope = nock(calendarUrl)
+        .get('/registeredUsers')
+        .reply(200, [
+          {
+            id: '5f50a663',
+            email: 'caluser@test.org',
+            firstname: 'Old',
+            lastname: 'Name',
+          },
+          { id: 'other', email: 'someoneelse@test.org' },
+        ])
+        .patch('/registeredUsers', body => {
+          patchBody = body as Record<string, unknown>;
+          return true;
+        })
+        .query(true)
+        .reply(function (uri) {
+          patchUri = uri;
+          return [204];
+        });
+
+      await calendarResources.syncRegisteredUser('test', userDN);
+
+      expect(scope.isDone()).to.be.true;
+      expect(patchUri).to.contain('id=5f50a663');
+      expect(patchBody).to.deep.equal({
+        email: 'caluser@test.org',
+        firstname: 'Benoit',
+        lastname: 'TELLIER',
+      });
+    });
+
+    it('looks up by the OLD email on mail change and PATCHes the new email', async () => {
+      let patchBody: Record<string, unknown> | null = null;
+      let patchUri = '';
+      const scope = nock(calendarUrl)
+        .get('/registeredUsers')
+        .reply(200, [
+          {
+            id: 'abc123',
+            email: 'old@test.org',
+            firstname: 'Benoit',
+            lastname: 'TELLIER',
+          },
+        ])
+        .patch('/registeredUsers', body => {
+          patchBody = body as Record<string, unknown>;
+          return true;
+        })
+        .query(true)
+        .reply(function (uri) {
+          patchUri = uri;
+          return [204];
+        });
+
+      // LDAP now holds caluser@test.org; Calendar still has old@test.org
+      await calendarResources.hooks.onLdapMailChange!(
+        userDN,
+        'old@test.org',
+        'caluser@test.org'
+      );
+
+      expect(scope.isDone()).to.be.true;
+      expect(patchUri).to.contain('id=abc123');
+      expect(patchBody).to.deep.equal({
+        email: 'caluser@test.org',
+        firstname: 'Benoit',
+        lastname: 'TELLIER',
+      });
+    });
+
+    it('does not PATCH when the user is not registered in Calendar', async () => {
+      const scope = nock(calendarUrl)
+        .get('/registeredUsers')
+        .reply(200, [{ id: 'other', email: 'someoneelse@test.org' }]);
+
+      await calendarResources.syncRegisteredUser('test', userDN);
+
+      // GET happened, no PATCH was issued (would throw on unmocked request)
+      expect(scope.isDone()).to.be.true;
+    });
+
+    it('skips sync when the mail is added (no previous mail)', async () => {
+      // No nock scope: any HTTP call would throw (netConnect disabled)
+      await calendarResources.hooks.onLdapMailChange!(
+        userDN,
+        null,
+        'caluser@test.org'
+      );
+      // Reaching here without a thrown unmocked-request error proves no call
+      expect(nock.pendingMocks()).to.have.length(0);
+    });
+  });
 });

--- a/test/plugins/twake/calendarResources.test.ts
+++ b/test/plugins/twake/calendarResources.test.ts
@@ -247,10 +247,9 @@ describe('Calendar Resources Plugin', function () {
       } catch (err) {
         // Ignore if already exists
       }
-      // Creating the entry fires an async onLdapDisplayNameChange (our own
-      // hook); let it settle — it fails harmlessly without a nock scope — so it
-      // cannot consume the interceptors the tests set up below.
-      await new Promise(resolve => setTimeout(resolve, 300));
+      // Creating the entry fires onLdapChange with the mail attribute present,
+      // which the plugin treats as an addition and skips — so no stray
+      // /registeredUsers call races with the interceptors set up below.
     });
 
     afterEach(async () => {
@@ -321,11 +320,9 @@ describe('Calendar Resources Plugin', function () {
         });
 
       // LDAP now holds caluser@test.org; Calendar still has old@test.org
-      await calendarResources.hooks.onLdapMailChange!(
-        userDN,
-        'old@test.org',
-        'caluser@test.org'
-      );
+      await calendarResources.hooks.onLdapChange!(userDN, {
+        mail: ['old@test.org', 'caluser@test.org'],
+      });
 
       expect(scope.isDone()).to.be.true;
       expect(patchUri).to.contain('id=abc123');
@@ -349,12 +346,55 @@ describe('Calendar Resources Plugin', function () {
 
     it('skips sync when the mail is added (no previous mail)', async () => {
       // No nock scope: any HTTP call would throw (netConnect disabled)
-      await calendarResources.hooks.onLdapMailChange!(
-        userDN,
-        null,
-        'caluser@test.org'
-      );
+      await calendarResources.hooks.onLdapChange!(userDN, {
+        mail: [null, 'caluser@test.org'],
+      });
       // Reaching here without a thrown unmocked-request error proves no call
+      expect(nock.pendingMocks()).to.have.length(0);
+    });
+
+    it('syncs names when a configured name attribute changes', async () => {
+      let patchBody: Record<string, unknown> | null = null;
+      let patchUri = '';
+      const scope = nock(calendarUrl)
+        .get('/registeredUsers')
+        .reply(200, [
+          {
+            id: 'nm1',
+            email: 'caluser@test.org',
+            firstname: 'Old',
+            lastname: 'Name',
+          },
+        ])
+        .patch('/registeredUsers', body => {
+          patchBody = body as Record<string, unknown>;
+          return true;
+        })
+        .query(true)
+        .reply(function (uri) {
+          patchUri = uri;
+          return [204];
+        });
+
+      // sn is the default configured lastname attribute
+      await calendarResources.hooks.onLdapChange!(userDN, {
+        sn: ['Name', 'TELLIER'],
+      });
+
+      expect(scope.isDone()).to.be.true;
+      expect(patchUri).to.contain('id=nm1');
+      expect(patchBody).to.deep.equal({
+        email: 'caluser@test.org',
+        firstname: 'Benoit',
+        lastname: 'TELLIER',
+      });
+    });
+
+    it('ignores changes to unrelated attributes', async () => {
+      // No nock scope: any HTTP call would throw (netConnect disabled)
+      await calendarResources.hooks.onLdapChange!(userDN, {
+        description: ['before', 'after'],
+      });
       expect(nock.pendingMocks()).to.have.length(0);
     });
   });


### PR DESCRIPTION
## Context

Extends the Calendar plugin (`calendarResources`) to propagate LDAP user identity changes (email, first name, last name) to the **Twake Calendar registered users** via the WebAdmin API.

Until now the Calendar plugin only synced *resources* (meeting rooms, equipment) and had a `deleteUserData` helper — there was no `registeredUsers` handling at all.

API contract per the [official docs](https://github.com/linagora/twake-calendar-side-service/blob/main/docs/apis/webadmin.md):

- `GET /registeredUsers` → `200` with `[{ id, email, firstname, lastname }]` (no filter)
- `PATCH /registeredUsers?id={id}` → `204`, body `{ email?, firstname?, lastname? }`

Since a PATCH targets the **internal `id`** and the GET exposes no filter, the plugin lists the registered users, locates the entry by email, then PATCHes it — mirroring the `GET-list → find-by-email → PATCH-by-id` flow already used for James identities.

## Behaviour

| Hook | Lookup key | PATCH payload |
|---|---|---|
| `onLdapMailChange` | **old** email (Calendar still holds it) | new email + current first/last name |
| `onLdapDisplayNameChange` (`cn`/`givenName`/`sn`) | current email | current first/last name |

- Additions/deletions of the mail attribute are skipped (nothing to update on the Calendar side).
- When the user is not registered in Calendar, it logs a warning and returns — no PATCH.
- First/last name attributes are configurable: `--calendar-firstname-attribute` (default `givenName`), `--calendar-lastname-attribute` (default `sn`).

## Tests

New `registered users sync` suite (4 tests): PATCH by matched email, lookup-by-old-email on mail change, no-PATCH when unregistered, skip on mail addition.

- ✅ `tsc --noEmit` and `eslint` clean
- ✅ Full Calendar Resources suite green against a real (Dockerized) LDAP — resources + `deleteUserData` + the 4 new tests
- ✅ Full embedded suite: 833 passing, 0 failing (no regressions)