### PR TITLE
fix(app-accounts): never report a password operation that did not happen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- `plugins/twake/appAccountsApi`: never report a password operation that did not
+  happen. Both endpoints kept the principal account — the entry services
+  actually bind against — in sync with a `logger.warn` and a
+  `// Not critical, continue`, so two failures were invisible: a `POST` whose
+  principal update failed returned `200` with a password that authenticates
+  nowhere, and a `DELETE` unable to read the account's `userPassword` deleted
+  the app account while leaving its credential valid on the principal — a
+  revocation that silently does not revoke, the kind of defect only an audit
+  finds. `POST` now rolls the app account back and returns `500`; `DELETE`
+  returns `500` and **keeps** the account so the call stays replayable once the
+  cause is fixed. `userPassword` is also requested explicitly instead of relying
+  on it being returned as part of "all user attributes", and the documentation
+  now states the ACL the bind DN needs on the applicative branch
+
 ## v0.4.7 (2026-07-26)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@
   revocation that silently does not revoke, the kind of defect only an audit
   finds. `POST` now rolls the app account back and returns `500`; `DELETE`
   returns `500` and **keeps** the account so the call stays replayable once the
-  cause is fixed. `userPassword` is also requested explicitly instead of relying
-  on it being returned as part of "all user attributes", and the documentation
-  now states the ACL the bind DN needs on the applicative branch
+  cause is fixed — a password already absent from the principal is treated as
+  revoked, so a retry after a partial failure still completes. `userPassword` is
+  also requested explicitly instead of relying on it being returned as part of
+  "all user attributes", and the documentation now states the ACL the bind DN
+  needs on the applicative branch (#105)
 
 ## v0.4.7 (2026-07-26)
 

--- a/docs/usage/plugins/integrations/app-accounts.md
+++ b/docs/usage/plugins/integrations/app-accounts.md
@@ -45,6 +45,33 @@ Instead of using a single primary password to access all services that authentic
    - Ensures automatic cleanup when users are deleted
    - Synchronizes mail changes across all app accounts
 3. **Applicative accounts base** configured in LDAP (e.g., `ou=applicative,dc=example,dc=com`)
+4. **Read access on `userPassword`** in that branch, for the bind DN
+   (`--ldap-dn`) - **Required for deletion**
+
+   Revoking an app account means removing _its_ value from the principal
+   account, which holds one `userPassword` per device. The server must read the
+   stored hash to know which value to remove — a salted hash cannot be
+   recomputed. Without that access, `DELETE` returns `500` and keeps the
+   account rather than reporting a revocation that did not happen.
+
+   A typical OpenLDAP ACL, scoped to the applicative branch so that the users'
+   primary passwords stay unreadable:
+
+   ```
+   olcAccess: to dn.subtree="ou=applicative,dc=example,dc=com" attrs=userPassword
+     by dn.exact="cn=ldap-rest,ou=tech,dc=example,dc=com" read
+     by * break
+   ```
+
+   It must precede any broader rule on `userPassword`; OpenLDAP stops at the
+   first matching directive, and `by * break` lets other identities fall
+   through to the following ones.
+
+5. **Uniqueness constraints must not cover the applicative branch.** The
+   principal account and its app accounts intentionally share the same `mail`,
+   so a `slapo-unique` overlay on `mail` has to be scoped to the users branch
+   (`olcUniqueURI: ldap:///ou=users,dc=example,dc=com?mail?sub?`) or every app
+   account creation is rejected.
 
 ## Configuration
 
@@ -181,6 +208,8 @@ Content-Type: application/json
 - `400 Bad Request` - Max accounts limit reached or user has no mail
 - `401 Unauthorized` - Missing or invalid token
 - `404 Not Found` - User not found
+- `500 Internal Server Error` - The password could not be added to the principal
+  account; the app account is rolled back and no password is returned
 
 ### Delete Applicative Account
 
@@ -202,6 +231,9 @@ Authorization: Bearer {token}
 - `200 OK` - Account deleted (or already deleted - idempotent)
 - `401 Unauthorized` - Missing or invalid token
 - `403 Forbidden` - UID does not belong to user
+- `500 Internal Server Error` - The account password could not be read, or could
+  not be removed from the principal account; the app account is kept so the
+  request stays replayable
 
 ## Password Generation
 

--- a/src/plugins/twake/appAccountsApi.ts
+++ b/src/plugins/twake/appAccountsApi.ts
@@ -173,6 +173,11 @@ export default class AppAccountsApi extends DmPlugin {
      *   2. Adds the cleartext password to the principal account
      *      (`uid=<mail>`) so single-point authentication still works.
      *
+     *   Step 2 is not optional: services bind against the principal account,
+     *   so a password absent there would authenticate nowhere. If it fails,
+     *   the app account created in step 1 is rolled back and the call returns
+     *   `500` rather than a credential that does not work.
+     *
      *   Returns a `400` if the user has already reached the server-side
      *   maximum number of app accounts (`max_app_accounts`, default 5).
      *
@@ -225,6 +230,13 @@ export default class AppAccountsApi extends DmPlugin {
      *
      *   The operation is **idempotent**: if the account does not exist,
      *   the response is still `200` with the `uid` echoed back.
+     *
+     *   Revocation requires reading the account's `userPassword` to know which
+     *   of the principal's values to remove. If it cannot be read — typically
+     *   a bind DN without read access on `userPassword` in the applicative
+     *   branch — or if removing it fails, the account is **kept** and the call
+     *   returns `500`, so that the request stays replayable once the cause is
+     *   fixed. It never reports a revocation that did not happen.
      * responses:
      *   '200':
      *     description: App account deleted (or was already absent).
@@ -240,6 +252,13 @@ export default class AppAccountsApi extends DmPlugin {
      *           uid: alice_c04729183
      *   '403':
      *     description: The `:uid` does not belong to `:user`.
+     *     content:
+     *       application/json:
+     *         schema: { $ref: '#/components/schemas/Error' }
+     *   '500':
+     *     description: |
+     *       The account password could not be read or could not be removed
+     *       from the principal account; the app account was left in place.
      *     content:
      *       application/json:
      *         schema: { $ref: '#/components/schemas/Error' }
@@ -512,11 +531,26 @@ export default class AppAccountsApi extends DmPlugin {
           add: { userPassword: newPassword },
         });
       } catch (error) {
-        this.logger.warn(
+        // Services authenticate against the principal account, so a password
+        // that is missing there authenticates nowhere. Returning it anyway
+        // would hand the caller a credential that silently never works: roll
+        // the app account back and report the failure.
+        this.logger.error(
           `${this.name}: Failed to add password to principal account ${principalDn}:`,
           error
         );
-        // Not critical, continue
+        try {
+          await this.server.ldap.delete(applicativeDn);
+        } catch (rollbackError) {
+          this.logger.error(
+            `${this.name}: Failed to roll back applicative account ${applicativeDn}:`,
+            rollbackError
+          );
+        }
+        res.status(500).json({
+          error: 'Failed to register the password on the principal account',
+        });
+        return;
       }
 
       res.json({ uid: newUid, pwd: newPassword, mail: mailStr });
@@ -565,12 +599,16 @@ export default class AppAccountsApi extends DmPlugin {
     const uid = req.params.uid as string;
 
     try {
-      // Search for the applicative account
+      // Search for the applicative account. `userPassword` is requested
+      // explicitly: revocation needs the stored hash to know which of the
+      // principal's values to remove, so this is a hard requirement rather
+      // than a side effect of returning every user attribute.
       const accountResult = await this.server.ldap.search(
         {
           scope: 'sub',
           filter: `(uid=${escapeLdapFilter(uid)})`,
           paged: false,
+          attributes: ['uid', this.mailAttr, 'userPassword'],
         },
         this.applicativeAccountBase
       );
@@ -626,30 +664,45 @@ export default class AppAccountsApi extends DmPlugin {
         return;
       }
 
+      // Revoking means removing this device's value from the principal
+      // account. Without the stored hash we cannot tell which value belongs to
+      // this device, so the credential would keep authenticating after the app
+      // account is gone. An unreadable `userPassword` is indistinguishable from
+      // an absent one (a bind DN lacking read access on it looks the same), so
+      // refuse instead of reporting a revocation that did not happen.
       const userPassword = accountEntry.userPassword;
       if (!userPassword) {
-        this.logger.warn(
-          `${this.name}: Account ${uid} has no userPassword attribute`
+        this.logger.error(
+          `${this.name}: Account ${uid} has no readable userPassword, refusing to delete: ` +
+            'the bind DN needs read access on userPassword in the applicative branch'
         );
+        res.status(500).json({
+          error: `Cannot revoke account ${uid}: its password is not readable`,
+        });
+        return;
       }
 
-      // Delete password from principal account if available
-      if (userPassword) {
-        const principalDn = `uid=${escapeDnValue(mailStr)},${this.applicativeAccountBase}`;
-        try {
-          const passwordToDelete = Array.isArray(userPassword)
-            ? userPassword[0]
-            : userPassword;
-          await this.server.ldap.modify(principalDn, {
-            delete: { userPassword: passwordToDelete },
-          });
-        } catch (error) {
-          this.logger.warn(
-            `${this.name}: Failed to delete password from principal account ${principalDn}:`,
-            error
-          );
-          // Not critical, continue
-        }
+      // Delete password from principal account
+      const principalDn = `uid=${escapeDnValue(mailStr)},${this.applicativeAccountBase}`;
+      try {
+        const passwordToDelete = Array.isArray(userPassword)
+          ? userPassword[0]
+          : userPassword;
+        await this.server.ldap.modify(principalDn, {
+          delete: { userPassword: passwordToDelete },
+        });
+      } catch (error) {
+        // Keep the app account: leaving it in place makes the call replayable
+        // once the cause is fixed, whereas deleting it would strand a working
+        // credential on the principal with nothing left pointing at it.
+        this.logger.error(
+          `${this.name}: Failed to delete password from principal account ${principalDn}:`,
+          error
+        );
+        res.status(500).json({
+          error: `Failed to revoke the password of account ${uid}`,
+        });
+        return;
       }
 
       // Delete the applicative account

--- a/src/plugins/twake/appAccountsApi.ts
+++ b/src/plugins/twake/appAccountsApi.ts
@@ -691,18 +691,33 @@ export default class AppAccountsApi extends DmPlugin {
         await this.server.ldap.modify(principalDn, {
           delete: { userPassword: passwordToDelete },
         });
-      } catch (error) {
-        // Keep the app account: leaving it in place makes the call replayable
-        // once the cause is fixed, whereas deleting it would strand a working
-        // credential on the principal with nothing left pointing at it.
-        this.logger.error(
-          `${this.name}: Failed to delete password from principal account ${principalDn}:`,
-          error
-        );
-        res.status(500).json({
-          error: `Failed to revoke the password of account ${uid}`,
-        });
-        return;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        // A value already absent means an earlier attempt did revoke it and
+        // then failed to delete the app account. The credential is gone, which
+        // is all this step guarantees, so carry on: failing here would make the
+        // retry loop forever on a revocation that has nothing left to do.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        const message = String(error.message ?? '');
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        const code: unknown = error.code;
+        if (code === 0x10 || /no ?such ?attribute/i.test(message)) {
+          this.logger.warn(
+            `${this.name}: Password of ${uid} was already absent from principal account ${principalDn}, resuming deletion`
+          );
+        } else {
+          // Keep the app account: leaving it in place makes the call replayable
+          // once the cause is fixed, whereas deleting it would strand a working
+          // credential on the principal with nothing left pointing at it.
+          this.logger.error(
+            `${this.name}: Failed to delete password from principal account ${principalDn}:`,
+            error
+          );
+          res.status(500).json({
+            error: `Failed to revoke the password of account ${uid}`,
+          });
+          return;
+        }
       }
 
       // Delete the applicative account

--- a/test/plugins/twake/appAccountsApi.test.ts
+++ b/test/plugins/twake/appAccountsApi.test.ts
@@ -833,6 +833,30 @@ describe('App Accounts API Plugin', function () {
         .true;
     });
 
+    // A previous attempt may have revoked the password and then failed to
+    // delete the app account. Retrying must finish the job, not fail forever on
+    // a revocation that has nothing left to remove.
+    it('DELETE resumes when the password is already gone from the principal', async function () {
+      this.timeout(15000);
+      await createTestUser();
+      const uid = await createAppAccount('Tablet');
+      const appDn = `uid=${uid},${applicativeBase}`;
+      const principalDn = `uid=${principalEmail},${applicativeBase}`;
+
+      // Simulate the earlier partial attempt: principal already cleaned up,
+      // app account still there.
+      await dm.ldap.modify(principalDn, { delete: ['userPassword'] });
+
+      const res = await request(dm.app)
+        .delete(`/api/v1/users/${principalEmail}/app-accounts/${uid}`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .expect(200);
+
+      expect(res.body.uid).to.equal(uid);
+      expect(await entryExists(appDn), 'app account finally removed').to.be
+        .false;
+    });
+
     it('DELETE keeps the account and returns 500 when revocation fails', async function () {
       this.timeout(15000);
       await createTestUser();

--- a/test/plugins/twake/appAccountsApi.test.ts
+++ b/test/plugins/twake/appAccountsApi.test.ts
@@ -725,6 +725,143 @@ describe('App Accounts API Plugin', function () {
     });
   });
 
+  // The principal account is what services bind against: it holds one
+  // userPassword value per device. Any failure to keep it in sync must surface,
+  // otherwise a created password authenticates nowhere or a deleted device
+  // keeps authenticating.
+  describe('password propagation failures', () => {
+    const createTestUser = async () => {
+      await dm.ldap.add(testUserDN, {
+        objectClass: 'inetOrgPerson',
+        uid: testUser,
+        cn: 'Test User',
+        sn: 'User',
+        mail: principalEmail,
+      });
+      await new Promise(resolve => setTimeout(resolve, 100));
+    };
+
+    const createAppAccount = async (name: string): Promise<string> => {
+      const res = await request(dm.app)
+        .post(`/api/v1/users/${principalEmail}/app-accounts`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({ name })
+        .expect(200);
+      return res.body.uid as string;
+    };
+
+    const entryExists = async (dn: string): Promise<boolean> => {
+      try {
+        const res = await dm.ldap.search({ scope: 'base', paged: false }, dn);
+        return ((res as any).searchEntries || []).length === 1;
+      } catch (err) {
+        return false;
+      }
+    };
+
+    it('POST rolls back and returns 500 when the principal cannot be updated', async function () {
+      this.timeout(15000);
+      await createTestUser();
+
+      // Fail only the `add: userPassword` on the principal account.
+      const realModify = dm.ldap.modify.bind(dm.ldap);
+      let attempted = false;
+      (dm.ldap as any).modify = async (dn: string, changes: any) => {
+        if (dn.startsWith(`uid=${principalEmail},`) && changes?.add) {
+          attempted = true;
+          throw new Error('simulated: no write access on principal');
+        }
+        return realModify(dn, changes);
+      };
+
+      let body: any;
+      try {
+        const res = await request(dm.app)
+          .post(`/api/v1/users/${principalEmail}/app-accounts`)
+          .set('Authorization', `Bearer ${testToken}`)
+          .send({ name: 'Doomed device' })
+          .expect(500);
+        body = res.body;
+      } finally {
+        (dm.ldap as any).modify = realModify;
+      }
+
+      expect(attempted, 'principal update was attempted').to.be.true;
+      expect(body).to.not.have.property('pwd');
+
+      // No orphan app account must survive the failure.
+      const leftovers = await dm.ldap.search(
+        { scope: 'sub', filter: `(uid=${appUidPrefix}_*)`, paged: false },
+        applicativeBase
+      );
+      expect((leftovers as any).searchEntries || []).to.have.lengthOf(0);
+    });
+
+    it('DELETE keeps the account and returns 500 when userPassword is unreadable', async function () {
+      this.timeout(15000);
+      await createTestUser();
+      const uid = await createAppAccount('Phone');
+      const appDn = `uid=${uid},${applicativeBase}`;
+
+      // Reproduce a bind DN without read access on userPassword: the entry is
+      // returned, that attribute simply is not. It is indistinguishable from an
+      // account that has none, and in both cases the server cannot tell which
+      // principal value to revoke.
+      const realSearch = dm.ldap.search.bind(dm.ldap);
+      (dm.ldap as any).search = async (opts: any, base: string) => {
+        const result: any = await realSearch(opts, base);
+        if (base === applicativeBase && result?.searchEntries) {
+          result.searchEntries = result.searchEntries.map((entry: any) => {
+            const { userPassword, ...rest } = entry;
+            return rest;
+          });
+        }
+        return result;
+      };
+
+      try {
+        const res = await request(dm.app)
+          .delete(`/api/v1/users/${principalEmail}/app-accounts/${uid}`)
+          .set('Authorization', `Bearer ${testToken}`)
+          .expect(500);
+        expect(res.body.error).to.match(/not readable/i);
+      } finally {
+        (dm.ldap as any).search = realSearch;
+      }
+
+      expect(await entryExists(appDn), 'app account kept for replay').to.be
+        .true;
+    });
+
+    it('DELETE keeps the account and returns 500 when revocation fails', async function () {
+      this.timeout(15000);
+      await createTestUser();
+      const uid = await createAppAccount('Laptop');
+      const appDn = `uid=${uid},${applicativeBase}`;
+
+      const realModify = dm.ldap.modify.bind(dm.ldap);
+      (dm.ldap as any).modify = async (dn: string, changes: any) => {
+        if (dn.startsWith(`uid=${principalEmail},`) && changes?.delete) {
+          throw new Error('simulated: revocation refused');
+        }
+        return realModify(dn, changes);
+      };
+
+      try {
+        const res = await request(dm.app)
+          .delete(`/api/v1/users/${principalEmail}/app-accounts/${uid}`)
+          .set('Authorization', `Bearer ${testToken}`)
+          .expect(500);
+        expect(res.body.error).to.match(/revoke/i);
+      } finally {
+        (dm.ldap as any).modify = realModify;
+      }
+
+      expect(await entryExists(appDn), 'app account kept for replay').to.be
+        .true;
+    });
+  });
+
   describe('Configuration', () => {
     it('should throw error if applicative_account_base is not configured', () => {
       const dmTest = new DM();


### PR DESCRIPTION
## Problem

The principal account (`uid=<mail>` in the applicative branch) is the entry services actually bind against — it accumulates one `userPassword` value per device. Both endpoints kept it in sync with a `logger.warn` and a `// Not critical, continue`, which made two failures invisible:

- **`POST`** returned `200` with a generated password even when adding it to the principal failed. The caller stores a credential that authenticates nowhere.
- **`DELETE`** needs the account's `userPassword` to know *which* of the principal's values to remove (a salted hash cannot be recomputed). When it was unreadable, the code logged a warning, skipped the revocation, and **deleted the app account anyway** — leaving its credential valid on the principal. A revocation that silently does not revoke.

The second one is the dangerous case: a bind DN lacking read access on `userPassword` looks exactly like an account that has none, the API answers `200`, the device disappears from the listing, and only an audit reveals that nothing was revoked.

## Changes

- `POST` rolls the app account back and returns `500` instead of returning a password that does not work.
- `DELETE` returns `500` and **keeps** the account when the password cannot be read or cannot be removed, so the call stays replayable once the cause is fixed. Deleting it would strand a working credential on the principal with nothing left pointing at it.
- `userPassword` is requested explicitly in the delete search, instead of relying on it being returned among "all user attributes" — the dependency was implicit and would break silently if a projection were introduced.
- Documentation: the `Prerequisites` section now states the ACL the bind DN needs on the applicative branch (scoped there, so users' primary passwords stay unreadable), and warns that a `slapo-unique` overlay on `mail` must not cover that branch.
- OpenAPI descriptions and status codes updated for both routes.

## Tests

Three regression tests in `test/plugins/twake/appAccountsApi.test.ts`, covering the rollback on create, the unreadable `userPassword` on delete (simulated the way an ACL denial actually appears: the entry comes back without the attribute), and a failing revocation.

```
20 passing (appAccountsApi)
13 passing (appAccountsConsistency)
```

`tsc --noEmit`, `eslint` and `prettier --check` clean.

## Note for the reviewer

I added an `## Unreleased` section to `CHANGELOG.md`. If you prefer writing those entries at release time, drop that hunk — the release workflow extracts sections by `## vX.Y.Z`, so an `Unreleased` heading is inert until renamed.

One behaviour was deliberately left alone: an app account whose `userPassword` is genuinely absent (a legacy entry created by the previous code) is now undeletable through this endpoint. It remains removable through the generic LDAP routes, so I did not add a `force` parameter — say the word if you would rather have one.
