### PR TITLE
feat(auth): restrict an authentication plugin to path prefixes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 # Build files
 dist/
 build/
+helm/
 package.json
 
 # Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,15 @@
   `/api/admin` behind OIDC. A credential is only valid on the branch it was
   scoped to: a leaked machine token buys nothing on the administration API.
   Prefixes match on segment boundaries, so `/api/m` never catches
-  `/api/machines`. The counterpart is that a route outside every prefix is
-  served without authentication, which no error would reveal, so those routes
-  are now listed in a warning at startup
+  `/api/machines`. A plugin left unscoped becomes the catch-all: it guards
+  everything no scoped plugin claims, so "OIDC on /api/admin, token everywhere
+  else" needs no list of everywhere else — the kind of list nobody maintains
+  without forgetting a branch. That subtraction is also what keeps the two from
+  colliding: both middlewares are terminal, so without it they would both match
+  the scoped branch and compose as AND, refusing every credential. The
+  counterpart is that a route outside every prefix, with no catch-all, is served
+  without authentication, which no error would reveal, so those routes are now
+  listed in a warning at startup
 
 - `plugins/ldap/raw` + `browser/ldap-browser`: low-level, read-only browsing of
   the directory — the phpLDAPadmin-shaped hole in an otherwise business-object

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,31 @@
 
 ### Bug fixes
 
+- `bin`: a plugin loaded with overrides (`module:name:{json}`) received a
+  crippled server. The view was built with `{...this}`, a spread that copies
+  own properties and leaves the prototype behind, so the plugin got the data —
+  config, hooks, app, ldap, registry — and none of the methods: any
+  `this.server.something()` threw, and only in that configuration. No existing
+  plugin had hit it because none called a server method
+
+- `bin`: `setupErrorMiddleware` looked the router stack up as `app._router`,
+  which Express 5 renamed to `app.router`. The lookup silently found nothing,
+  so the previous error handler was never removed and one more was appended on
+  every `registerPlugin`. Only the first ever ran, so nothing broke — the stack
+  just kept growing
+
+- `bin`: registering a plugin under a name already taken was reported at `info`
+  level and the instance was dropped, so its routes simply did not exist and
+  every request to them answered 404 with nothing in the log to explain why. It
+  is now a warning naming the plugin, saying the instance was dropped, and
+  showing how to load the same plugin twice
+
+- `plugins/auth/rateLimit`: warn when `core/auth/trustedProxy` is not loaded.
+  The limiter keys on `X-Forwarded-For`, which a client can set to anything;
+  that is only safe because `trustedProxy` strips the header on requests that
+  do not come from a declared proxy. Without it, rotating the header defeats
+  the limiter entirely and the brute-force protection is decorative
+
 - `plugins/twake/appAccountsApi`: never report a password operation that did not
   happen. Both endpoints kept the principal account — the entry services
   actually bind against — in sync with a `logger.warn` and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Features
 
+- `lib/auth`: `--auth-path-prefix` restricts an authentication plugin to one or
+  more path prefixes. Populations rarely authenticate the same way — machines
+  carry a token, administrators arrive with an SSO session — and until now the
+  only way to serve both was two servers on two ports, because `AuthBase`
+  mounted its middleware on every path and the first plugin loaded decided for
+  everyone. Each plugin can now be scoped, and since any plugin can be loaded
+  twice under its own name, one server hosts `/api/m` behind a token and
+  `/api/admin` behind OIDC. A credential is only valid on the branch it was
+  scoped to: a leaked machine token buys nothing on the administration API.
+  Prefixes match on segment boundaries, so `/api/m` never catches
+  `/api/machines`. The counterpart is that a route outside every prefix is
+  served without authentication, which no error would reveal, so those routes
+  are now listed in a warning at startup
+
+### Features
+
 - `plugins/ldap/raw` + `browser/ldap-browser`: low-level, read-only browsing of
   the directory — the phpLDAPadmin-shaped hole in an otherwise business-object
   API. The high-level plugins answer "who are the users of this group"; nothing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@
   served without authentication, which no error would reveal, so those routes
   are now listed in a warning at startup
 
-### Features
-
 - `plugins/ldap/raw` + `browser/ldap-browser`: low-level, read-only browsing of
   the directory — the phpLDAPadmin-shaped hole in an otherwise business-object
   API. The high-level plugins answer "who are the users of this group"; nothing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,18 @@
   `/api/admin` behind OIDC. A credential is only valid on the branch it was
   scoped to: a leaked machine token buys nothing on the administration API.
   Prefixes match on segment boundaries, so `/api/m` never catches
-  `/api/machines`. A plugin left unscoped becomes the catch-all: it guards
+  `/api/machines`. A plugin left unscoped is the catch-all: it guards
   everything no scoped plugin claims, so "OIDC on /api/admin, token everywhere
   else" needs no list of everywhere else — the kind of list nobody maintains
-  without forgetting a branch. That subtraction is also what keeps the two from
-  colliding: both middlewares are terminal, so without it they would both match
-  the scoped branch and compose as AND, refusing every credential. The
-  counterpart is that a route outside every prefix, with no catch-all, is served
-  without authentication, which no error would reveal, so those routes are now
-  listed in a warning at startup
+  without forgetting a branch. Authentication is no longer a middleware each
+  plugin mounts for itself: the server mounts one dispatcher, after the guards
+  and the access log, before the first plugin able to register a route, and
+  authentication plugins register with it. Declaration order therefore no
+  longer decides what is protected, and the most specific claim wins, so two
+  plugins covering one request never compose as an AND no credential can
+  satisfy. The counterpart is that a route outside every prefix, with no
+  catch-all, is served without authentication, which no error would reveal, so
+  those routes are listed in a warning at startup
 
 - `plugins/ldap/raw` + `browser/ldap-browser`: low-level, read-only browsing of
   the directory — the phpLDAPadmin-shaped hole in an otherwise business-object

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,7 @@ ENV NODE_ENV=production \
  DM_TRASH_ADD_METADATA="true" \
  DM_TRASH_AUTO_CREATE="true" \
  DM_LLNG_INI="/etc/lemonldap-ng/lemonldap-ng.ini" \
+ DM_AUTH_PATH_PREFIX= \
  DM_AUTH_TOKENS= \
  DM_AUTH_TOTP= \
  DM_AUTH_TOTP_WINDOW="1" \

--- a/bin/sync-james.mjs
+++ b/bin/sync-james.mjs
@@ -122,7 +122,9 @@ async function syncJames() {
 
     if (!getRes.ok) {
       if (getRes.status === 404) {
-        dm.logger.warn(`User ${mail} not found in James, skipping quota (DN: ${dn})`);
+        dm.logger.warn(
+          `User ${mail} not found in James, skipping quota (DN: ${dn})`
+        );
       } else {
         dm.logger.error(
           `Error getting quota for ${mail}: ${getRes.status} ${getRes.statusText}`
@@ -164,7 +166,9 @@ async function syncJames() {
       }
       stats.quotaSynced++;
     } else {
-      dm.logger.error(`  Failed to update quota: ${putRes.status} ${putRes.statusText}`);
+      dm.logger.error(
+        `  Failed to update quota: ${putRes.status} ${putRes.statusText}`
+      );
       stats.errors++;
     }
   }

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -204,6 +204,14 @@ Read-only low-level browsing (root DSE, schema, entries). See [raw plugin](plugi
 
 ### Authentication Plugins
 
+#### Common to every authentication plugin
+
+| CLI                  | Plural                 | Env                   | Default | Description                                 |
+| -------------------- | ---------------------- | --------------------- | ------- | ------------------------------------------- |
+| `--auth-path-prefix` | `--auth-path-prefixes` | `DM_AUTH_PATH_PREFIX` | `[]`    | Restrict this plugin to these path prefixes |
+
+Empty means the plugin guards every path. Scoping several instances to different prefixes lets one server serve populations that authenticate differently — see [Serving several populations from one server](plugins/auth/README.md#serving-several-populations-from-one-server), including the routes it can leave unauthenticated.
+
 #### `core/auth/token`
 
 | CLI            | Plural          | Env              | Default | Description           |

--- a/docs/usage/plugins/auth/README.md
+++ b/docs/usage/plugins/auth/README.md
@@ -72,9 +72,18 @@ ldap-rest \
   --auth-token "…:robot"
 ```
 
-`/api/admin` requires the SSO session, everything else requires the token. Loading order does not matter: the subtraction is computed per request, once every plugin has registered.
+`/api/admin` requires the SSO session, everything else requires the token.
 
-This is also what keeps the two from colliding. Both middlewares are terminal, so without the subtraction they would both match `/api/admin` and compose as **AND** — the session refused by the token plugin, the token refused by the session plugin, and the branch unusable by anyone.
+### How the choice is made
+
+Authentication is not a middleware each plugin mounts for itself. The server mounts **one dispatcher**, positioned after the guards (`protect`: rate limiting, proxy trust, CrowdSec) and access logging, and before the first plugin able to register a route. Authentication plugins register with it instead of adding a layer.
+
+Two properties follow, and both are load-bearing:
+
+- **Order of declaration does not matter.** A plugin that registers after the API it guards still guards it, because the dispatcher — not the plugin — owns the layer. With per-plugin middlewares that was untrue and silent: a guard mounted after its routes never ran for them.
+- **The most specific claim wins.** `/api/admin` is handled by the plugin scoped to it, `/api` by the plugin scoped to `/api`, and anything unclaimed by an unscoped plugin. Only the winner runs, so two plugins covering the same request never compose as an AND that no credential can satisfy.
+
+Several plugins sharing the same winning prefix all run, in registration order: requiring two credentials on one branch is a legitimate ask, and an accident there fails closed rather than open.
 
 ### The gap to watch
 

--- a/docs/usage/plugins/auth/README.md
+++ b/docs/usage/plugins/auth/README.md
@@ -59,6 +59,21 @@ ldap-rest \
 
 A token presented on `/api/admin` is refused, and a session presented on `/api/m` is refused too: each authentication plugin only sees the branch it was mounted on. Prefixes match on segment boundaries, so `/api/m` guards `/api/m` and `/api/m/entry` but never `/api/machines`.
 
+### One branch apart, a token on everything else
+
+Leaving a plugin unscoped makes it the **catch-all**: it guards everything no scoped plugin claims. There is no list of "everything else" to write, and none to keep up to date when a route is added:
+
+```bash
+ldap-rest \
+  --plugin 'core/auth/openidconnect:auth-admins:{"auth_path_prefix":"/api/admin"}' \
+  --plugin core/auth/token \
+  --auth-token "…:robot"
+```
+
+`/api/admin` requires the SSO session, everything else requires the token. Loading order does not matter: the subtraction is computed per request, once every plugin has registered.
+
+This is also what keeps the two from colliding. Both middlewares are terminal, so without the subtraction they would both match `/api/admin` and compose as **AND** — the session refused by the token plugin, the token refused by the session plugin, and the branch unusable by anyone.
+
 ### The gap to watch
 
 A route registered **outside every prefix is served without authentication**. That is the price of scoping, and it is silent — the server starts, the API answers. To make it visible, the routes no plugin guards are listed at startup:
@@ -68,7 +83,9 @@ Authentication is restricted to /api/m, /api/admin, so these routes are
 served without authentication: /api/v1/config, /api/v1/ldap/users
 ```
 
-Read that line on every configuration change. Either scope the missing routes to a prefix as well, load one unscoped authentication plugin as a catch-all, or keep them public deliberately. Nothing is reported when no authentication is configured (the server is open on purpose) or when at least one plugin guards every path.
+Read that line on every configuration change. Either scope the missing routes to a prefix as well, add an unscoped plugin as the catch-all, or keep them public deliberately. Nothing is reported when no authentication is configured (the server is open on purpose) or when a catch-all covers what the scoped plugins do not.
+
+Note the converse: with a catch-all there is no public branch at all. Making one API reachable without credentials means scoping every authentication plugin and leaving that branch out — the warning will then name it, which is correct but reads as an oversight rather than a decision.
 
 Note that a prefix scopes **authentication**, not authorization: once past it, a caller reaches everything the branch exposes. Restrict what each population may do with [authz-per-route](authz-per-route.md) or [authz-per-branch](authz-per-branch.md).
 

--- a/docs/usage/plugins/auth/README.md
+++ b/docs/usage/plugins/auth/README.md
@@ -59,6 +59,8 @@ ldap-rest \
 
 A token presented on `/api/admin` is refused, and a session presented on `/api/m` is refused too: each authentication plugin only sees the branch it was mounted on. Prefixes match on segment boundaries, so `/api/m` guards `/api/m` and `/api/m/entry` but never `/api/machines`.
 
+A prefix must be a string starting with `/`. Anything else — a number left in the JSON, an empty entry, a prefix without its leading slash — refuses to start rather than being skipped: a dropped entry shrinks what the plugin guards, which is the failure that leaves a branch open while the configuration still reads as if it were covered. `/` is not a prefix but the whole server, so a list containing it makes the plugin a catch-all: `["/", "/api/admin"]` guards everything, not only `/api/admin`.
+
 ### One branch apart, a token on everything else
 
 Leaving a plugin unscoped makes it the **catch-all**: it guards everything no scoped plugin claims. There is no list of "everything else" to write, and none to keep up to date when a route is added:

--- a/docs/usage/plugins/auth/README.md
+++ b/docs/usage/plugins/auth/README.md
@@ -43,6 +43,35 @@ LDAP-Rest provides multiple authentication plugins to secure API access. These p
 | **Best For**           | APIs, Scripts | APIs, Enhanced    | Backend Services       | Enterprises with LLNG | Cloud/SaaS, Enterprises with SSO |
 | **Dependencies**       | None          | None              | None                   | lemonldap-ng-handler  | express-openid-connect           |
 
+## Serving several populations from one server
+
+Populations rarely authenticate the same way: machines carry a token, administrators arrive with an SSO session. `--auth-path-prefix` restricts an authentication plugin to one or more path prefixes, so a single server can host both without either credential being valid on the other's branch of the API.
+
+Any plugin can be loaded more than once under a distinct name with its own configuration (`module:name:{json}`), which is what makes this work:
+
+```bash
+ldap-rest \
+  --plugin 'core/auth/token:auth-machines:{"auth_path_prefix":"/api/m","auth_token":"…:robot"}' \
+  --plugin 'core/ldap/raw:raw-machines:{"api_prefix":"/api/m"}' \
+  --plugin 'core/auth/openidconnect:auth-admins:{"auth_path_prefix":"/api/admin"}' \
+  --plugin 'core/ldap/raw:raw-admins:{"api_prefix":"/api/admin"}'
+```
+
+A token presented on `/api/admin` is refused, and a session presented on `/api/m` is refused too: each authentication plugin only sees the branch it was mounted on. Prefixes match on segment boundaries, so `/api/m` guards `/api/m` and `/api/m/entry` but never `/api/machines`.
+
+### The gap to watch
+
+A route registered **outside every prefix is served without authentication**. That is the price of scoping, and it is silent — the server starts, the API answers. To make it visible, the routes no plugin guards are listed at startup:
+
+```
+Authentication is restricted to /api/m, /api/admin, so these routes are
+served without authentication: /api/v1/config, /api/v1/ldap/users
+```
+
+Read that line on every configuration change. Either scope the missing routes to a prefix as well, load one unscoped authentication plugin as a catch-all, or keep them public deliberately. Nothing is reported when no authentication is configured (the server is open on purpose) or when at least one plugin guards every path.
+
+Note that a prefix scopes **authentication**, not authorization: once past it, a caller reaches everything the branch exposes. Restrict what each population may do with [authz-per-route](authz-per-route.md) or [authz-per-branch](authz-per-branch.md).
+
 ## Combining with Authorization
 
 All authentication plugins set `req.user` to the authenticated identity. You can use hooks to implement custom authorization:

--- a/docs/usage/plugins/auth/rate-limit.md
+++ b/docs/usage/plugins/auth/rate-limit.md
@@ -54,6 +54,15 @@ For correct IP detection behind reverse proxies:
 
 The rate limiter will use the real client IP from `X-Forwarded-For` when the request comes from a trusted proxy.
 
+This pairing is not a refinement, it is what makes the limit hold. The limiter keys on `X-Forwarded-For`, a header any client can set to anything; `trustedProxy` is what strips it on requests that do not come from a declared proxy. Loaded alone, the limiter counts forged keys: rotating the header on every attempt gives an attacker a fresh counter each time, and the brute-force protection becomes decorative while still looking configured. The plugin therefore warns at startup when `trustedProxy` is absent:
+
+```
+Auth rate limiting keys on X-Forwarded-For but core/auth/trustedProxy is not
+loaded: a client can forge that header and evade the limit.
+```
+
+Either load `trustedProxy`, or make sure the reverse proxy in front **overwrites** `X-Forwarded-For` rather than appending to it.
+
 ## Security Considerations
 
 - Always use with `trustedProxy` plugin behind reverse proxies

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -33,11 +33,18 @@ import pluginPriority from '../plugins/priority.json';
 
 export type { Config };
 
-// Internal Express router structure (used to remove error middleware)
+// Internal Express router structure (used to remove error middleware and to
+// list the registered routes when checking authentication coverage).
+// Express 5 exposes it as `router`, Express 4 as `_router`.
+interface ExpressRouterStack {
+  stack: Array<{
+    handle: unknown;
+    route?: { path?: string | string[] };
+  }>;
+}
 interface ExpressAppInternal {
-  _router?: {
-    stack: Array<{ handle: unknown }>;
-  };
+  router?: ExpressRouterStack;
+  _router?: ExpressRouterStack;
 }
 
 export * from '../lib/utils';
@@ -129,6 +136,7 @@ export class DM {
         Promise.all(promises)
           .then(() => {
             this.setupErrorMiddleware();
+            this.warnUnauthenticatedRoutes();
             resolve();
           })
           .catch(err => reject(new Error('Error loading plugins: ' + err)));
@@ -137,6 +145,57 @@ export class DM {
         resolve();
       }
     });
+  }
+
+  /**
+   * List the routes no authentication plugin guards, once every plugin is
+   * loaded.
+   *
+   * Scoping authentication to a path prefix is what lets one server host
+   * populations that authenticate differently, but it also means a route
+   * registered outside every prefix is served to anyone. That gap is silent
+   * — the server starts, the API answers — so it is named at startup.
+   *
+   * Nothing is reported when no authentication is configured at all (the
+   * server is open on purpose) or when one plugin guards every path.
+   *
+   * @returns the unguarded route paths, for tests and callers
+   */
+  warnUnauthenticatedRoutes(): string[] {
+    const authPlugins = Object.values(this.loadedPlugins).filter(p =>
+      p.roles?.includes('auth')
+    ) as Array<DmPlugin & { pathPrefixes?: string[] }>;
+    if (authPlugins.length === 0) return [];
+
+    const prefixes: string[] = [];
+    for (const plugin of authPlugins) {
+      // A plugin without prefixes guards everything: nothing can be exposed
+      if (!plugin.pathPrefixes || plugin.pathPrefixes.length === 0) return [];
+      prefixes.push(...plugin.pathPrefixes);
+    }
+
+    const internal = this.app as unknown as ExpressAppInternal;
+    const stack = (internal.router ?? internal._router)?.stack;
+    const paths = new Set<string>();
+    for (const layer of stack || []) {
+      const path = layer.route?.path;
+      if (typeof path === 'string') paths.add(path);
+      else if (Array.isArray(path))
+        path.forEach(p => typeof p === 'string' && paths.add(p));
+    }
+
+    const unguarded = [...paths].filter(
+      path =>
+        !prefixes.some(
+          prefix => path === prefix || path.startsWith(`${prefix}/`)
+        )
+    );
+    if (unguarded.length > 0)
+      this.logger.warn(
+        `Authentication is restricted to ${prefixes.join(', ')}, so these ` +
+          `routes are served without authentication: ${unguarded.sort().join(', ')}`
+      );
+    return unguarded.sort();
   }
 
   setupErrorMiddleware(): void {

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -29,6 +29,7 @@ import ldapActions from '../lib/ldapActions';
 import type DmPlugin from '../abstract/plugin';
 import { buildLogger } from '../logger/winston';
 import { setLogger } from '../lib/expressFormatedResponses';
+import { claimedPrefixes } from '../lib/auth/base';
 import pluginPriority from '../plugins/priority.json';
 
 export type { Config };
@@ -145,6 +146,20 @@ export class DM {
         resolve();
       }
     });
+  }
+
+  /**
+   * Path prefixes claimed by scoped authentication plugins.
+   *
+   * An unscoped plugin subtracts these from what it guards, so a
+   * configuration can say "OIDC on /api/admin, token everywhere else"
+   * without anyone maintaining the list of everywhere else.
+   *
+   * @param except name of the plugin asking, excluded from the result
+   * @returns the prefixes other authentication plugins guard
+   */
+  claimedAuthPrefixes(except?: string): string[] {
+    return claimedPrefixes(this.loadedPlugins, except);
   }
 
   /**

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -149,6 +149,17 @@ export class DM {
   }
 
   /**
+   * The Express router stack, whatever the Express version calls it: 5
+   * exposes `router`, 4 exposed `_router`.
+   *
+   * @returns the layer stack, or undefined when Express hides it
+   */
+  private routerStack(): ExpressRouterStack['stack'] | undefined {
+    const internal = this.app as unknown as ExpressAppInternal;
+    return (internal.router ?? internal._router)?.stack;
+  }
+
+  /**
    * A view of this server carrying a different configuration, handed to a
    * plugin loaded with overrides (`module:name:{json}`).
    *
@@ -212,8 +223,7 @@ export class DM {
       prefixes.push(...plugin.pathPrefixes);
     }
 
-    const internal = this.app as unknown as ExpressAppInternal;
-    const stack = (internal.router ?? internal._router)?.stack;
+    const stack = this.routerStack();
     const paths = new Set<string>();
     for (const layer of stack || []) {
       const path = layer.route?.path;
@@ -237,9 +247,13 @@ export class DM {
   }
 
   setupErrorMiddleware(): void {
-    // Remove existing error middleware if already set up
+    // Remove existing error middleware if already set up.
+    // Express 5 renamed `_router` to `router`, so this lookup silently found
+    // nothing and the old handler was never removed: one more was appended on
+    // every registerPlugin. Only the first ever ran, so nothing broke — the
+    // stack just kept growing.
     if (this._errorMiddlewareSetup && this._errorMiddleware) {
-      const stack = (this.app as unknown as ExpressAppInternal)._router?.stack;
+      const stack = this.routerStack();
       if (stack) {
         const index = stack.findIndex(
           layer => layer.handle === this._errorMiddleware
@@ -427,7 +441,16 @@ export class DM {
     if (!obj.name) obj.name = pluginName;
     if (name) obj.name = name;
     if (this.loadedPlugins[obj.name]) {
-      this.logger.info(`Plugin ${pluginName} already loaded as ${obj.name}`);
+      // Dropping the instance silently is what makes this expensive to
+      // debug: its api() is never called, so its routes simply do not exist
+      // and every request to them answers 404 with nothing in the log to
+      // explain why. Loading a plugin twice on purpose needs a distinct name.
+      this.logger.warn(
+        `Plugin ${pluginName} not registered: the name "${obj.name}" is ` +
+          'already taken. This instance is dropped and its routes will not ' +
+          'exist. To load the same plugin twice, give each one a name: ' +
+          `--plugin '${pluginName}:${obj.name}2:{…}'`
+      );
       return false;
     }
     this.logger.debug(`Registering plugin ${pluginName} as ${obj.name}`);

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -149,6 +149,29 @@ export class DM {
   }
 
   /**
+   * A view of this server carrying a different configuration, handed to a
+   * plugin loaded with overrides (`module:name:{json}`).
+   *
+   * Everything is shared by reference — the Express app, the hooks, the LDAP
+   * connection, the plugin registry — so the plugin acts on this server; only
+   * `config` differs. The copy is built on this instance's prototype rather
+   * than by spreading it: `{...this}` copies own properties and leaves the
+   * methods behind, so a plugin calling `this.server.anything()` would throw,
+   * and only when configured with overrides — the kind of failure that shows
+   * up in production and not in a test that instantiates the plugin directly.
+   *
+   * @param config configuration the plugin must see
+   * @returns a server view backed by this instance
+   */
+  withConfig(config: Config): DM {
+    return Object.assign(
+      Object.create(Object.getPrototypeOf(this) as object) as DM,
+      this,
+      { config }
+    );
+  }
+
+  /**
    * Path prefixes claimed by scoped authentication plugins.
    *
    * An unscoped plugin subtracts these from what it guards, so a
@@ -381,7 +404,7 @@ export class DM {
           if (overrides) {
             const newConfig = { ...this.config, ...overrides };
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            obj = new pluginModule({ ...this, config: newConfig } as DM);
+            obj = new pluginModule(this.withConfig(newConfig));
           } else {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             obj = new pluginModule(this);

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -29,7 +29,7 @@ import ldapActions from '../lib/ldapActions';
 import type DmPlugin from '../abstract/plugin';
 import { buildLogger } from '../logger/winston';
 import { setLogger } from '../lib/expressFormatedResponses';
-import { claimedPrefixes } from '../lib/auth/base';
+import AuthBase, { claimedPrefixes, prefixCoversPath } from '../lib/auth/base';
 import pluginPriority from '../plugins/priority.json';
 
 export type { Config };
@@ -80,6 +80,9 @@ export class DM {
   ldap: ldapActions;
   operationSequence: number;
   logger: winston.Logger;
+  /** Authentication plugins, in registration order */
+  authenticators: AuthBase[] = [];
+  private _authDispatcherMounted = false;
   private _errorMiddlewareSetup: boolean = false;
   private _errorMiddleware?: express.ErrorRequestHandler;
 
@@ -180,6 +183,96 @@ export class DM {
       this,
       { config }
     );
+  }
+
+  /**
+   * Mount the authentication dispatcher, once, before the first plugin that
+   * can register a route.
+   *
+   * Position is the whole point. Guards (`protect`: rate limiting, proxy
+   * trust, CrowdSec) and access logging must see a request *before*
+   * authentication — a rate limiter that runs after a 401 never gets to
+   * answer 429, and `trustedProxy` strips forged `X-Forwarded-For` headers
+   * that authentication relies on. Everything else may register routes, and
+   * a route must never precede authentication: mounting one layer here, at
+   * the boundary between the two, is what makes protection independent of
+   * the order plugins happen to load in.
+   *
+   * @param plugin the plugin about to register
+   */
+  private mountAuthDispatcher(plugin: DmPlugin): void {
+    const roles = plugin.roles || [];
+    if (roles.includes('protect') || roles.includes('logging')) return;
+    this.mountAuthDispatcherNow();
+  }
+
+  /** Mount the dispatcher layer if it is not mounted yet */
+  private mountAuthDispatcherNow(): void {
+    if (this._authDispatcherMounted) return;
+    this._authDispatcherMounted = true;
+    this.app.use((req, res, next) => {
+      this.dispatchAuth(req, res, next);
+    });
+  }
+
+  /**
+   * Add an authentication plugin to the dispatcher.
+   *
+   * Mounts the dispatcher too: a plugin may call `api()` directly instead of
+   * going through `registerPlugin`, and authentication that registers but is
+   * never dispatched would leave the server open.
+   *
+   * @param plugin plugin whose `authenticate` guards the paths it claims
+   */
+  registerAuthenticator(plugin: AuthBase): void {
+    this.mountAuthDispatcherNow();
+    if (!this.authenticators.includes(plugin)) this.authenticators.push(plugin);
+  }
+
+  /**
+   * Pick the authentication a request must satisfy, and run it.
+   *
+   * The most specific claim wins: a plugin scoped to `/api/admin` guards that
+   * branch alone, a plugin scoped to `/api` guards the rest of `/api`, and an
+   * unscoped plugin guards everything nobody claimed. Only the winners run,
+   * so two plugins covering the same request never compose as an AND that no
+   * credential can satisfy.
+   *
+   * Several plugins sharing the same winning prefix all run, in registration
+   * order: asking for two credentials on one branch is a legitimate ask, and
+   * an accident there fails closed.
+   *
+   * A path no plugin claims, with no unscoped plugin loaded, passes through
+   * unauthenticated — the gap `warnUnauthenticatedRoutes` names at startup.
+   *
+   * @param req incoming request
+   * @param res response, ended by the plugin when authentication fails
+   * @param next called when the request is authenticated, or when no
+   *             authentication applies to its path
+   */
+  dispatchAuth(req: Request, res: Response, next: () => void): void {
+    let winning = -1;
+    let selected: AuthBase[] = [];
+    for (const plugin of this.authenticators) {
+      for (const prefix of plugin.pathPrefixes) {
+        if (!prefixCoversPath(prefix, req.path)) continue;
+        if (prefix.length > winning) {
+          winning = prefix.length;
+          selected = [plugin];
+        } else if (prefix.length === winning && !selected.includes(plugin))
+          selected.push(plugin);
+      }
+    }
+    if (winning < 0)
+      selected = this.authenticators.filter(p => p.pathPrefixes.length === 0);
+    if (selected.length === 0) return next();
+
+    // Every selected plugin must let the request through
+    const run = (index: number): void => {
+      if (index >= selected.length) return next();
+      void selected[index].authenticate(req, res, () => run(index + 1));
+    };
+    run(0);
   }
 
   /**
@@ -465,6 +558,7 @@ export class DM {
       }
     }
     if (obj.api) {
+      this.mountAuthDispatcher(obj);
       this.logger.debug(`Plugin ${obj.name} has API, registering it`);
       await obj.api(this.app);
       // If error middleware was already setup, re-setup it to ensure it stays at the end

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -82,7 +82,17 @@ export class DM {
   logger: winston.Logger;
   /** Authentication plugins, in registration order */
   authenticators: AuthBase[] = [];
-  private _authDispatcherMounted = false;
+  /**
+   * Held in an object, not a boolean field: `withConfig` copies own
+   * properties, so a plain flag would be duplicated per configured plugin and
+   * each clone would mount a dispatcher of its own — authentication running
+   * as many times as there are plugins, which a one-shot method like TOTP
+   * fails on the second pass. An object is copied by reference and stays
+   * shared.
+   */
+  private _authState: { dispatcherMounted: boolean } = {
+    dispatcherMounted: false,
+  };
   private _errorMiddlewareSetup: boolean = false;
   private _errorMiddleware?: express.ErrorRequestHandler;
 
@@ -208,8 +218,8 @@ export class DM {
 
   /** Mount the dispatcher layer if it is not mounted yet */
   private mountAuthDispatcherNow(): void {
-    if (this._authDispatcherMounted) return;
-    this._authDispatcherMounted = true;
+    if (this._authState.dispatcherMounted) return;
+    this._authState.dispatcherMounted = true;
     this.app.use((req, res, next) => {
       this.dispatchAuth(req, res, next);
     });

--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -97,6 +97,9 @@ export interface Config {
   static_path?: string;
   static_name?: string;
 
+  // auth (all authentication plugins)
+  auth_path_prefix?: string[];
+
   // auth/llng
   llng_ini?: string;
 
@@ -633,6 +636,15 @@ const configArgs: ConfigTemplate = [
 
   // Lemonldap options
   ['--llng-ini', 'DM_LLNG_INI', '/etc/lemonldap-ng/lemonldap-ng.ini'],
+
+  // Common to every authentication plugin: restrict it to path prefixes
+  [
+    '--auth-path-prefix',
+    'DM_AUTH_PATH_PREFIX',
+    [],
+    'array',
+    '--auth-path-prefixes',
+  ],
 
   // Auth token plugin
   ['--auth-token', 'DM_AUTH_TOKENS', [], 'array', '--auth-tokens'],

--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -98,7 +98,10 @@ export interface Config {
   static_name?: string;
 
   // auth (all authentication plugins)
-  auth_path_prefix?: string[];
+  // A single prefix is accepted as a bare string: plugin overrides are raw
+  // JSON (`{"auth_path_prefix":"/api/m"}`) and never go through the array
+  // parsing that `--auth-path-prefix` and `DM_AUTH_PATH_PREFIX` apply
+  auth_path_prefix?: string | string[];
 
   // auth/llng
   llng_ini?: string;

--- a/src/lib/auth/base.ts
+++ b/src/lib/auth/base.ts
@@ -26,6 +26,51 @@ function stripTrailingSlashes(path: string): string {
   return path.slice(0, end);
 }
 
+/**
+ * Tell whether a mount prefix covers a request path, with the rule Express
+ * itself applies: on segment boundaries, so `/api/m` covers `/api/m` and
+ * `/api/m/entry` but never `/api/machines`.
+ *
+ * The catch-all uses this to decide what another plugin already guards, so
+ * it must agree with Express exactly — a looser rule here would skip paths
+ * nobody guards.
+ *
+ * @param prefix mount prefix
+ * @param path request path
+ * @returns true when the prefix covers the path
+ */
+export function prefixCoversPath(prefix: string, path: string): boolean {
+  return path === prefix || path.startsWith(`${prefix}/`);
+}
+
+/**
+ * Path prefixes claimed by scoped authentication plugins.
+ *
+ * Reads the plugin registry rather than calling a method on the server:
+ * `loadPlugin` builds a plugin loaded with overrides from `{...this}`, a
+ * spread that copies own properties but leaves the prototype behind, so a
+ * `DM` method would be missing on exactly the configuration this feature is
+ * meant for. `loadedPlugins` is a shared reference and stays live as the
+ * remaining plugins register.
+ *
+ * @param loadedPlugins the server's plugin registry
+ * @param except name of the plugin asking, excluded from the result
+ * @returns the prefixes other authentication plugins guard
+ */
+export function claimedPrefixes(
+  loadedPlugins: Record<string, DmPlugin>,
+  except?: string
+): string[] {
+  const claimed: string[] = [];
+  for (const plugin of Object.values(loadedPlugins)) {
+    if (plugin.name === except || !plugin.roles?.includes('auth')) continue;
+    const prefixes = (plugin as DmPlugin & { pathPrefixes?: string[] })
+      .pathPrefixes;
+    if (prefixes?.length) claimed.push(...prefixes);
+  }
+  return claimed;
+}
+
 export default abstract class AuthBase extends DmPlugin {
   abstract authMethod(req: DmRequest, res: Response, next: () => void): void;
 
@@ -92,7 +137,25 @@ export default abstract class AuthBase extends DmPlugin {
     };
 
     if (prefixes.length === 0) {
-      app.use(middleware);
+      // An unscoped plugin guards everything *no scoped plugin claims*, so
+      // "OIDC here, token everywhere else" needs no list of everywhere else
+      // — which nobody maintains without forgetting a branch. The check runs
+      // per request rather than at mount time: plugins load in any order, and
+      // the claims are only complete once they all have.
+      //
+      // Without this, the two middlewares would both match the scoped branch
+      // and compose as AND: every credential refused, the branch unusable.
+      const catchAll = (
+        req: Request,
+        res: Response,
+        next: () => void
+      ): void => {
+        const claimed = claimedPrefixes(this.server.loadedPlugins, this.name);
+        if (claimed.some(prefix => prefixCoversPath(prefix, req.path)))
+          return next();
+        void middleware(req, res, next);
+      };
+      app.use(catchAll);
       return;
     }
 

--- a/src/lib/auth/base.ts
+++ b/src/lib/auth/base.ts
@@ -146,66 +146,64 @@ export default abstract class AuthBase extends DmPlugin {
     return (this._pathPrefixes = prefixes);
   }
 
-  api(app: Express): void {
-    const prefixes = this.pathPrefixes;
-
-    const middleware = async (
-      req: Request,
-      res: Response,
-      next: () => void
-    ): Promise<void> => {
-      try {
-        [req, res] = await launchHooksChained(this.server.hooks.beforeAuth, [
-          req,
-          res,
-        ]);
-      } catch (err) {
-        return serverError(res, err as Error);
-      }
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      this.authMethod(req, res, async (): Promise<void> => {
-        try {
-          if (this.hooks?.onAuth) {
-            [req, res] = await launchHooksChained(this.server.hooks.afterAuth, [
-              req,
-              res,
-            ]);
-          }
-          next();
-        } catch (err) {
-          serverError(res, err as Error);
-        }
-      });
-    };
-
-    if (prefixes.length === 0) {
-      // An unscoped plugin guards everything *no scoped plugin claims*, so
-      // "OIDC here, token everywhere else" needs no list of everywhere else
-      // — which nobody maintains without forgetting a branch. The check runs
-      // per request rather than at mount time: plugins load in any order, and
-      // the claims are only complete once they all have.
-      //
-      // Without this, the two middlewares would both match the scoped branch
-      // and compose as AND: every credential refused, the branch unusable.
-      const catchAll = (
-        req: Request,
-        res: Response,
-        next: () => void
-      ): void => {
-        const claimed = claimedPrefixes(this.server.loadedPlugins, this.name);
-        if (claimed.some(prefix => prefixCoversPath(prefix, req.path)))
-          return next();
-        void middleware(req, res, next);
-      };
-      app.use(catchAll);
-      return;
+  /**
+   * Run this plugin's authentication on a request, hooks included.
+   *
+   * The dispatcher calls this; the plugin no longer owns a layer of its own.
+   *
+   * @param req incoming request
+   * @param res response, ended here when authentication fails
+   * @param next called only when the request is authenticated
+   */
+  async authenticate(
+    req: Request,
+    res: Response,
+    next: () => void
+  ): Promise<void> {
+    try {
+      [req, res] = await launchHooksChained(this.server.hooks.beforeAuth, [
+        req,
+        res,
+      ]);
+    } catch (err) {
+      return serverError(res, err as Error);
     }
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    this.authMethod(req, res, async (): Promise<void> => {
+      try {
+        if (this.hooks?.onAuth) {
+          [req, res] = await launchHooksChained(this.server.hooks.afterAuth, [
+            req,
+            res,
+          ]);
+        }
+        next();
+      } catch (err) {
+        serverError(res, err as Error);
+      }
+    });
+  }
 
-    // Express matches a mount path on segment boundaries, so `/api/m` guards
-    // `/api/m` and `/api/m/entry` without ever catching `/api/machines`
-    app.use(prefixes, middleware);
+  /**
+   * Register with the server's authentication dispatcher instead of mounting
+   * a middleware.
+   *
+   * Mounting per plugin made protection depend on registration order: a
+   * plugin whose `app.use` landed after the routes it was meant to guard
+   * never ran for them, and the catch-all — stepping aside for a branch that
+   * guard was supposed to cover — turned that into anonymous access. The
+   * dispatcher is mounted by `DM` before any plugin loads, so it always
+   * precedes every route, whatever order the plugins register in.
+   *
+   * @param _app unused: the dispatcher owns the only authentication layer
+   */
+  api(_app: Express): void {
+    const prefixes = this.pathPrefixes;
+    this.server.registerAuthenticator(this);
     this.logger.info(
-      `${this.name}: authentication restricted to ${prefixes.join(', ')}`
+      prefixes.length === 0
+        ? `${this.name}: authentication guards every path not claimed by another plugin`
+        : `${this.name}: authentication restricted to ${prefixes.join(', ')}`
     );
   }
 }

--- a/src/lib/auth/base.ts
+++ b/src/lib/auth/base.ts
@@ -72,6 +72,9 @@ export function claimedPrefixes(
 export default abstract class AuthBase extends DmPlugin {
   abstract authMethod(req: DmRequest, res: Response, next: () => void): void;
 
+  /** Validated prefixes, computed once: the catch-all reads them per request */
+  private _pathPrefixes?: string[];
+
   /**
    * Path prefixes this authentication applies to, empty when it guards the
    * whole server.
@@ -88,18 +91,59 @@ export default abstract class AuthBase extends DmPlugin {
    * A credential is then only valid on the branch it was scoped to, which is
    * the point: a leaked machine token buys nothing on the admin API.
    *
-   * @returns the configured prefixes, without trailing slashes
+   * A malformed entry is refused rather than skipped. Dropping one silently
+   * would shrink what the plugin guards — the failure mode that leaves a
+   * branch open while the configuration still reads as if it were covered.
+   *
+   * `/` is not a prefix but the whole server, so a list containing it makes
+   * the plugin a catch-all: `["/", "/api/admin"]` guards everything, not
+   * only `/api/admin`.
+   *
+   * @returns the configured prefixes without their trailing slashes, empty
+   *          when the plugin guards the whole server
+   * @throws Error when an entry is not a usable path prefix
    */
   get pathPrefixes(): string[] {
+    if (this._pathPrefixes) return this._pathPrefixes;
+
     const configured = this.config.auth_path_prefix;
     const list = Array.isArray(configured)
       ? configured
       : configured
         ? [configured]
         : [];
-    return list
-      .map(p => stripTrailingSlashes(p.trim()))
-      .filter(p => p.length > 0);
+
+    const prefixes: string[] = [];
+    for (const entry of list) {
+      // Plugin overrides are raw JSON, so an entry can be anything at all
+      if (typeof entry !== 'string')
+        throw new Error(
+          `${this.name}: auth_path_prefix must contain strings, got ` +
+            `${JSON.stringify(entry)}`
+        );
+
+      const trimmed = entry.trim();
+      const prefix = stripTrailingSlashes(trimmed);
+      if (prefix.length === 0) {
+        if (trimmed.length === 0)
+          throw new Error(
+            `${this.name}: auth_path_prefix contains an empty entry`
+          );
+        // Only slashes: the plugin guards everything, whatever else is listed
+        this.logger.info(
+          `${this.name}: auth_path_prefix contains "${trimmed}", which covers ` +
+            'the whole server: this authentication guards every path'
+        );
+        return (this._pathPrefixes = []);
+      }
+      if (!prefix.startsWith('/'))
+        throw new Error(
+          `${this.name}: auth_path_prefix entry "${entry}" must start with ` +
+            '"/", otherwise it matches no request and guards nothing'
+        );
+      prefixes.push(prefix);
+    }
+    return (this._pathPrefixes = prefixes);
   }
 
   api(app: Express): void {

--- a/src/lib/auth/base.ts
+++ b/src/lib/auth/base.ts
@@ -10,8 +10,45 @@ import { launchHooksChained } from '../../lib/utils';
 
 export default abstract class AuthBase extends DmPlugin {
   abstract authMethod(req: DmRequest, res: Response, next: () => void): void;
+
+  /**
+   * Path prefixes this authentication applies to, empty when it guards the
+   * whole server.
+   *
+   * Loading the same plugin twice with different prefixes lets one server
+   * serve populations that authenticate differently — machines with a token
+   * on one branch of the API, administrators with an SSO session on another:
+   *
+   * ```
+   * --plugin 'core/auth/token:tok:{"auth_path_prefix":"/api/m"}'
+   * --plugin 'core/auth/openidconnect:oidc:{"auth_path_prefix":"/api/admin"}'
+   * ```
+   *
+   * A credential is then only valid on the branch it was scoped to, which is
+   * the point: a leaked machine token buys nothing on the admin API.
+   *
+   * @returns the configured prefixes, without trailing slashes
+   */
+  get pathPrefixes(): string[] {
+    const configured = this.config.auth_path_prefix;
+    const list = Array.isArray(configured)
+      ? configured
+      : configured
+        ? [configured]
+        : [];
+    return list
+      .map(p => p.trim().replace(/\/+$/, ''))
+      .filter(p => p.length > 0);
+  }
+
   api(app: Express): void {
-    app.use(async (req, res, next) => {
+    const prefixes = this.pathPrefixes;
+
+    const middleware = async (
+      req: Request,
+      res: Response,
+      next: () => void
+    ): Promise<void> => {
       try {
         [req, res] = await launchHooksChained(this.server.hooks.beforeAuth, [
           req,
@@ -34,6 +71,18 @@ export default abstract class AuthBase extends DmPlugin {
           serverError(res, err as Error);
         }
       });
-    });
+    };
+
+    if (prefixes.length === 0) {
+      app.use(middleware);
+      return;
+    }
+
+    // Express matches a mount path on segment boundaries, so `/api/m` guards
+    // `/api/m` and `/api/m/entry` without ever catching `/api/machines`
+    app.use(prefixes, middleware);
+    this.logger.info(
+      `${this.name}: authentication restricted to ${prefixes.join(', ')}`
+    );
   }
 }

--- a/src/lib/auth/base.ts
+++ b/src/lib/auth/base.ts
@@ -8,6 +8,24 @@ import DmPlugin from '../../abstract/plugin';
 import { serverError } from '../../lib/expressFormatedResponses';
 import { launchHooksChained } from '../../lib/utils';
 
+/**
+ * Drop the trailing slashes of a path prefix.
+ *
+ * Written as a scan rather than a `/\/+$/` replacement: that pattern
+ * backtracks quadratically on a long run of slashes, which CodeQL flags as
+ * a polynomial ReDoS. The value comes from the configuration rather than
+ * from a request, so nothing was exploitable — but a linear scan says what
+ * it does and costs nothing.
+ *
+ * @param path prefix to clean
+ * @returns the prefix without its trailing slashes
+ */
+function stripTrailingSlashes(path: string): string {
+  let end = path.length;
+  while (end > 0 && path[end - 1] === '/') end--;
+  return path.slice(0, end);
+}
+
 export default abstract class AuthBase extends DmPlugin {
   abstract authMethod(req: DmRequest, res: Response, next: () => void): void;
 
@@ -37,7 +55,7 @@ export default abstract class AuthBase extends DmPlugin {
         ? [configured]
         : [];
     return list
-      .map(p => p.trim().replace(/\/+$/, ''))
+      .map(p => stripTrailingSlashes(p.trim()))
       .filter(p => p.length > 0);
   }
 

--- a/src/lib/auth/base.ts
+++ b/src/lib/auth/base.ts
@@ -46,12 +46,10 @@ export function prefixCoversPath(prefix: string, path: string): boolean {
 /**
  * Path prefixes claimed by scoped authentication plugins.
  *
- * Reads the plugin registry rather than calling a method on the server:
- * `loadPlugin` builds a plugin loaded with overrides from `{...this}`, a
- * spread that copies own properties but leaves the prototype behind, so a
- * `DM` method would be missing on exactly the configuration this feature is
- * meant for. `loadedPlugins` is a shared reference and stays live as the
- * remaining plugins register.
+ * Takes the registry as an argument rather than reaching for the server, so
+ * `DM` and `AuthBase` share one definition of what "claimed" means. The
+ * registry is a live reference: it keeps filling as the remaining plugins
+ * register, which is why the catch-all consults it per request.
  *
  * @param loadedPlugins the server's plugin registry
  * @param except name of the plugin asking, excluded from the result

--- a/src/plugins/auth/rateLimit.ts
+++ b/src/plugins/auth/rateLimit.ts
@@ -37,6 +37,20 @@ export default class RateLimit extends DmPlugin {
   }
 
   api(app: Express): void {
+    // The limiter keys on the client IP taken from X-Forwarded-For, which a
+    // client can set to anything. That is only safe because trustedProxy —
+    // loaded first — strips the header on requests that do not come from a
+    // declared proxy. Without it, rotating the header defeats the limiter
+    // entirely and the brute-force protection is decorative, with nothing to
+    // show for it in the logs.
+    if (!this.server.loadedPlugins.trustedProxy)
+      this.logger.warn(
+        'Auth rate limiting keys on X-Forwarded-For but core/auth/trustedProxy ' +
+          'is not loaded: a client can forge that header and evade the limit. ' +
+          'Load core/auth/trustedProxy, or put the API behind a proxy that ' +
+          'overwrites the header.'
+      );
+
     // Middleware to check rate limits and track failed authentications
     app.use((req: Request, res: Response, next: NextFunction) => {
       const ip = this.getClientIp(req);

--- a/test/plugins/auth/authPathScope.test.ts
+++ b/test/plugins/auth/authPathScope.test.ts
@@ -2,7 +2,7 @@ import type { Express } from 'express';
 import request from 'supertest';
 import { expect } from 'chai';
 
-import { DM } from '../../../src/bin';
+import { DM, type Config } from '../../../src/bin';
 import AuthToken from '../../../src/plugins/auth/token';
 import HelloWorld from '../../../src/plugins/demo/helloworld';
 
@@ -38,8 +38,8 @@ describe('Authentication path scope', () => {
     await dm.ready;
 
     /** Clone the server with an overridden configuration, as loadPlugin does */
-    const withConfig = (overrides: Record<string, unknown>): DM =>
-      ({ ...dm, config: { ...dm.config, ...overrides } }) as DM;
+    const withConfig = (overrides: Partial<Config>): DM =>
+      dm.withConfig({ ...dm.config, ...overrides });
 
     for (const scope of scopes) {
       const plugin = new AuthToken(
@@ -71,6 +71,127 @@ describe('Authentication path scope', () => {
     );
     return { app: dm.app, dm };
   }
+
+  describe('registration order', () => {
+    /**
+     * Authentication used to be a middleware each plugin mounted itself, so
+     * a plugin registering after the routes it guarded never ran for them —
+     * and the catch-all, stepping aside for that branch, turned the hole into
+     * anonymous access. The dispatcher is mounted before any plugin loads, so
+     * this ordering must no longer matter.
+     *
+     * @returns the app, with the API registered before its authentication
+     */
+    async function routesBeforeAuth(): Promise<Express> {
+      const dm = new DM();
+      await dm.ready;
+      const withConfig = (o: Partial<Config>): DM =>
+        dm.withConfig({ ...dm.config, ...o });
+
+      // 1. an unscoped catch-all, as a priority plugin would register
+      await dm.registerPlugin(
+        'core/auth/token',
+        new AuthToken(withConfig({ auth_token: [`${machineToken}:rest`] })),
+        'authRest'
+      );
+      // 2. the admin API routes
+      await dm.registerPlugin(
+        'core/demo/helloworld',
+        new HelloWorld(withConfig({ api_prefix: '/api/admin' })),
+        'helloAdmin'
+      );
+      // 3. the plugin guarding them, registered last
+      await dm.registerPlugin(
+        'core/auth/token',
+        new AuthToken(
+          withConfig({
+            auth_token: [`${adminToken}:admins`],
+            auth_path_prefix: ['/api/admin'],
+          })
+        ),
+        'authAdmins'
+      );
+      return dm.app;
+    }
+
+    it('should guard a branch whose plugin registered after its routes', async () => {
+      const app = await routesBeforeAuth();
+      expect((await request(app).get('/api/admin/hello')).status).to.equal(401);
+    });
+
+    it('should still accept the right credential there', async () => {
+      const app = await routesBeforeAuth();
+      expect(
+        (
+          await request(app)
+            .get('/api/admin/hello')
+            .set('Authorization', `Bearer ${adminToken}`)
+        ).status
+      ).to.equal(200);
+    });
+
+    it('should not accept the catch-all credential there', async () => {
+      const app = await routesBeforeAuth();
+      expect(
+        (
+          await request(app)
+            .get('/api/admin/hello')
+            .set('Authorization', `Bearer ${machineToken}`)
+        ).status
+      ).to.equal(401);
+    });
+  });
+
+  describe('nested prefixes', () => {
+    let app: Express;
+
+    before(async () => {
+      ({ app } = await build([
+        { name: 'authApi', token: machineToken, prefix: ['/api'] },
+        { name: 'authAdmins', token: adminToken, prefix: ['/api/admin'] },
+      ]));
+    });
+
+    it('should let the most specific claim win', async () => {
+      // /api/admin belongs to authAdmins alone, even though /api covers it
+      expect(
+        (
+          await request(app)
+            .get('/api/admin/hello')
+            .set('Authorization', `Bearer ${adminToken}`)
+        ).status
+      ).to.equal(200);
+    });
+
+    it('should not require both credentials on the nested branch', async () => {
+      // Two overlapping guards used to compose as AND, which no single
+      // credential could satisfy
+      expect(
+        (
+          await request(app)
+            .get('/api/admin/hello')
+            .set('Authorization', `Bearer ${machineToken}`)
+        ).status
+      ).to.equal(401);
+    });
+
+    it('should keep the outer claim on the rest of its branch', async () => {
+      expect(
+        (
+          await request(app)
+            .get('/api/hello')
+            .set('Authorization', `Bearer ${machineToken}`)
+        ).status
+      ).to.equal(200);
+      expect(
+        (
+          await request(app)
+            .get('/api/hello')
+            .set('Authorization', `Bearer ${adminToken}`)
+        ).status
+      ).to.equal(401);
+    });
+  });
 
   describe('a single scoped plugin', () => {
     let app: Express;

--- a/test/plugins/auth/authPathScope.test.ts
+++ b/test/plugins/auth/authPathScope.test.ts
@@ -202,6 +202,92 @@ describe('Authentication path scope', () => {
     });
   });
 
+  describe('an unscoped plugin as the catch-all', () => {
+    /**
+     * "OIDC on /api/admin, token everywhere else", without anyone listing
+     * everywhere else. Loading order must not matter, so both are covered.
+     */
+    const scopedFirst: Scope[] = [
+      { name: 'authAdmins', token: adminToken, prefix: ['/api/admin'] },
+      { name: 'authRest', token: machineToken },
+    ];
+    const catchAllFirst: Scope[] = [
+      { name: 'authRest', token: machineToken },
+      { name: 'authAdmins', token: adminToken, prefix: ['/api/admin'] },
+    ];
+
+    for (const [label, scopes] of [
+      ['catch-all loaded first', catchAllFirst],
+      ['scoped plugin loaded first', scopedFirst],
+    ] as const) {
+      describe(label, () => {
+        let app: Express;
+
+        before(async () => {
+          ({ app } = await build([...scopes]));
+        });
+
+        it('should let the catch-all guard everything unclaimed', async () => {
+          expect((await request(app).get('/api/hello')).status).to.equal(401);
+          expect(
+            (
+              await request(app)
+                .get('/api/hello')
+                .set('Authorization', `Bearer ${machineToken}`)
+            ).status
+          ).to.equal(200);
+        });
+
+        it('should leave the claimed branch to its own plugin', async () => {
+          expect(
+            (
+              await request(app)
+                .get('/api/admin/hello')
+                .set('Authorization', `Bearer ${adminToken}`)
+            ).status
+          ).to.equal(200);
+        });
+
+        it('should not let the catch-all credential in on that branch', async () => {
+          // Without the subtraction both middlewares would match and compose
+          // as AND: every credential refused and the branch unusable
+          expect(
+            (
+              await request(app)
+                .get('/api/admin/hello')
+                .set('Authorization', `Bearer ${machineToken}`)
+            ).status
+          ).to.equal(401);
+        });
+
+        it('should still refuse an anonymous request everywhere', async () => {
+          expect((await request(app).get('/api/hello')).status).to.equal(401);
+          expect((await request(app).get('/api/admin/hello')).status).to.equal(
+            401
+          );
+        });
+      });
+    }
+
+    it('should subtract on segment boundaries only', async () => {
+      const { app } = await build([
+        { name: 'authScoped', token: adminToken, prefix: ['/api/m'] },
+        { name: 'authRest', token: machineToken },
+      ]);
+      // `/api/machines` is not below `/api/m`, so the catch-all still guards it
+      const res = await request(app).get('/api/machines');
+      expect(res.status).to.equal(401);
+    });
+
+    it('should report no unauthenticated route', async () => {
+      const { dm } = await build([
+        { name: 'authScoped', token: adminToken, prefix: ['/api/admin'] },
+        { name: 'authRest', token: machineToken },
+      ]);
+      expect(dm.warnUnauthenticatedRoutes()).to.deep.equal([]);
+    });
+  });
+
   describe('unscoped plugins', () => {
     it('should keep guarding every path', async () => {
       const { app } = await build([

--- a/test/plugins/auth/authPathScope.test.ts
+++ b/test/plugins/auth/authPathScope.test.ts
@@ -22,7 +22,8 @@ describe('Authentication path scope', () => {
   interface Scope {
     name: string;
     token: string;
-    prefix?: string[];
+    /** A bare string is what a plugin override carries: `"/api/m"` */
+    prefix?: string | string[];
   }
 
   /**
@@ -53,7 +54,9 @@ describe('Authentication path scope', () => {
     }
 
     for (const scope of scopes)
-      for (const prefix of scope.prefix || [])
+      for (const prefix of typeof scope.prefix === 'string'
+        ? [scope.prefix]
+        : scope.prefix || [])
         await dm.registerPlugin(
           'core/demo/helloworld',
           new HelloWorld(withConfig({ api_prefix: prefix })),
@@ -131,6 +134,16 @@ describe('Authentication path scope', () => {
       expect((await request(trailing).get('/api/m/hello')).status).to.equal(
         401
       );
+    });
+
+    it('should accept a single prefix given as a bare string', async () => {
+      // The form the documented plugin override produces:
+      // --plugin 'core/auth/token:tok:{"auth_path_prefix":"/api/m"}'
+      const { app: single } = await build([
+        { name: 'authString', token: machineToken, prefix: '/api/m' },
+      ]);
+      expect((await request(single).get('/api/m/hello')).status).to.equal(401);
+      expect((await request(single).get('/api/hello')).status).to.equal(200);
     });
 
     it('should accept several prefixes', async () => {

--- a/test/plugins/auth/authPathScope.test.ts
+++ b/test/plugins/auth/authPathScope.test.ts
@@ -107,6 +107,74 @@ describe('Authentication path scope', () => {
     });
   });
 
+  describe('malformed prefixes', () => {
+    let dm: DM;
+
+    before(async () => {
+      dm = new DM();
+      await dm.ready;
+    });
+
+    /**
+     * Read the prefixes of a token plugin configured with an arbitrary
+     * `auth_path_prefix`, as a plugin override would: the value comes from
+     * raw JSON and is validated nowhere upstream.
+     *
+     * @param prefix value to put in the configuration
+     * @returns a thunk reading the plugin's prefixes
+     */
+    const prefixesOf = (prefix: unknown) => (): string[] =>
+      new AuthToken(
+        dm.withConfig({
+          ...dm.config,
+          auth_token: ['t:name'],
+          auth_path_prefix: prefix as string | string[],
+        })
+      ).pathPrefixes;
+
+    it('should refuse an entry that is not a string', () => {
+      // Skipping it silently would shrink what the plugin guards
+      expect(prefixesOf(['/api/m', 42])).to.throw('must contain strings');
+      expect(prefixesOf([null])).to.throw('must contain strings');
+    });
+
+    it('should refuse an empty entry', () => {
+      expect(prefixesOf(['/api/m', '   '])).to.throw('empty entry');
+    });
+
+    it('should refuse a prefix that cannot match a request', () => {
+      // Express matches against a pathname, which always starts with a slash
+      expect(prefixesOf(['api/m'])).to.throw('must start with "/"');
+    });
+
+    it('should treat "/" as the whole server, not as a prefix', () => {
+      expect(prefixesOf('/')()).to.deep.equal([]);
+      expect(prefixesOf('///')()).to.deep.equal([]);
+    });
+
+    it('should keep a list containing "/" a catch-all', () => {
+      // ["/", "/api/admin"] means everything: reducing it to /api/admin would
+      // silently leave every other branch unguarded
+      expect(prefixesOf(['/', '/api/admin'])()).to.deep.equal([]);
+      expect(prefixesOf(['/api/admin', '/'])()).to.deep.equal([]);
+    });
+
+    it('should still guard everything when configured that way', async () => {
+      const { app } = await build([
+        { name: 'authSlash', token: machineToken, prefix: ['/', '/api/admin'] },
+      ]);
+      expect((await request(app).get('/api/hello')).status).to.equal(401);
+      expect((await request(app).get('/api/admin/hello')).status).to.equal(401);
+      expect(
+        (
+          await request(app)
+            .get('/api/hello')
+            .set('Authorization', `Bearer ${machineToken}`)
+        ).status
+      ).to.equal(200);
+    });
+  });
+
   describe('prefix boundaries', () => {
     let app: Express;
 

--- a/test/plugins/auth/authPathScope.test.ts
+++ b/test/plugins/auth/authPathScope.test.ts
@@ -1,0 +1,229 @@
+import type { Express } from 'express';
+import request from 'supertest';
+import { expect } from 'chai';
+
+import { DM } from '../../../src/bin';
+import AuthToken from '../../../src/plugins/auth/token';
+import HelloWorld from '../../../src/plugins/demo/helloworld';
+
+/**
+ * Scoping authentication to a path prefix is what lets a single server host
+ * machines authenticating with a token and administrators authenticating
+ * with an SSO session, without either credential being valid on the other's
+ * branch of the API.
+ *
+ * The setup mirrors the documented deployment: one API instance and one
+ * authentication instance per branch, all in one server.
+ */
+describe('Authentication path scope', () => {
+  const machineToken = 'machine-token';
+  const adminToken = 'admin-token';
+
+  interface Scope {
+    name: string;
+    token: string;
+    prefix?: string[];
+  }
+
+  /**
+   * Build a server with one token plugin per scope and one hello API per
+   * prefix, plus an unscoped hello API on the default prefix.
+   *
+   * @param scopes prefix and token of each authentication instance
+   * @returns the Express app and the DM instance
+   */
+  async function build(scopes: Scope[]): Promise<{ app: Express; dm: DM }> {
+    const dm = new DM();
+    await dm.ready;
+
+    /** Clone the server with an overridden configuration, as loadPlugin does */
+    const withConfig = (overrides: Record<string, unknown>): DM =>
+      ({ ...dm, config: { ...dm.config, ...overrides } }) as DM;
+
+    for (const scope of scopes) {
+      const plugin = new AuthToken(
+        withConfig({
+          auth_token: [`${scope.token}:${scope.name}`],
+          auth_path_prefix: scope.prefix,
+        })
+      );
+      // The name must be passed explicitly: registerPlugin keeps the one
+      // declared by the class otherwise, and the second instance is dropped
+      await dm.registerPlugin('core/auth/token', plugin, scope.name);
+    }
+
+    for (const scope of scopes)
+      for (const prefix of scope.prefix || [])
+        await dm.registerPlugin(
+          'core/demo/helloworld',
+          new HelloWorld(withConfig({ api_prefix: prefix })),
+          `hello${prefix}`
+        );
+
+    // An API left on the default prefix, outside every scope
+    await dm.registerPlugin(
+      'core/demo/helloworld',
+      new HelloWorld(dm),
+      'hello'
+    );
+    return { app: dm.app, dm };
+  }
+
+  describe('a single scoped plugin', () => {
+    let app: Express;
+    let dm: DM;
+
+    before(async () => {
+      ({ app, dm } = await build([
+        { name: 'authMachines', token: machineToken, prefix: ['/api/m'] },
+      ]));
+    });
+
+    it('should protect its own prefix', async () => {
+      const res = await request(app).get('/api/m/hello');
+      expect(res.status).to.equal(401);
+    });
+
+    it('should accept its token on that prefix', async () => {
+      const res = await request(app)
+        .get('/api/m/hello')
+        .set('Authorization', `Bearer ${machineToken}`);
+      expect(res.status).to.equal(200);
+      expect(res.body.message).to.equal('Hello');
+    });
+
+    it('should leave routes outside the prefix unauthenticated', async () => {
+      const res = await request(app).get('/api/hello');
+      expect(res.status).to.equal(200);
+    });
+
+    it('should name the routes it does not guard', () => {
+      const unguarded = dm.warnUnauthenticatedRoutes();
+      expect(unguarded).to.contain('/api/hello');
+      expect(unguarded).to.not.contain('/api/m/hello');
+    });
+  });
+
+  describe('prefix boundaries', () => {
+    let app: Express;
+
+    before(async () => {
+      ({ app } = await build([
+        { name: 'authBoundary', token: machineToken, prefix: ['/api/m'] },
+      ]));
+    });
+
+    it('should guard every path below the prefix', async () => {
+      expect((await request(app).get('/api/m/hello')).status).to.equal(401);
+      expect((await request(app).get('/api/m/anything')).status).to.equal(401);
+      expect((await request(app).get('/api/m')).status).to.equal(401);
+    });
+
+    it('should not guard a path that merely starts with the same letters', async () => {
+      // `/api/machines` is not below `/api/m`
+      expect((await request(app).get('/api/machines')).status).to.equal(404);
+    });
+
+    it('should ignore a trailing slash in the configuration', async () => {
+      const { app: trailing } = await build([
+        { name: 'authTrailing', token: machineToken, prefix: ['/api/m/'] },
+      ]);
+      expect((await request(trailing).get('/api/m/hello')).status).to.equal(
+        401
+      );
+    });
+
+    it('should accept several prefixes', async () => {
+      const { app: multi } = await build([
+        {
+          name: 'authMulti',
+          token: machineToken,
+          prefix: ['/api/m', '/api/n'],
+        },
+      ]);
+      expect((await request(multi).get('/api/m/hello')).status).to.equal(401);
+      expect((await request(multi).get('/api/n/hello')).status).to.equal(401);
+      expect((await request(multi).get('/api/hello')).status).to.equal(200);
+    });
+  });
+
+  describe('two populations on one server', () => {
+    let app: Express;
+
+    before(async () => {
+      ({ app } = await build([
+        { name: 'authMachines', token: machineToken, prefix: ['/api/m'] },
+        { name: 'authAdmins', token: adminToken, prefix: ['/api/admin'] },
+      ]));
+    });
+
+    it('should accept each token on its own branch', async () => {
+      const machines = await request(app)
+        .get('/api/m/hello')
+        .set('Authorization', `Bearer ${machineToken}`);
+      expect(machines.status).to.equal(200);
+
+      const admins = await request(app)
+        .get('/api/admin/hello')
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(admins.status).to.equal(200);
+    });
+
+    it('should refuse a credential outside its branch', async () => {
+      // The whole point of scoping: a leaked machine token buys nothing on
+      // the administration API
+      const crossed = await request(app)
+        .get('/api/admin/hello')
+        .set('Authorization', `Bearer ${machineToken}`);
+      expect(crossed.status).to.equal(401);
+
+      const other = await request(app)
+        .get('/api/m/hello')
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(other.status).to.equal(401);
+    });
+
+    it('should refuse a request with no credential on either branch', async () => {
+      expect((await request(app).get('/api/m/hello')).status).to.equal(401);
+      expect((await request(app).get('/api/admin/hello')).status).to.equal(401);
+    });
+  });
+
+  describe('unscoped plugins', () => {
+    it('should keep guarding every path', async () => {
+      const { app } = await build([
+        { name: 'authGlobal', token: machineToken },
+      ]);
+      expect((await request(app).get('/api/hello')).status).to.equal(401);
+      expect(
+        (
+          await request(app)
+            .get('/api/hello')
+            .set('Authorization', `Bearer ${machineToken}`)
+        ).status
+      ).to.equal(200);
+    });
+
+    it('should report nothing, since no route is left out', async () => {
+      const { dm } = await build([
+        { name: 'authGlobal2', token: machineToken },
+      ]);
+      expect(dm.warnUnauthenticatedRoutes()).to.deep.equal([]);
+    });
+
+    it('should report nothing when no authentication is configured', async () => {
+      const dm = new DM();
+      await dm.ready;
+      await dm.registerPlugin('core/demo/helloworld', new HelloWorld(dm));
+      expect(dm.warnUnauthenticatedRoutes()).to.deep.equal([]);
+    });
+
+    it('should report nothing when one plugin guards everything', async () => {
+      const { dm } = await build([
+        { name: 'authScoped', token: machineToken, prefix: ['/api/m'] },
+        { name: 'authEverything', token: adminToken },
+      ]);
+      expect(dm.warnUnauthenticatedRoutes()).to.deep.equal([]);
+    });
+  });
+});

--- a/test/plugins/auth/authPathScopeLoader.test.ts
+++ b/test/plugins/auth/authPathScopeLoader.test.ts
@@ -1,0 +1,77 @@
+import request from 'supertest';
+import { expect } from 'chai';
+
+import { DM } from '../../../src/bin';
+
+/**
+ * The same scoping, exercised through the real plugin loader rather than
+ * through `registerPlugin` calls written in the right order by hand.
+ *
+ * This is the path the authentication bypass lived on: `loadPlugin` matches
+ * the priority list by exact string, so a named instance — the only form that
+ * can carry a scope — never gets the sequential early load and lands in the
+ * parallel batch, where an API plugin can register its routes first. The API
+ * is deliberately declared before the plugin that guards it.
+ */
+describe('Authentication path scope through the plugin loader', () => {
+  let dm: DM;
+
+  before(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.DM_AUTH_TOKENS = '';
+    // `;` separates plugins, since the override JSON contains commas
+    process.env.DM_PLUGINS = [
+      '../../dist/plugins/demo/helloworld.js:helloAdmin:{"api_prefix":"/api/admin"}',
+      '../../dist/plugins/auth/token.js:authAdmins:{"auth_path_prefix":"/api/admin","auth_token":["admtok:admins"]}',
+      '../../dist/plugins/auth/token.js:authRest:{"auth_token":["resttok:rest"]}',
+    ].join(';');
+
+    dm = new DM();
+    await dm.ready;
+  });
+
+  after(() => {
+    delete process.env.NODE_ENV;
+    delete process.env.DM_PLUGINS;
+    delete process.env.DM_AUTH_TOKENS;
+  });
+
+  it('should load both authentications', () => {
+    expect(Object.keys(dm.loadedPlugins)).to.include('authAdmins');
+    expect(Object.keys(dm.loadedPlugins)).to.include('authRest');
+    expect(dm.authenticators).to.have.length(2);
+  });
+
+  it('should guard the branch whose plugin was declared after its API', async () => {
+    expect((await request(dm.app).get('/api/admin/hello')).status).to.equal(
+      401
+    );
+  });
+
+  it('should accept the credential scoped to that branch', async () => {
+    const res = await request(dm.app)
+      .get('/api/admin/hello')
+      .set('Authorization', 'Bearer admtok');
+    expect(res.status).to.equal(200);
+    expect(res.body.message).to.equal('Hello');
+  });
+
+  it('should refuse the catch-all credential on that branch', async () => {
+    const res = await request(dm.app)
+      .get('/api/admin/hello')
+      .set('Authorization', 'Bearer resttok');
+    expect(res.status).to.equal(401);
+  });
+
+  it('should let the catch-all guard everything else', async () => {
+    // No route there, but authentication answers before the 404
+    expect((await request(dm.app).get('/api/whatever')).status).to.equal(401);
+    expect(
+      (
+        await request(dm.app)
+          .get('/api/whatever')
+          .set('Authorization', 'Bearer resttok')
+      ).status
+    ).to.equal(404);
+  });
+});

--- a/test/plugins/pluginOverride.test.ts
+++ b/test/plugins/pluginOverride.test.ts
@@ -26,6 +26,28 @@ describe('Plugin Override', () => {
     expect(res.body).to.deep.equal({ message: 'Hello', hookResults: [] });
   });
 
+  it('should hand the overridden plugin a usable server', () => {
+    // A configuration override used to be applied by spreading the server,
+    // which dropped its prototype: the plugin got an object carrying the
+    // data but none of the methods, so `this.server.anything()` threw — and
+    // only in that configuration
+    const plugin = dm.loadedPlugins.myHello;
+    expect(plugin, 'overridden plugin').to.not.equal(undefined);
+    expect(plugin.server).to.be.instanceOf(DM);
+    expect(plugin.server.claimedAuthPrefixes()).to.deep.equal([]);
+    expect(plugin.server.registerPlugin).to.be.a('function');
+  });
+
+  it('should share everything but the configuration with the server', () => {
+    const plugin = dm.loadedPlugins.myHello;
+    expect(plugin.server.app).to.equal(dm.app);
+    expect(plugin.server.hooks).to.equal(dm.hooks);
+    expect(plugin.server.loadedPlugins).to.equal(dm.loadedPlugins);
+    expect(plugin.server.config).to.not.equal(dm.config);
+    expect(plugin.server.config.api_prefix).to.equal('/myapi');
+    expect(dm.config.api_prefix).to.equal('/api');
+  });
+
   after(() => {
     delete process.env.NODE_ENV;
     delete process.env.DM_PLUGINS;

--- a/test/plugins/twake/james.test.ts
+++ b/test/plugins/twake/james.test.ts
@@ -31,7 +31,9 @@ describe('James Plugin', () => {
       // Mail rename
       .post('/users/testmail@test.org/rename/t@t.org?action=rename&force')
       .reply(200, { success: true })
-      .post('/users/primary@test.org/rename/newprimary@test.org?action=rename&force')
+      .post(
+        '/users/primary@test.org/rename/newprimary@test.org?action=rename&force'
+      )
       .reply(200, { success: true })
       // Quota
       .put('/quota/users/testmail@test.org/size', '50000000')
@@ -391,7 +393,9 @@ describe('James Plugin', () => {
       const renameScope = nock(
         process.env.DM_JAMES_WEBADMIN_URL || 'http://localhost:8000'
       )
-        .post('/users/noalias@test.org/rename/newalias@test.org?action=rename&force')
+        .post(
+          '/users/noalias@test.org/rename/newalias@test.org?action=rename&force'
+        )
         .reply(200, { success: true })
         .get('/users/noalias@test.org/identities')
         .reply(200, [
@@ -458,7 +462,9 @@ describe('James Plugin', () => {
       const renameScope = nock(
         process.env.DM_JAMES_WEBADMIN_URL || 'http://localhost:8000'
       )
-        .post('/users/noalias@test.org/rename/newalias@test.org?action=rename&force')
+        .post(
+          '/users/noalias@test.org/rename/newalias@test.org?action=rename&force'
+        )
         .reply(200, { success: true })
         .get('/users/noalias@test.org/identities')
         .reply(200, [

--- a/test/serverInternals.test.ts
+++ b/test/serverInternals.test.ts
@@ -1,0 +1,155 @@
+import { expect } from 'chai';
+
+import { DM } from '../src/bin';
+import HelloWorld from '../src/plugins/demo/helloworld';
+import RateLimit from '../src/plugins/auth/rateLimit';
+import TrustedProxy from '../src/plugins/auth/trustedProxy';
+
+/** Express 5 exposes the layer stack as `router`, Express 4 as `_router` */
+interface AppInternal {
+  router?: { stack: Array<{ handle: unknown }> };
+  _router?: { stack: Array<{ handle: unknown }> };
+}
+
+/**
+ * Count the error-handling layers of an app: Express recognises a middleware
+ * as one by its arity, four arguments instead of three.
+ *
+ * @param dm server to inspect
+ * @returns number of error middlewares in the stack
+ */
+function countErrorMiddlewares(dm: DM): number {
+  const internal = dm.app as unknown as AppInternal;
+  const stack = (internal.router ?? internal._router)?.stack || [];
+  return stack.filter(
+    layer => typeof layer.handle === 'function' && layer.handle.length === 4
+  ).length;
+}
+
+/**
+ * Capture what a server logs at a given level.
+ *
+ * @param dm server whose logger is replaced
+ * @param level level to capture
+ * @returns the collected messages, filled as they are logged
+ */
+function captureLogs(dm: DM, level: 'warn' | 'info'): string[] {
+  const messages: string[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (dm.logger as any)[level] = (message: string): unknown => {
+    messages.push(message);
+    return dm.logger;
+  };
+  return messages;
+}
+
+describe('Server internals', () => {
+  describe('error middleware', () => {
+    it('should keep exactly one however many plugins register', async () => {
+      const dm = new DM();
+      await dm.ready;
+      expect(countErrorMiddlewares(dm)).to.equal(1);
+
+      // Each registration re-runs setupErrorMiddleware, which must remove the
+      // previous handler rather than stack another one on top
+      for (const name of ['a', 'b', 'c'])
+        await dm.registerPlugin(
+          'core/demo/helloworld',
+          new HelloWorld(dm),
+          name
+        );
+
+      expect(countErrorMiddlewares(dm)).to.equal(1);
+    });
+
+    it('should keep the error middleware last', async () => {
+      const dm = new DM();
+      await dm.ready;
+      await dm.registerPlugin('core/demo/helloworld', new HelloWorld(dm), 'z');
+
+      const internal = dm.app as unknown as AppInternal;
+      const stack = (internal.router ?? internal._router)?.stack || [];
+      const last = stack[stack.length - 1];
+      expect(typeof last.handle === 'function' && last.handle.length).to.equal(
+        4
+      );
+    });
+  });
+
+  describe('duplicate plugin names', () => {
+    it('should refuse the second instance and say why', async () => {
+      const dm = new DM();
+      await dm.ready;
+      const warnings = captureLogs(dm, 'warn');
+
+      const first = await dm.registerPlugin(
+        'core/demo/helloworld',
+        new HelloWorld(dm),
+        'twice'
+      );
+      const second = await dm.registerPlugin(
+        'core/demo/helloworld',
+        new HelloWorld(dm),
+        'twice'
+      );
+
+      expect(first).to.equal(true);
+      expect(second).to.equal(false);
+      // The message must name the culprit and the way out, since the symptom
+      // is a 404 on routes the operator believes they configured
+      const message = warnings.find(w => w.includes('twice'));
+      expect(message, 'warning about the dropped instance').to.not.equal(
+        undefined
+      );
+      expect(message).to.contain('dropped');
+      expect(message).to.contain('give each one a name');
+    });
+
+    it('should collide on the name declared by the class when none is given', async () => {
+      const dm = new DM();
+      await dm.ready;
+      captureLogs(dm, 'warn');
+
+      // Both instances keep the class name `helloWorld`: the module path
+      // passed as first argument is not an instance name
+      expect(
+        await dm.registerPlugin('core/demo/helloworld', new HelloWorld(dm))
+      ).to.equal(true);
+      expect(
+        await dm.registerPlugin('core/demo/otherPath', new HelloWorld(dm))
+      ).to.equal(false);
+    });
+  });
+
+  describe('rate limiting without a trusted proxy', () => {
+    it('should warn that the client IP can be forged', async () => {
+      const dm = new DM();
+      await dm.ready;
+      const warnings = captureLogs(dm, 'warn');
+
+      new RateLimit(dm).api(dm.app);
+
+      const message = warnings.find(w => w.includes('X-Forwarded-For'));
+      expect(message, 'warning about a forgeable key').to.not.equal(undefined);
+      expect(message).to.contain('trustedProxy');
+    });
+
+    it('should stay silent when trustedProxy is loaded', async () => {
+      const dm = new DM();
+      await dm.ready;
+      dm.config.trusted_proxy = ['127.0.0.1'];
+      await dm.registerPlugin(
+        'core/auth/trustedProxy',
+        new TrustedProxy(dm),
+        'trustedProxy'
+      );
+
+      const warnings = captureLogs(dm, 'warn');
+      new RateLimit(dm).api(dm.app);
+
+      expect(warnings.find(w => w.includes('X-Forwarded-For'))).to.equal(
+        undefined
+      );
+    });
+  });
+});

--- a/test/serverInternals.test.ts
+++ b/test/serverInternals.test.ts
@@ -1,8 +1,12 @@
 import { expect } from 'chai';
+import request from 'supertest';
 
 import { DM } from '../src/bin';
 import HelloWorld from '../src/plugins/demo/helloworld';
 import RateLimit from '../src/plugins/auth/rateLimit';
+import AuthBase from '../src/lib/auth/base';
+import AuthToken from '../src/plugins/auth/token';
+import type { Role } from '../src/abstract/plugin';
 import TrustedProxy from '../src/plugins/auth/trustedProxy';
 
 /** Express 5 exposes the layer stack as `router`, Express 4 as `_router` */
@@ -73,6 +77,84 @@ describe('Server internals', () => {
       expect(typeof last.handle === 'function' && last.handle.length).to.equal(
         4
       );
+    });
+  });
+
+  describe('authentication dispatcher', () => {
+    /** An authenticator that lets everything through and counts its calls */
+    class CountingAuth extends AuthBase {
+      name = 'countingAuth';
+      roles: Role[] = ['auth'] as const;
+      calls = 0;
+      authMethod(_req: unknown, _res: unknown, next: () => void): void {
+        this.calls++;
+        next();
+      }
+    }
+
+    it('should authenticate a request once, whatever the plugin count', async () => {
+      const dm = new DM();
+      await dm.ready;
+
+      // Plugins configured with overrides get a server clone: a per-clone
+      // "already mounted" flag would mount one dispatcher each, and the
+      // request would be authenticated as many times — which a one-shot
+      // method such as TOTP fails on the second pass
+      const counters: CountingAuth[] = [];
+      for (const name of ['authA', 'authB', 'authC']) {
+        const plugin = new CountingAuth(dm.withConfig({ ...dm.config }));
+        counters.push(plugin);
+        await dm.registerPlugin('core/auth/counting', plugin, name);
+      }
+      await dm.registerPlugin(
+        'core/demo/helloworld',
+        new HelloWorld(dm),
+        'hello'
+      );
+
+      await request(dm.app).get('/api/hello');
+      // Three unscoped plugins compose as AND: each runs exactly once
+      expect(counters.map(c => c.calls)).to.deep.equal([1, 1, 1]);
+    });
+
+    it('should let every unscoped plugin refuse the request', async () => {
+      const dm = new DM();
+      await dm.ready;
+      const passing = new CountingAuth(dm.withConfig({ ...dm.config }));
+      await dm.registerPlugin('core/auth/counting', passing, 'authPass');
+      await dm.registerPlugin(
+        'core/auth/token',
+        new AuthToken(
+          dm.withConfig({ ...dm.config, auth_token: ['secret:name'] })
+        ),
+        'authToken'
+      );
+      await dm.registerPlugin(
+        'core/demo/helloworld',
+        new HelloWorld(dm),
+        'hello'
+      );
+
+      // The token plugin still guards the path the other one lets through
+      expect((await request(dm.app).get('/api/hello')).status).to.equal(401);
+      expect(
+        (
+          await request(dm.app)
+            .get('/api/hello')
+            .set('Authorization', 'Bearer secret')
+        ).status
+      ).to.equal(200);
+    });
+
+    it('should leave a server with no authentication open', async () => {
+      const dm = new DM();
+      await dm.ready;
+      await dm.registerPlugin(
+        'core/demo/helloworld',
+        new HelloWorld(dm),
+        'hello'
+      );
+      expect((await request(dm.app).get('/api/hello')).status).to.equal(200);
     });
   });
 


### PR DESCRIPTION
Follow-up to the discussion on running several plugin combinations at once: option **B** — one server, authentication scoped by path.

## Why

Machines and administrators do not authenticate the same way (token vs SSO session), yet they hit the same server. Until now `AuthBase` mounted its middleware on **every** path: the first authentication plugin loaded decided for everyone, and the only way out was two servers on two ports.

## What it gives

```bash
ldap-rest \
  --plugin 'core/auth/token:auth-machines:{"auth_path_prefix":"/api/m","auth_token":"…:robot"}' \
  --plugin 'core/ldap/raw:raw-machines:{"api_prefix":"/api/m"}' \
  --plugin 'core/auth/openidconnect:auth-admins:{"auth_path_prefix":"/api/admin"}' \
  --plugin 'core/ldap/raw:raw-admins:{"api_prefix":"/api/admin"}'
```

Loading a plugin several times under its own name (`module:name:{json}`) already worked; only the authentication scope was missing.

**The property that matters**: a credential is valid only on the branch it was scoped to. A leaked machine token buys nothing on `/api/admin`, and the tests are built around that (`should refuse a credential outside its branch`).

Prefixes match on segment boundaries — `/api/m` covers `/api/m` and `/api/m/entry`, never `/api/machines`. A trailing slash in the configuration is ignored. Several prefixes per instance are accepted.

## "One branch apart, a token on everything else"

Scoping alone could not express it: an unscoped plugin guarded every path, including the branch another plugin was mounted on, and since both middlewares were terminal they composed as **AND** — measured on a running server, neither credential got through and the branch was unusable by anyone. The only way out was enumerating the complement, a list nobody maintains without eventually forgetting a branch.

An unscoped plugin is now the **catch-all**: it guards everything no scoped plugin claims, and the server already knows those claims, so the complement needs no configuration:

```bash
ldap-rest \
  --plugin 'core/auth/openidconnect:auth-admins:{"auth_path_prefix":"/api/admin"}' \
  --plugin core/auth/token --auth-token "…:robot"
```

## One dispatcher, not one middleware per plugin

The security review found the first shape of that catch-all could be talked out of guarding a branch nothing else guarded. Reproduced: unscoped token plugin, API on `/api/admin`, plugin scoped to `/api/admin` registered last — `GET /api/admin/hello` with no credentials answered **200** where the pre-scoping code answered 401.

The cause was the mounting model, not the matching rule. Each plugin mounted its own middleware, so protection depended on where that layer landed relative to the routes; Express dispatches in registration order, and a guard mounted after its routes never runs for them. The catch-all stepped aside on the strength of a registry claim, which says nothing about stack position. Named instances made it likely rather than theoretical: `loadPlugin` matches the priority list by exact string, so `core/auth/token:auth-admins:{…}` — the only way to scope a plugin — never gets the sequential early load.

Authentication is now dispatched from **one layer the server mounts itself**, after the `protect` guards and access logging, before the first plugin able to register a route. `AuthBase.api()` registers with it instead of calling `app.use`. Consequences:

- **Declaration order no longer decides what is protected.** Three tests pin the previously failing order.
- **The most specific claim wins** — nested scopes (`/api` and `/api/admin`) behave the way routing does, which removes the AND collision the subtraction was invented to work around.
- Plugins sharing the winning prefix all run, so requiring two credentials on one branch stays possible, and an accident there fails closed.

Verified on the exact reproduction: `401` with no credential, `401` with the catch-all credential, `200` with the admin credential.

## The trap, made visible

Scoping authentication means a route **outside every prefix is served without authentication**. Nothing would reveal it: the server starts, the API answers. Hence a startup warning naming those routes:

```
Authentication is restricted to /api/m, /api/admin, so these routes are
served without authentication: /api/v1/config, /api/v1/ldap/users
```

It stays silent when no authentication is configured (the server is open on purpose) or when one plugin still guards every path.

## Verification

- 980 tests green (46 new), including the existing authentication tests unchanged: an unscoped plugin behaves exactly as before.
- Express mount-path semantics checked against a running server before writing the code.

## CodeQL

Three alerts were raised on this diff:

- `js/polynomial-redos` (high) — my `replace(/\/+$/, '')` backtracks quadratically on a long run of slashes. The value comes from the configuration rather than from a request, so nothing was exploitable, but it is fixed in `fb1a331` with a linear scan.
- `js/missing-rate-limiting` ×3 (high) — dismissed as *won't fix*. Rate limiting is delegated to `core/auth/rateLimit`, loaded before every authentication plugin through `priority.json`; it counts failed authentications (401/403) per client IP using its own store, which CodeQL does not recognise as a limiter, and plugins are wired at runtime so the query cannot see the composition. These lines are flagged as new only because the surrounding code was rewritten — the third one because `app.use(middleware)` became `app.use(catchAll)`. The exposure is identical to what it was before this PR.

## Fixed along the way

Each of these was found while building the feature, and each was silent — nothing failed, so nothing was investigated.

- **`loadPlugin` handed overridden plugins a crippled server.** The view was built with `{...this}`, a spread that copies own properties and leaves the prototype behind, so the plugin got the data — config, hooks, app, ldap, registry — and none of the methods: `this.server.anything()` threw, and only when that plugin was configured with `module:name:{json}`. No existing plugin had hit it because none called a server method; writing the catch-all did. `DM.withConfig()` now builds the view on the instance's prototype, so it is a real `DM` sharing everything by reference with only `config` replaced.

- **The error middleware was never removed, only stacked.** `setupErrorMiddleware` looked the router stack up as `app._router`, which Express 5 renamed to `app.router` (verified: `has _router: false | has router: true`). One more handler was appended on every `registerPlugin`; only the first ever ran, so nothing broke and the stack just grew. Both accessors now go through one helper, and a test pins a single error middleware whatever the number of registrations.

- **A duplicate plugin name dropped the instance quietly.** It was an `info` line, and the dropped instance's `api()` never ran — so its routes did not exist and every request to them answered 404, with nothing in the log connecting the two. It is now a warning naming the plugin, saying the instance was dropped, and showing how to load the same plugin twice.

- **`core/auth/rateLimit` counted forgeable keys.** It keys on `X-Forwarded-For`, which any client can set; that is only safe because `core/auth/trustedProxy` — loaded first — strips the header on requests from undeclared sources. Nothing enforced loading both, and loaded alone the limiter gives an attacker a fresh counter per attempt while still looking configured. It now warns at startup, and `docs/usage/plugins/auth/rate-limit.md` states that the pairing *is* the protection rather than a refinement.


