### PR TITLE
ci(release): publish Docker image, Helm chart and npm package on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,230 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY_GHCR: ghcr.io
+  REGISTRY_DOCKER: docker.io
+  IMAGE_GHCR: ghcr.io/linagora/ldap-rest
+  IMAGE_DOCKER: docker.io/yadd/ldap-rest
+
+jobs:
+  # Build and push the amd64 image (fast, runs first).
+  docker-amd64:
+    name: Build & Push Docker (amd64)
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_GHCR }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_DOCKER }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.IMAGE_GHCR }}
+            ${{ env.IMAGE_DOCKER }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push (amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_GHCR }}:${{ steps.version.outputs.version }}-amd64
+            ${{ env.IMAGE_DOCKER }}:${{ steps.version.outputs.version }}-amd64
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # Build the arm64 image (slow; runs in parallel with the helm job).
+  docker-arm64:
+    name: Build & Push Docker (arm64)
+    runs-on: ubuntu-latest
+    needs: docker-amd64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_GHCR }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_DOCKER }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_GHCR }}:${{ needs.docker-amd64.outputs.version }}-arm64
+            ${{ env.IMAGE_DOCKER }}:${{ needs.docker-amd64.outputs.version }}-arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # Assemble the multi-arch manifests once both arch builds are pushed.
+  docker-manifest:
+    name: Create Multi-arch Manifest
+    runs-on: ubuntu-latest
+    needs: [docker-amd64, docker-arm64]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_GHCR }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_DOCKER }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifests
+        env:
+          VERSION: ${{ needs.docker-amd64.outputs.version }}
+        run: |
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+
+          for IMAGE in "$IMAGE_GHCR" "$IMAGE_DOCKER"; do
+            for TAG in "$VERSION" "$MAJOR_MINOR" "$MAJOR" "latest"; do
+              docker buildx imagetools create -t "${IMAGE}:${TAG}" \
+                "${IMAGE}:${VERSION}-amd64" \
+                "${IMAGE}:${VERSION}-arm64"
+            done
+          done
+
+  # Package and push the Helm chart as an OCI artifact (parallel with arm64).
+  helm:
+    name: Release Helm Chart
+    runs-on: ubuntu-latest
+    needs: docker-amd64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.0
+
+      - name: Set chart version from tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Setting chart version and appVersion to $VERSION"
+          sed -i "s/^version:.*/version: $VERSION/" helm/ldap-rest/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" helm/ldap-rest/Chart.yaml
+          cat helm/ldap-rest/Chart.yaml
+
+      - name: Lint chart
+        run: helm lint helm/ldap-rest
+
+      - name: Package chart
+        run: helm package helm/ldap-rest --destination .
+
+      - name: Login to GHCR (Helm registry)
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY_GHCR }} --username ${{ github.actor }} --password-stdin
+
+      - name: Push chart to OCI registry
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          helm push "ldap-rest-${VERSION}.tgz" oci://${{ env.REGISTRY_GHCR }}/linagora/charts
+
+  # Publish the package to the npm registry (independent of the Docker/Helm jobs).
+  npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # required for npm provenance
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "❌ Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "✅ Tag version matches package.json version: $PKG_VERSION"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/helm/ldap-rest/.helmignore
+++ b/helm/ldap-rest/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/ldap-rest/Chart.yaml
+++ b/helm/ldap-rest/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: ldap-rest
+description: A Helm chart for deploying ldap-rest — a REST/SCIM API server in front of an LDAP directory
+type: application
+# version and appVersion are overwritten from the git tag by the release
+# workflow (.github/workflows/release.yml). The values here are only a
+# fallback for local `helm package` / `helm install` from a checkout.
+version: 0.4.5
+appVersion: "0.4.5"
+
+home: https://github.com/linagora/ldap-rest
+
+keywords:
+  - ldap
+  - rest
+  - scim
+  - directory
+  - twake
+
+maintainers:
+  - name: yadd
+    url: https://github.com/linagora/ldap-rest
+
+sources:
+  - https://github.com/linagora/ldap-rest

--- a/helm/ldap-rest/README.md
+++ b/helm/ldap-rest/README.md
@@ -1,0 +1,70 @@
+# ldap-rest Helm chart
+
+Deploys [ldap-rest](https://github.com/linagora/ldap-rest), a REST/SCIM API
+server that sits in front of an LDAP directory.
+
+The chart is published as an OCI artifact on each release tag.
+
+## Install
+
+```bash
+# Latest release
+helm install ldap-rest oci://ghcr.io/linagora/charts/ldap-rest
+
+# A specific version
+helm install ldap-rest oci://ghcr.io/linagora/charts/ldap-rest --version 0.4.5
+
+# With your own values
+helm install ldap-rest oci://ghcr.io/linagora/charts/ldap-rest -f my-values.yaml
+```
+
+## Configuration
+
+ldap-rest is configured entirely through `DM_*` environment variables. Pass
+non-secret ones via `env` and sensitive ones via `secrets` (both are plain
+Kubernetes env lists):
+
+```yaml
+image:
+  # ghcr.io/linagora/ldap-rest (default) or docker.io/yadd/ldap-rest
+  repository: ghcr.io/linagora/ldap-rest
+  tag: ""            # defaults to the chart appVersion
+
+service:
+  port: 8081         # keep in sync with DM_PORT if you override it
+
+env:
+  - name: DM_LDAP_URL
+    value: "ldap://openldap"
+  - name: DM_LDAP_BASE
+    value: "dc=example,dc=com"
+  - name: DM_PLUGINS
+    value: "core/static,core/ldap/flatGeneric"
+
+secrets:
+  - name: DM_LDAP_PWD
+    valueFrom:
+      secretKeyRef:
+        name: ldap-rest-secrets
+        key: DM_LDAP_PWD
+```
+
+### Key values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `replicaCount` | `1` | Number of pods (stateless, scalable). |
+| `image.repository` | `ghcr.io/linagora/ldap-rest` | Image repository. |
+| `image.tag` | `""` | Image tag; defaults to chart `appVersion`. |
+| `service.type` / `service.port` | `ClusterIP` / `8081` | Service exposure. `port` is also the container port. |
+| `ingress.enabled` | `false` | Enable an Ingress. |
+| `env` | `[]` | Plain `DM_*` env vars (list of `{name, value}`). |
+| `secrets` | `[]` | Sensitive env vars (list, prefer `valueFrom.secretKeyRef`). |
+| `externalFileConfig` | `""` | Inline JS plugin mounted at `/app/external/cnb-plugin.js`. |
+| `resources` | see `values.yaml` | CPU/memory requests and limits. |
+| `livenessProbe` / `readinessProbe` | TCP on `http` | Probes (no HTTP health route exists; `{}` disables). |
+
+See [`values.yaml`](./values.yaml) for the full list.
+
+> No dedicated HTTP health endpoint exists, so the probes use a TCP check on the
+> listen port.

--- a/helm/ldap-rest/templates/NOTES.txt
+++ b/helm/ldap-rest/templates/NOTES.txt
@@ -1,0 +1,31 @@
+ldap-rest has been deployed as release "{{ .Release.Name }}".
+
+The API is reachable inside the cluster at:
+  http://{{ include "ldap-rest.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}
+
+{{- if .Values.ingress.enabled }}
+
+Ingress hosts:
+{{- range .Values.ingress.hosts }}
+  - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+
+To reach it locally:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ldap-rest.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  # then, e.g. (adjust the prefix to your DM_API_PREFIX, default /api):
+  curl http://localhost:{{ .Values.service.port }}/api/hello
+{{- end }}
+
+Useful commands:
+  # Logs
+  kubectl -n {{ .Release.Namespace }} logs -l app.kubernetes.io/name={{ include "ldap-rest.name" . }} -f
+
+{{- if not .Values.env }}
+
+⚠️  No `env` values set — ldap-rest is running with image defaults
+   (DM_LDAP_URL=ldap://localhost, empty DM_LDAP_BASE). Configure at least
+   DM_LDAP_URL / DM_LDAP_BASE (and DM_LDAP_PWD via `secrets`) for real use.
+{{- end }}
+
+For configuration options, see: https://github.com/linagora/ldap-rest

--- a/helm/ldap-rest/templates/_helpers.tpl
+++ b/helm/ldap-rest/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ldap-rest.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ldap-rest.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ldap-rest.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ldap-rest.labels" -}}
+helm.sh/chart: {{ include "ldap-rest.chart" . }}
+{{ include "ldap-rest.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ldap-rest.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ldap-rest.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ldap-rest.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ldap-rest.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Container image reference (tag defaults to the chart appVersion)
+*/}}
+{{- define "ldap-rest.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}

--- a/helm/ldap-rest/templates/configmap.yaml
+++ b/helm/ldap-rest/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.externalFileConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ldap-rest.fullname" . }}-external
+  labels:
+    {{- include "ldap-rest.labels" . | nindent 4 }}
+data:
+  cnb-plugin.js: |
+{{ .Values.externalFileConfig | nindent 4 }}
+{{- end }}

--- a/helm/ldap-rest/templates/deployment.yaml
+++ b/helm/ldap-rest/templates/deployment.yaml
@@ -29,9 +29,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "ldap-rest.serviceAccountName" . }}
-      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -48,6 +46,7 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- if or .Values.env .Values.secrets }}
           env:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
@@ -55,6 +54,7 @@ spec:
             {{- with .Values.secrets }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/helm/ldap-rest/templates/deployment.yaml
+++ b/helm/ldap-rest/templates/deployment.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ldap-rest.fullname" . }}
+  labels:
+    {{- include "ldap-rest.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ldap-rest.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ldap-rest.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- if .Values.externalFileConfig }}
+        checksum/config: {{ .Values.externalFileConfig | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "ldap-rest.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: ldap-rest
+          image: {{ include "ldap-rest.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.secrets }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or .Values.externalFileConfig .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- if .Values.externalFileConfig }}
+            - name: external-plugin
+              mountPath: /app/external
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+      {{- if or .Values.externalFileConfig .Values.extraVolumes }}
+      volumes:
+        {{- if .Values.externalFileConfig }}
+        - name: external-plugin
+          configMap:
+            name: {{ include "ldap-rest.fullname" . }}-external
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/ldap-rest/templates/ingress.yaml
+++ b/helm/ldap-rest/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ldap-rest.fullname" . }}
+  labels:
+    {{- include "ldap-rest.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "ldap-rest.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/ldap-rest/templates/service.yaml
+++ b/helm/ldap-rest/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ldap-rest.fullname" . }}
+  labels:
+    {{- include "ldap-rest.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "ldap-rest.selectorLabels" . | nindent 4 }}

--- a/helm/ldap-rest/templates/serviceaccount.yaml
+++ b/helm/ldap-rest/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ldap-rest.serviceAccountName" . }}
+  labels:
+    {{- include "ldap-rest.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/ldap-rest/values.yaml
+++ b/helm/ldap-rest/values.yaml
@@ -1,0 +1,153 @@
+# Default values for the ldap-rest Helm chart.
+#
+# ldap-rest is configured entirely through DM_* environment variables (see the
+# project Dockerfile / documentation). Pass them through `env` (plain values)
+# and `secrets` (sensitive values). This keeps the same values interface as the
+# in-house deployment chart, so existing overlays work unchanged.
+
+# -- Override the chart name used in labels
+nameOverride: ""
+# -- Fully override the generated resource name (defaults to the release name)
+fullnameOverride: ""
+
+# -- Number of replicas. ldap-rest is stateless (all state lives in LDAP), so it
+# can be scaled horizontally.
+replicaCount: 1
+
+image:
+  # -- Image repository. Published to both ghcr.io/linagora/ldap-rest and
+  # docker.io/yadd/ldap-rest by the release workflow.
+  repository: ghcr.io/linagora/ldap-rest
+  # -- Image tag. Defaults to the chart appVersion when left empty.
+  tag: ""
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+# -- Deployment update strategy
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount
+  create: false
+  # -- Annotations to add to the ServiceAccount
+  annotations: {}
+  # -- Name of the ServiceAccount to use (generated if empty and create=true)
+  name: ""
+
+# -- Extra pod annotations. A checksum of externalFileConfig is always added on
+# top so pods roll automatically when the mounted plugin changes.
+podAnnotations: {}
+
+# -- Pod-level security context. The image runs as the unprivileged `node` user.
+podSecurityContext: {}
+  # fsGroup: 1000
+
+# -- Container-level security context
+securityContext: {}
+  # runAsNonRoot: true
+  # allowPrivilegeEscalation: false
+  # readOnlyRootFilesystem: false
+  # capabilities:
+  #   drop:
+  #     - ALL
+
+service:
+  # -- Service type: ClusterIP, NodePort, LoadBalancer
+  type: ClusterIP
+  # -- Service port. Also used as the container port, so keep it in sync with
+  # DM_PORT if you override the listen port through `env`.
+  port: 8081
+  # -- Annotations
+  annotations: {}
+
+ingress:
+  # -- Enable ingress
+  enabled: false
+  # -- Ingress class name
+  className: ""
+  # -- Ingress annotations
+  annotations: {}
+  # -- Ingress hosts
+  hosts:
+    - host: ldap-rest.local
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- TLS configuration
+  tls: []
+  # - secretName: ldap-rest-tls
+  #   hosts:
+  #     - ldap-rest.local
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    cpu: 250m
+    memory: 1Gi
+
+# -- Liveness probe. No dedicated HTTP health route exists, so a TCP check on
+# the listen port is used. Set to {} to disable.
+livenessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 15
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# -- Readiness probe. Set to {} to disable.
+readinessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# -- Node selector
+nodeSelector: {}
+# -- Tolerations
+tolerations: []
+# -- Affinity rules
+affinity: {}
+
+# -- Plain (non-secret) environment variables, as a list of {name, value}.
+# Every ldap-rest setting is a DM_* variable. Example:
+#   env:
+#     - name: DM_LDAP_URL
+#       value: "ldap://openldap"
+#     - name: DM_LDAP_BASE
+#       value: "dc=example,dc=com"
+#     - name: DM_PLUGINS
+#       value: "core/static,core/ldap/flatGeneric"
+env: []
+
+# -- Sensitive environment variables, as a list of env entries. Prefer
+# `valueFrom.secretKeyRef` pointing at a Secret you manage (e.g. via SOPS /
+# External Secrets) rather than inlining values here. Example:
+#   secrets:
+#     - name: DM_LDAP_PWD
+#       valueFrom:
+#         secretKeyRef:
+#           name: ldap-rest-secrets
+#           key: DM_LDAP_PWD
+secrets: []
+
+# -- Inline JavaScript for an external plugin. When set, it is rendered into a
+# ConfigMap and mounted at /app/external/cnb-plugin.js (reference it in
+# DM_PLUGINS as /app/external/cnb-plugin.js).
+externalFileConfig: ""
+
+# -- Extra volumes to add to the pod
+extraVolumes: []
+# -- Extra volume mounts to add to the container
+extraVolumeMounts: []


### PR DESCRIPTION
## Goal

Automatically publish **on every `v*` tag**, following the `crowdsieve` (Docker/Helm) and `lasso.js` (npm) models:
- the multi-arch **Docker image** (amd64 + arm64)
- the **Helm chart** as an **OCI** artifact
- the **npm package**

## Contents

### `.github/workflows/release.yml` (5 jobs, on `push` of `v*` tags)
1. **docker-amd64** — build/push amd64 to `ghcr.io/linagora/ldap-rest` **and** `docker.io/yadd/ldap-rest`
2. **docker-arm64** — build/push arm64 (QEMU, in parallel)
3. **docker-manifest** — multi-arch manifests (`version`, `major.minor`, `major`, `latest`) on both registries
4. **helm** — chart `version`/`appVersion` set from the tag, `helm lint`, package, push to `oci://ghcr.io/linagora/charts/ldap-rest`
5. **npm** — verify tag == `package.json`, `npm ci`, `npm run build`, `npm publish --provenance --access public`

### `helm/ldap-rest/` — Helm chart
Derived from the in-house deployment chart (`cnb-stg-ovh-apps/charts/ldap-rest`): **same values interface** (`env`/`secrets` as lists, `externalFileConfig` mounted at `/app/external`), enhanced with:
- TCP probes (no dedicated HTTP health route), securityContext, config checksum
- optional ingress / serviceAccount, standard Helm labels
- `helm lint` + `helm template` OK (default values and a realistic override)

## Required repo secrets
- `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` — Docker Hub push to `yadd/ldap-rest`
- `NPM_TOKEN` — npm publish
- `GITHUB_TOKEN` — automatic (GHCR image + OCI chart)

## Notes
- The `vX.Y.Z` tag must match `package.json` (the npm job fails otherwise).
- Chart default image: `ghcr.io/linagora/ldap-rest` (both registries are published; configurable via `image.repository`).