### PR TITLE
feat(weblogs): merge req.logDetails into the access log entry

### DIFF
--- a/docs/usage/plugins/utilities/weblogs.md
+++ b/docs/usage/plugins/utilities/weblogs.md
@@ -52,6 +52,53 @@ Each response is logged when completed at **notice** level (between info and war
 | `responseTime` | Request duration                | `45ms`, `123ms`                   |
 | `error`        | Error message (if applicable)   | `Connection timeout`              |
 
+## Enriching the Log Line From Another Plugin
+
+The standard fields say _that_ a request happened, not _what_ was requested. For
+`POST`/`DELETE` routes carrying their parameters in the body, the URL alone is
+not enough for auditing.
+
+Any plugin can attach extra context to the access log entry by setting
+`req.logDetails` in its handler. Those fields are merged into the single
+`notice` entry emitted when the response completes — no second log line, no
+correlation by timestamp:
+
+```typescript
+app.post('/api/_getldapentries', (req, res) => {
+  req.logDetails = { uids: req.body };
+  // ...
+});
+```
+
+Output:
+
+```json
+{
+  "level": "notice",
+  "message": {
+    "uids": ["jdoe", "asmith"],
+    "method": "POST",
+    "url": "/api/_getldapentries",
+    "status": 200,
+    "duration": 9,
+    "ip": "10.0.9.12",
+    "user": "admin"
+  }
+}
+```
+
+Notes:
+
+- Core fields (`method`, `url`, `status`, `duration`, `ip`, `user`, `error`)
+  always take precedence: a plugin cannot overwrite them.
+- The value must be set **before** the response completes (i.e. before
+  `res.json()` / `res.end()`), since the entry is written on the `finish` event.
+- Only log what identifies the request (uids, mail addresses, target user,
+  action). Do **not** put credentials or free-text personal data there — this
+  line is written at `notice` level, i.e. in production.
+- Keep lists bounded: a request with thousands of uids produces an unreadable
+  log line. Truncate and log the real count alongside.
+
 ## Use Cases
 
 ### 1. Request Monitoring

--- a/src/plugins/weblogs.ts
+++ b/src/plugins/weblogs.ts
@@ -3,6 +3,20 @@ import type { Express, Request, Response } from 'express';
 import DmPlugin, { type Role } from '../abstract/plugin';
 import { DmRequest } from '../lib/auth/base';
 
+// Extend Express Request so any plugin can enrich the access log line.
+// A handler sets `req.logDetails = { … }` (usually the parameters it received)
+// and those fields are merged into the single "notice" entry emitted when the
+// response completes. Core fields (method, url, status, …) always win, so a
+// plugin cannot overwrite them.
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      logDetails?: Record<string, unknown>;
+    }
+  }
+}
+
 export default class WebLogs extends DmPlugin {
   name = 'weblogs';
   roles: Role[] = ['logging'] as const;
@@ -47,6 +61,8 @@ export default class WebLogs extends DmPlugin {
   ): void {
     const duration = Date.now() - start;
     const _log = {
+      // Spread first: core fields below take precedence over plugin-supplied ones
+      ...(req.logDetails || {}),
       method: req.method,
       url: req.originalUrl,
       status: res.statusCode,

--- a/test/plugins/weblogs.test.ts
+++ b/test/plugins/weblogs.test.ts
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import supertest from 'supertest';
+
+import { DM } from '../../src/bin';
+import WebLogs from '../../src/plugins/weblogs';
+
+describe('weblogs', () => {
+  let dm: DM;
+  let plugin: WebLogs;
+  let notices: Record<string, unknown>[];
+  let savedLdapBase: string | undefined;
+
+  before(() => {
+    savedLdapBase = process.env.DM_LDAP_BASE;
+  });
+
+  after(() => {
+    if (savedLdapBase !== undefined) {
+      process.env.DM_LDAP_BASE = savedLdapBase;
+    } else {
+      delete process.env.DM_LDAP_BASE;
+    }
+  });
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.DM_LDAP_BASE = 'dc=example,dc=com';
+    dm = new DM();
+    await dm.ready;
+
+    plugin = new WebLogs(dm);
+    await dm.registerPlugin('weblogs', plugin);
+
+    // Collect what would be written to the access log
+    notices = [];
+    plugin.logger.notice = ((entry: Record<string, unknown>) => {
+      notices.push(entry);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+
+    // Routes are declared after registerPlugin so the middleware sees them
+    dm.app.get('/test/plain', (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    dm.app.get('/test/details', (req, res) => {
+      req.logDetails = { uids: ['u1', 'u2'], entries: 2 };
+      res.json({ ok: true });
+    });
+
+    dm.app.get('/test/override', (req, res) => {
+      // A plugin must not be able to rewrite the core fields
+      req.logDetails = { url: '/spoofed', status: 999, custom: 'kept' };
+      res.status(418).json({ ok: false });
+    });
+  });
+
+  it('should log the standard fields', async () => {
+    await supertest(dm.app).get('/test/plain').expect(200);
+
+    expect(notices).to.have.lengthOf(1);
+    expect(notices[0]).to.include({
+      method: 'GET',
+      url: '/test/plain',
+      status: 200,
+    });
+    expect(notices[0]).to.have.property('duration');
+    expect(notices[0]).to.have.property('ip');
+  });
+
+  it('should merge req.logDetails into the access log entry', async () => {
+    await supertest(dm.app).get('/test/details').expect(200);
+
+    expect(notices).to.have.lengthOf(1);
+    expect(notices[0].uids).to.deep.equal(['u1', 'u2']);
+    expect(notices[0].entries).to.equal(2);
+    // Standard fields are still there
+    expect(notices[0]).to.include({ method: 'GET', url: '/test/details' });
+  });
+
+  it('should not let req.logDetails override core fields', async () => {
+    await supertest(dm.app).get('/test/override').expect(418);
+
+    expect(notices).to.have.lengthOf(1);
+    expect(notices[0]).to.include({
+      url: '/test/override',
+      status: 418,
+      custom: 'kept',
+    });
+  });
+
+  it('should log nothing extra when req.logDetails is unset', async () => {
+    await supertest(dm.app).get('/test/plain').expect(200);
+
+    expect(Object.keys(notices[0]).sort()).to.deep.equal([
+      'duration',
+      'ip',
+      'method',
+      'status',
+      'url',
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

The access log says *that* a request happened, never *what* was requested:

```json
{"level":"notice","message":{"duration":9,"ip":"54.36.52.8","method":"POST","status":200,"url":"/api/_getldapentries","user":"linagora"}}
```

On `POST`/`DELETE` routes carrying their parameters in the body, the URL alone is
useless for auditing — there is no way to know which uids were read or updated.

## Change

Any plugin can now set `req.logDetails` in its handler; those fields are merged
into the single `notice` entry emitted when the response completes — no second
log line to correlate by timestamp:

```typescript
app.post('/api/_getldapentries', (req, res) => {
  req.logDetails = { uids: req.body };
  // ...
});
```

```json
{"level":"notice","message":{"uids":["jdoe","asmith"],"duration":9,"ip":"54.36.52.8","method":"POST","status":200,"url":"/api/_getldapentries","user":"linagora"}}
```

The spread comes **first** in `log()` so the core fields (`method`, `url`,
`status`, `duration`, `ip`, `user`, `error`) always take precedence: a plugin
cannot spoof them. A dedicated test covers that.

`Express.Request` is augmented via `declare global`, the same pattern already
used by `trustedProxy` for `trustedProxy`/`proxyAuthUser`.

## Tests

`test/plugins/weblogs.test.ts` (new, 4 tests):

- standard fields are logged
- `req.logDetails` is merged into the entry
- `req.logDetails` cannot override `url`/`status`
- nothing extra is logged when `req.logDetails` is unset

Full suite: 837 passing, 0 failing.

## Docs

New section "Enriching the Log Line From Another Plugin" in
`docs/usage/plugins/utilities/weblogs.md`, including the caveats: core fields
win, the value must be set before the response completes, no credentials or
free-text personal data (this line is written at `notice` level, i.e. in
production), and keep lists bounded.

## Motivation

Needed by the CNB plugin, which populates `logDetails` on all its routes for
audit purposes but currently has no consumer for it.