### PR TITLE
test(infra): stop the LDAP test server failing on a check-then-use race

### DIFF
--- a/test/helpers/ldapServer.ts
+++ b/test/helpers/ldapServer.ts
@@ -58,6 +58,82 @@ export class LdapTestServer {
   }
 
   /**
+   * Run a command that talks to the container's `ldapi:///` socket, retrying
+   * while the socket is unreachable.
+   *
+   * `waitForLdapi` proves the socket answered *once*; it cannot promise it
+   * still answers a moment later. The osixia image bootstraps by starting
+   * slapd, configuring it and restarting it, so a check that passed is
+   * routinely followed by a window where the socket is gone and the command
+   * fails with `Can't contact LDAP server (-1)` — the check-then-use race
+   * that made the suite fail on a loaded machine, or simply when another
+   * container was still running.
+   *
+   * Only connection failures are retried. Anything the directory actually
+   * answered — a duplicate schema, a syntax error — is reported at once.
+   *
+   * @param command command to run
+   * @param what named in the error, to say which step gave up
+   * @param maxAttempts how many times to try before failing
+   * @returns the command output
+   * @throws Error when the command keeps failing
+   */
+  private async execLdapi(
+    command: string,
+    what: string,
+    maxAttempts = 10
+  ): Promise<string> {
+    let lastError = '';
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return execSync(command, { encoding: 'utf-8' });
+      } catch (err) {
+        const e = err as { stderr?: Buffer; message?: string };
+        lastError = e.stderr?.toString() || e.message || '';
+        const unreachable =
+          lastError.includes("Can't contact LDAP server") ||
+          lastError.includes('ldap_sasl_interactive_bind_s');
+        if (!unreachable) throw err;
+        if (attempt < maxAttempts)
+          await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+    throw new Error(
+      `${what}: ldapi:/// stayed unreachable after ${maxAttempts} attempts: ${lastError}`
+    );
+  }
+
+  /**
+   * Remove containers left behind by interrupted runs.
+   *
+   * Every run names its container after the moment it started, so nothing
+   * ever removed the previous one: they piled up, competed for the machine,
+   * and made the next run fail during schema loading — with an error naming
+   * LDAP rather than the leftovers. Only containers older than an hour are
+   * removed, so a suite running in parallel is never touched.
+   */
+  private static cleanupOrphans(): void {
+    try {
+      const names = execSync(
+        'docker ps -aq --filter "name=ldap-test-" --format "{{.Names}}"',
+        { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }
+      )
+        .split('\n')
+        .filter(Boolean);
+      const hourAgo = Date.now() - 3600_000;
+      const stale = names.filter(name => {
+        const started = parseInt(name.replace('ldap-test-', ''), 10);
+        return !isNaN(started) && started < hourAgo;
+      });
+      if (stale.length === 0) return;
+      console.log(`Removing ${stale.length} orphaned LDAP container(s)...`);
+      execSync(`docker rm -f ${stale.join(' ')}`, { stdio: 'ignore' });
+    } catch {
+      // Docker missing or unreadable: start() reports it with a clearer message
+    }
+  }
+
+  /**
    * Start the LDAP server
    */
   async start(): Promise<void> {
@@ -71,6 +147,8 @@ export class LdapTestServer {
         'Docker is not available. Please install Docker to run LDAP tests.'
       );
     }
+
+    LdapTestServer.cleanupOrphans();
 
     // Stop any existing container with the same name
     try {
@@ -124,9 +202,9 @@ export class LdapTestServer {
         execSync(
           `docker cp ${mailSchemaPath} ${this.containerName}:/tmp/mail-schema.ldif`
         );
-        const result = execSync(
+        const result = await this.execLdapi(
           `docker exec ${this.containerName} ldapadd -Y EXTERNAL -H ldapi:/// -f /tmp/mail-schema.ldif`,
-          { encoding: 'utf-8' }
+          'mail schema'
         );
         console.log(`✓ Mail schema loaded`);
         if (result && result.trim()) {
@@ -148,9 +226,9 @@ export class LdapTestServer {
     // Load dyngroup schema (required for groupOfURLs objectClass used by twakeDynamicGroup)
     try {
       console.log(`Loading dyngroup schema...`);
-      const result = execSync(
+      const result = await this.execLdapi(
         `docker exec ${this.containerName} ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/ldap/schema/dyngroup.ldif`,
-        { encoding: 'utf-8' }
+        'dyngroup schema'
       );
       console.log(`✓ Dyngroup schema loaded`);
       if (result && result.trim()) {
@@ -172,9 +250,9 @@ export class LdapTestServer {
     // Try to use the official schema from the container first
     try {
       console.log(`Attempting to load official Twake schema...`);
-      const result = execSync(
+      const result = await this.execLdapi(
         `docker exec ${this.containerName} sh -c "if [ -f /usr/local/openldap/etc/openldap/schema/twake.ldif ]; then ldapadd -Y EXTERNAL -H ldapi:/// -f /usr/local/openldap/etc/openldap/schema/twake.ldif; else exit 1; fi"`,
-        { encoding: 'utf-8' }
+        'official Twake schema'
       );
       console.log(`✓ Official Twake schema loaded from container`);
       if (result && result.trim()) {
@@ -194,9 +272,9 @@ export class LdapTestServer {
           );
 
           // Load schema using ldapadd
-          const result = execSync(
+          const result = await this.execLdapi(
             `docker exec ${this.containerName} ldapadd -Y EXTERNAL -H ldapi:/// -f /tmp/twake-schema.ldif`,
-            { encoding: 'utf-8' }
+            'custom Twake schema'
           );
           console.log(`✓ Custom Twake schema loaded`);
           if (result && result.trim()) {


### PR DESCRIPTION
Running the suite twice in a row, or after an interrupted run, failed during schema loading:

```
ldap_sasl_interactive_bind_s: Can't contact LDAP server (-1)
❌ Failed to setup test environment: Error: Failed to load mail schema
```

An error naming LDAP, for a problem that is neither in LDAP nor in the code under test. It cost a dozen false alarms in a single day.

## Two causes, both in the harness

**A check-then-use race.** `waitForLdapi()` proves the socket answered *once*; it cannot promise it still answers a moment later. The osixia image bootstraps by starting slapd, configuring it and restarting it, so a check that passed is routinely followed by a window where the socket is gone. The four schema loads now retry the operation itself while the socket is unreachable — and only then: anything the directory actually answered (a duplicate schema, a syntax error) still fails immediately, so a real problem is not retried into a timeout.

**Orphan containers.** Every run names its container after the moment it started, so the `docker rm -f` at startup only ever removed a container of the same name — which by construction never exists. Interrupted runs piled up, competed for the machine, and made the next run fail. Containers older than an hour are now removed at startup; anything more recent is left alone, so a suite running in parallel is never killed.

## Verification

Started a stale container (`ldap-test-1700000000000`) and a fresh one, then ran the suite:

```
Removing 1 orphaned LDAP container(s)...
✓ LDAP test server started on port 36287
17 passing
```

The stale one is gone, the fresh one survives. Two full `npm run coverage:check` runs then pass back to back with no manual cleanup — 988 passing each time.

## What I did not do, and why it matters more than this PR

You asked for everything in one PR. The two hollow test files are not in it, because looking into them turned up something worth deciding rather than patching.

`jamesMailboxTypeTransitions.test.ts` asserts `expect(scope.isDone()).to.be.false` six times under nock persist mode, where it is always false. I replaced the first one with a real assertion — that a `mailingList → teamMailbox` transition calls `PUT /domains/test.org/team-mailboxes/<mail>` — and recorded every request the mock served. Result:

```
APPELS ENREGISTRÉS: [
 "GET  /users/transuser1-…@test.org/identities",
 "PUT  /users/transuser1-…@test.org/identities/…",
 "GET  /users/transition1-…@test.org/identities",
 "PUT  /users/transition1-…@test.org/identities/…"
]
```

**No mailing-list or team-mailbox call at all** — only identity syncs. The test drives the change with a raw `dm.ldap.modify()`, which emits no `ldapgroupmodifydone`; James therefore never learns of the transition. Routing it through `ldapGroups.modifyGroup()` instead did not change the outcome either.

So one of two things is true, and I cannot tell which without you: either the plugin does not act on a `twakeMailboxType` change, or it needs conditions the test does not set up. Either way, **six tests named "should transition …" have never exercised a transition**, and the vacuous assertion is what kept that invisible. Same class of problem in `jamesBranchValidation.test.ts` (`expect(true).to.be.true`, eight times).

I reverted my exploratory changes rather than commit a guess. Tell me what a mailbox-type transition owes the James API and I will write those tests properly — or I can open an issue with the trace above.