### PR TITLE
docs(changelog): keep Unreleased about what changes for users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,6 @@
 
 ### Features
 
-- build: `npm run coverage` and `npm run coverage:check`. Nothing measured
-  coverage before — no tool, no script, no CI step, while `npm run clean`
-  deleted a `coverage/` directory nothing ever produced — so the figure was
-  unknown to everyone and no pull request could show a regression. It is 86.6%
-  of statements and 78.1% of branches on server code; the gate sits two to
-  three points below and runs the suite once rather than twice. Files holding
-  only type declarations are excluded, since they report 0% and mean nothing,
-  and so are the browser libraries: the suite has no DOM, they sit around 24%,
-  and a single global number would average two unrelated situations into one
-  nobody can act on. `npm run coverage` still reports them, so the gap stays
-  visible
-
-### Features
-
 - `lib/auth`: `--auth-path-prefix` restricts an authentication plugin to one or
   more path prefixes. Populations rarely authenticate the same way — machines
   carry a token, administrators arrive with an SSO session — and until now the
@@ -104,6 +90,13 @@
   also requested explicitly instead of relying on it being returned as part of
   "all user attributes", and the documentation now states the ACL the bind DN
   needs on the applicative branch (#105)
+
+### Internal
+
+- Tooling and tests, no runtime change: coverage is measured and gated in CI
+  (`npm run coverage`, `npm run coverage:check` — 86.6% of statements on server
+  code), the fourteen ESLint errors are cleared and CI now runs lint and format
+  checks, and tests wait on the condition they expect instead of a fixed delay
 
 ## v0.4.7 (2026-07-26)
 


### PR DESCRIPTION
Two problems in the `Unreleased` section:

- It had grown **a second `### Features` heading** — the same defect Copilot caught in #107, reintroduced by the coverage PR.
- The coverage tooling took **eleven lines**, as much room as the authentication scope, for something no deployment can observe.

## What changed

Work with no runtime effect is now a single `### Internal` entry:

```
### Internal

- Tooling and tests, no runtime change: coverage is measured and gated in CI
  (`npm run coverage`, `npm run coverage:check` — 86.6% of statements on server
  code), the fourteen ESLint errors are cleared and CI now runs lint and format
  checks, and tests wait on the condition they expect instead of a fixed delay
```

That covers #108, #109 and #110 in four lines instead of eleven, and drops nothing an operator would act on — the numbers and the command names are still there for anyone who wants them.

Features and bug fixes keep their detail: `ldap-raw`, the authentication scope, and the four behaviour-affecting `bin` / `rateLimit` fixes are what someone reads a changelog for.

Net: **-14 lines, +7**.

## Not included

The test-harness fix in #111 gets no line: it is invisible outside the repository, and the `Internal` entry already says tests and tooling changed. Say the word if you would rather have every internal PR listed.