### PR TITLE
fix(utils): stop parsing a DN whose .length the caller can forge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Security
 
+- `lib/utils`: a DN read from a JSON body was parsed by looping on its
+  `.length`, so `{"length": 1e100}` hung the worker (CWE-834). `parseDn()` and
+  `unescapeDnValue()` now answer 400 on a non-string
+
+- `plugins/ldap/groups`: `member`, `targetOrgDn` and `newCn` were forwarded
+  without a type check, unlike the equivalent organization and flat-branch
+  endpoints; a non-string now gets a 400
+
 - `lsc-plugin`: jackson-databind 2.17.2 → 2.22.1, clearing five advisories
   (CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, CVE-2026-54515,
   CVE-2026-59888)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,6 +9,7 @@ import type { Request, Response, NextFunction, RequestHandler } from 'express';
 
 import type { Config } from '../bin';
 
+import { BadRequestError } from './errors';
 import { getLogger } from './expressFormatedResponses';
 
 const logger = getLogger();
@@ -188,8 +189,16 @@ export function escapeDnValue(value: string): string {
  * unescapeDnValue('user\\+admin')
  * // => 'user+admin'
  * ```
+ *
+ * @throws BadRequestError if `value` is not a string
  */
 export function unescapeDnValue(value: string): string {
+  // Same unbounded-loop hazard as {@link parseDn}: the loop below is driven by
+  // `value.length`, which a JSON body can forge.
+  if (typeof value !== 'string') {
+    throw new BadRequestError('DN value must be a string');
+  }
+
   let result = '';
   let i = 0;
 
@@ -277,8 +286,21 @@ export function validateDnValue(value: string, fieldName: string): void {
  * parseDn('cn=Smith\\, John,ou=users,dc=example,dc=com')
  * // => ['cn=Smith\\, John', 'ou=users', 'dc=example', 'dc=com']
  * ```
+ *
+ * @throws BadRequestError if `dn` is not a string
  */
 export function parseDn(dn: string): string[] {
+  // DNs reach us straight from JSON request bodies, where the declared
+  // `string` type is a compile-time promise only. An object such as
+  // `{"length": 1e100}` would drive the loop below for 10^100 iterations
+  // (CWE-834), so refuse anything that is not a real string: its length is
+  // then bounded by the body-size limit. Callers already relied on this
+  // throwing (it used to be an opaque TypeError); a BadRequestError just
+  // turns the 500 into the 400 it always should have been.
+  if (typeof dn !== 'string') {
+    throw new BadRequestError('DN must be a string');
+  }
+
   const parts: string[] = [];
   let current = '';
   let escaped = false;

--- a/src/plugins/ldap/groups.ts
+++ b/src/plugins/ldap/groups.ts
@@ -399,6 +399,12 @@ export default class LdapGroups extends DmPlugin {
           member: string | string[];
         };
         if (!body) return;
+        const members = Array.isArray(body.member)
+          ? body.member
+          : [body.member];
+        if (members.some(m => typeof m !== 'string')) {
+          throw new BadRequestError('member must be a string or string array');
+        }
         await tryMethod(res, this.addMember.bind(this), cn, body.member);
       })
     );
@@ -473,6 +479,9 @@ export default class LdapGroups extends DmPlugin {
             targetOrgDn: string;
           };
           if (!body) return;
+          if (typeof body.targetOrgDn !== 'string') {
+            throw new BadRequestError('targetOrgDn must be a string');
+          }
           await tryMethod(
             res,
             this.moveGroup.bind(this),
@@ -518,6 +527,9 @@ export default class LdapGroups extends DmPlugin {
           newCn: string;
         };
         if (!body) return;
+        if (typeof body.newCn !== 'string') {
+          throw new BadRequestError('newCn must be a string');
+        }
         await tryMethod(res, this.renameGroup.bind(this), cn, body.newCn);
       })
     );

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeDn,
   isDnInBranch,
 } from '../../src/lib/utils';
+import { BadRequestError } from '../../src/lib/errors';
 
 describe('LDAP Utils', () => {
   describe('escapeDnValue', () => {
@@ -67,6 +68,12 @@ describe('LDAP Utils', () => {
 
     it('should unescape multiple special characters', () => {
       expect(unescapeDnValue('a\\,b\\+c\\=d')).to.equal('a,b+c=d');
+    });
+
+    it('should reject a non-string with a forged length', () => {
+      expect(() =>
+        unescapeDnValue({ length: 1e100 } as unknown as string)
+      ).to.throw(BadRequestError, 'must be a string');
     });
 
     it('should unescape leading space', () => {
@@ -223,6 +230,30 @@ describe('LDAP Utils', () => {
         'dc=example',
         'dc=com',
       ]);
+    });
+
+    // CWE-834: a JSON body can forge `.length`, e.g. {"dn": {"length": 1e100}},
+    // which would drive the parsing loop for 10^100 iterations.
+    it('should reject a non-string with a forged length instead of looping', () => {
+      const forged = { length: 1e100 } as unknown as string;
+      expect(() => parseDn(forged)).to.throw(
+        BadRequestError,
+        'must be a string'
+      );
+      expect(() => getParentDn(forged)).to.throw(BadRequestError);
+      expect(() => normalizeDn(forged)).to.throw(BadRequestError);
+      expect(() => isDnInBranch(forged, 'dc=example,dc=com')).to.throw(
+        BadRequestError
+      );
+    });
+
+    it('should answer with a 400 status code', () => {
+      try {
+        parseDn(undefined as unknown as string);
+        expect.fail('parseDn should have thrown');
+      } catch (err) {
+        expect((err as BadRequestError).statusCode).to.equal(400);
+      }
     });
   });
 


### PR DESCRIPTION
Closes the only open CodeQL alert on `master`: [#19](https://github.com/linagora/ldap-rest/security/code-scanning/19), `js/loop-bound-injection` (CWE-834, severity high).

## The problem

`parseDn()` drives its loop with `dn.length` (`src/lib/utils.ts:286`), and `dn` arrives straight from `req.body` — where the declared `string` type is a compile-time promise, nothing more. A body of

```json
{"dn": {"length": 1e100}}
```

makes the loop run 10^100 times, appending `undefined` to `current` on every pass: the worker hangs and the heap fills.

`parseDn` is the primitive every other DN helper is built on — `getParentDn`, `getRdn`, `normalizeDn`, `isDnInBranch` — so it backs the branch computation used by the authorization plugins as well.

## The fix

- **`lib/utils`** — refuse a non-string in `parseDn()` and `unescapeDnValue()`, the two helpers that iterate on a caller-supplied `.length`. For a real string the bound is already the body-size limit. Fixing the sink closes the class whatever the calling path, present or future.
- **`plugins/ldap/groups`** — `member`, `targetOrgDn` and `newCn` were cast and passed on without a `typeof` check, unlike the equivalent endpoints in `organizations.ts` and `ldapFlat.ts`. Now a 400 at the edge.

No behaviour regression: callers already relied on these throwing for a non-string, via an opaque `TypeError` surfacing as a 500. `BadRequestError` makes it the 400 it always should have been.

## One caveat worth reviewing

I could not confirm an end-to-end exploit on `master`. Every path I traced to `parseDn` calls a string method first, which throws a `TypeError` on an object rather than reaching the loop:

- `raw.checkDn` → `dn.trim()`
- `authzDynamic.isAtOrUnder` → `.toLowerCase()`
- `ldapFlat.addEntry` → `RegExp.test` (coerces to `"[object Object]"`, so the DN branch is never taken)

So the alert is either exploitable through a path I did not find, or a false positive as the code stands today. The guard is worth having either way — it is the sink-level fix CodeQL recommends, and it does not depend on every caller keeping its accidental coercion.

## Verification

- `npm run test:dev` → 996 passing, 7 pending
- `tsc --noEmit`, eslint and prettier clean
- New cases in `test/lib/utils.test.ts`, including an explicit `{length: 1e100}` payload
