### PR TITLE
ci(release): npm publish via OIDC Trusted Publishing + GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,12 @@ permissions:
   contents: read
   packages: write
 
+# Serialize releases: a later tag must not race an in-flight publish and win
+# the npm `latest` dist-tag. Never cancel a publish mid-flight.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 env:
   REGISTRY_GHCR: ghcr.io
   REGISTRY_DOCKER: docker.io
@@ -194,9 +200,13 @@ jobs:
   npm:
     name: Publish to npm
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # id-token: write authenticates to npm through OIDC (Trusted Publishing):
+    # no long-lived NPM_TOKEN to store or rotate, and a provenance attestation
+    # is attached to every release for free.
     permissions:
       contents: read
-      id-token: write   # required for npm provenance
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -204,27 +214,96 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: 22.x
           cache: 'npm'
+      # registry-url is intentionally omitted: it makes setup-node write an
+      # .npmrc carrying a dummy auth token that can shadow OIDC. npmjs.org is
+      # already the default registry, so OIDC publishing works without it.
 
-      - name: Verify tag matches package.json version
-        run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "❌ Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "✅ Tag version matches package.json version: $PKG_VERSION"
+      # Trusted Publishing requires npm >= 11.5.1, newer than the version
+      # bundled with Node 22.
+      - name: Update npm for Trusted Publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
+      - name: Run tests
+        run: npm test
+
+      - name: Build package
         run: npm run build
 
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "Tag v$TAG does not match package.json version $PKG."
+            echo "Bump the version in package.json before pushing the tag."
+            exit 1
+          fi
+          echo "Tag matches package.json version: $PKG"
+
+      - name: Verify package entry points exist
+        run: |
+          node -e '
+            const fs = require("fs");
+            const p = require("./package.json");
+            const files = new Set();
+            for (const v of Object.values(p.exports || {})) {
+              if (v && typeof v === "object") {
+                if (v.import) files.add(v.import);
+                if (v.types) files.add(v.types);
+              }
+            }
+            for (const b of Object.values(p.bin || {})) files.add(b);
+            const missing = [...files].filter((f) => !fs.existsSync(f));
+            if (missing.length) {
+              console.error("Missing entry files:\n  " + missing.join("\n  "));
+              process.exit(1);
+            }
+            console.log("Verified " + files.size + " package entry files");
+          '
+
+      - name: Pack tarball
+        run: npm pack
+
       - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # Keep prereleases (e.g. v1.2.3-rc.1) off the `latest` dist-tag.
+          case "$GITHUB_REF_NAME" in
+            *-*) NPM_TAG=next ;;
+            *)   NPM_TAG=latest ;;
+          esac
+          npm publish --access public --tag "$NPM_TAG"
+
+      - name: Upload release tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-tarball
+          path: ldap-rest-*.tgz
+          if-no-files-found: error
+
+  # Cut a GitHub Release, gated on a successful npm publish so the two never
+  # disagree. Notes are auto-generated and the published tarball is attached.
+  release:
+    name: Create GitHub Release
+    needs: npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Download release tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-tarball
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: ldap-rest-*.tgz

--- a/package.json
+++ b/package.json
@@ -549,7 +549,7 @@
       "require": "./static/schemas/twake/users.json"
     }
   },
-  "main": "dist/bin/index.mjs",
+  "main": "dist/bin/index.js",
   "types": "./dist/src/bin/index.d.ts",
   "bin": {
     "cleanup-external-users": "bin/cleanup-external-users.mjs",


### PR DESCRIPTION
Follow-up to #101. Folds in the useful parts of #98 (npm-only release, by @rezk2ll) and fixes a `package.json` entry-point bug found while testing.

## Changes

### npm job → OIDC Trusted Publishing
- Authenticate to npm via **OIDC Trusted Publishing** (`id-token: write`) instead of a stored `NPM_TOKEN` — no long-lived token to rotate, automatic **provenance** attestation.
- `registry-url` dropped on purpose (it writes an `.npmrc` dummy token that shadows OIDC); npm bumped to `>= 11.5.1` (required by Trusted Publishing, newer than Node 22's bundled npm).
- Gate the publish on **`npm test`** and a **package-entry-point existence check** (`exports` + `bin`).
- **Prereleases** (`vX.Y.Z-rc.N`) publish to the `next` dist-tag, not `latest`.
- **`concurrency`** group serializes the whole release workflow (a late tag can't race an in-flight publish for `latest`).

### New `release` job
- Cuts a **GitHub Release** (auto-generated notes + attached tarball), **gated on a successful npm publish** so npm and GitHub never disagree.

### `package.json` fix
- `main` pointed at `dist/bin/index.mjs`, a file rollup **never produces** (it emits `dist/bin/index.js`, ESM, matching `exports["."]`). With an `exports` map Node ignores `main`, but legacy tooling that falls back to it would fail. Corrected to `dist/bin/index.js`.

## One-time setup required
Publishing fails until a package owner registers this workflow as a **Trusted Publisher** on npmjs.com (package `ldap-rest` → Settings → Trusted Publisher → GitHub Actions):
- Organization: `linagora` · Repository: `ldap-rest` · Workflow: `release.yml` · Environment: empty

Once configured, the `NPM_TOKEN` repo secret is no longer used and can be deleted.

## Closes
Supersedes #98.