### PR TITLE
fix(lint): clear the ESLint errors and gate CI on them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Run rollup build to check typescript compilation
         run: npm run build
 
+      # Nothing ran ESLint here, which is how fourteen errors accumulated
+      # unnoticed. Warnings stay warnings: only errors fail the build.
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
       - name: Run tests
         run: npm run test
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ import prettier from 'eslint-plugin-prettier';
 import prettierConfig from 'eslint-config-prettier';
 import importPlugin from 'eslint-plugin-import';
 import nodePlugin from 'eslint-plugin-node';
+import globals from 'globals';
 
 export default [
   // Node.js config
@@ -21,13 +22,10 @@ export default [
         sourceType: 'module',
         project: './tsconfig.json',
       },
-      globals: {
-        console: 'readonly',
-        process: 'readonly',
-        Buffer: 'readonly',
-        __dirname: 'readonly',
-        __filename: 'readonly',
-      },
+      // The published lists rather than a hand-kept one: every name missing
+      // from it surfaces as a `no-undef` error on correct code, which is how
+      // `crypto`, `setInterval` and `clearInterval` ended up reported
+      globals: globals.node,
     },
     plugins: {
       '@typescript-eslint': tseslint,
@@ -91,18 +89,7 @@ export default [
         sourceType: 'module',
         project: './tsconfig.json',
       },
-      globals: {
-        console: 'readonly',
-        document: 'readonly',
-        window: 'readonly',
-        fetch: 'readonly',
-        HTMLElement: 'readonly',
-        CustomEvent: 'readonly',
-        alert: 'readonly',
-        confirm: 'readonly',
-        setTimeout: 'readonly',
-        clearTimeout: 'readonly',
-      },
+      globals: globals.browser,
     },
     plugins: {
       '@typescript-eslint': tseslint,

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.5.4",
         "fast-glob": "^3.3.3",
+        "globals": "^14.0.0",
         "js-yaml": "^4.1.1",
         "mocha": "^11.7.2",
         "nock": "^14.0.10",
@@ -6816,6 +6817,7 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/package.json
+++ b/package.json
@@ -665,6 +665,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.5.4",
     "fast-glob": "^3.3.3",
+    "globals": "^14.0.0",
     "js-yaml": "^4.1.1",
     "mocha": "^11.7.2",
     "nock": "^14.0.10",

--- a/src/browser/ldap-unit-editor/components/UnitTree.ts
+++ b/src/browser/ldap-unit-editor/components/UnitTree.ts
@@ -71,7 +71,6 @@ export class UnitTree {
       return;
     }
 
-    // eslint-disable-next-line no-undef
     const ouName = prompt(
       'Enter the name for the new organizational unit (ou):'
     );

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -247,6 +247,8 @@ export function validateDnValue(value: string, fieldName: string): void {
 
   // Reject control characters (0x00-0x1F and 0x7F)
   // These are invisible and can cause issues in logs, LDIF exports, etc.
+  // The control characters are the point of this check, hence the exemption
+  // eslint-disable-next-line no-control-regex
   if (/[\x00-\x1F\x7F]/.test(value)) {
     throw new Error(`${fieldName} contains invalid control characters`);
   }

--- a/src/plugins/auth/authzPerRoute.ts
+++ b/src/plugins/auth/authzPerRoute.ts
@@ -31,7 +31,7 @@ const ALLOWED_GLOB_CHARS = /^[\w/.\-+*]*$/;
 export function globToRegex(glob: string): RegExp {
   if (!ALLOWED_GLOB_CHARS.test(glob)) {
     throw new Error(
-      `Invalid glob pattern: "${glob}" — only [a-zA-Z0-9_/.\-+*] are allowed`
+      `Invalid glob pattern: "${glob}" — only [a-zA-Z0-9_/.+*-] are allowed`
     );
   }
   // Escape every regex-significant character first (producing a safe string).
@@ -64,7 +64,7 @@ export default class AuthzPerRoute extends DmPlugin {
   constructor(...args: ConstructorParameters<typeof DmPlugin>) {
     super(...args);
 
-    const entries = (this.config.authz_per_route as string[] | undefined) ?? [];
+    const entries = this.config.authz_per_route ?? [];
     for (const entry of entries) {
       this.parseEntry(entry);
     }

--- a/src/plugins/ldap/organization.ts
+++ b/src/plugins/ldap/organization.ts
@@ -6,7 +6,6 @@
  */
 import LdapOrganizations from './organizations';
 
-// eslint-disable-next-line no-console
 console.warn(
   '[ldap-rest] Plugin `core/ldap/organization` is deprecated; use `core/ldap/organizations` instead.'
 );

--- a/src/plugins/ldap/organizations.ts
+++ b/src/plugins/ldap/organizations.ts
@@ -1075,9 +1075,9 @@ export default class LdapOrganizations extends DmPlugin {
         targetOrgDn
       )) as SearchResult;
     } catch (err) {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       throw new NotFoundError(
-        `Target organization ${targetOrgDn} not found: ${err}`
+        `Target organization ${targetOrgDn} not found: ` +
+          `${err instanceof Error ? err.message : String(err)}`
       );
     }
     if (!targetOrg.searchEntries || targetOrg.searchEntries.length === 0) {

--- a/src/plugins/twake/james.ts
+++ b/src/plugins/twake/james.ts
@@ -259,7 +259,6 @@ export default class James extends TwakePlugin {
 
       // Wait for James to create the user (configurable delay)
       if (this.initDelay > 0) {
-        // eslint-disable-next-line no-undef -- setTimeout is a Node.js global
         await new Promise(resolve => setTimeout(resolve, this.initDelay));
       }
 


### PR DESCRIPTION
`npm run lint` reported **14 errors** on master. None was ever caught, because CI runs `npm ci`, `npm run build` and `npm run test`, and `npm test` is `check:ts && mocha` — **nothing ran ESLint or Prettier**. That is the reason they accumulated rather than any one commit.

## The ten that were a configuration gap

`eslint.config.mjs` listed browser globals by hand — `console`, `document`, `window`, `fetch`, `HTMLElement`, `CustomEvent`, `alert`, `confirm`, `setTimeout`, `clearTimeout` — so anything missing from that list surfaced as `no-undef` on perfectly correct code:

- `crypto` in `shared/utils/hmac.ts` (×4) and `shared/utils/totp.ts` (×2)
- `setInterval` / `clearInterval` in `shared/components/DisposableComponent.ts` (×4)

Both blocks now use the published lists from the `globals` package (`globals.node`, `globals.browser`), added as an explicit devDependency rather than relied on transitively. That also made three `eslint-disable` directives unnecessary — they were suppressing errors that no longer exist, which is worse than useless since they read as if something were wrong.

## The four real ones

| File | Error | Fix |
| --- | --- | --- |
| `lib/utils.ts:250` | `no-control-regex` | The regex rejects control characters in a DN, so it must contain them. Rule disabled on that line, with the reason. |
| `authzPerRoute.ts:34` | `no-useless-escape` | `\-` outside a character class means nothing. |
| `authzPerRoute.ts:67` | `no-unnecessary-type-assertion` | The assertion restated the type the configuration already declares. |
| `organizations.ts:1080` | `restrict-template-expressions` | An `unknown` interpolated into a template; now narrowed the way the rest of the codebase does. |

## The gate

The workflow gains a `Lint` step and a `Check formatting` step, so the next error fails the build instead of joining a pile. Both pass on this branch.

**Warnings stay warnings**: 33 remain, all pre-existing (mostly `explicit-function-return-type`), and only errors fail the build. Cleaning those is a separate conversation — gating on them today would mean touching 30 files for no behavioural gain.

## Verification

- `npm run lint`: 0 errors (was 14), 33 warnings
- `npx prettier --check .`: clean
- `npm test`: 988 passing — the three source fixes change no behaviour, and the error-message narrowing in `organizations.ts` is covered by the existing suite