### PR TITLE
fix(lsc-plugin): update jackson-databind to 2.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Security
+
+- `lsc-plugin`: jackson-databind 2.17.2 → 2.22.1, clearing five advisories
+  (CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, CVE-2026-54515,
+  CVE-2026-59888)
+
 ## v0.5.0 (2026-08-01)
 
 ### Features

--- a/lsc-plugin/pom.xml
+++ b/lsc-plugin/pom.xml
@@ -21,7 +21,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lsc.version>2.2</lsc.version>
-        <jackson.version>2.17.2</jackson.version>
+        <jackson.version>2.22.1</jackson.version>
         <junit.version>5.10.2</junit.version>
         <wiremock.version>3.9.1</wiremock.version>
     </properties>


### PR DESCRIPTION
Clears the five open Dependabot alerts, all against the `jackson-databind` 2.17.2 pinned in `lsc-plugin/pom.xml`:

| # | Severity | CVE | Summary |
|---|---|---|---|
| [53](https://github.com/linagora/ldap-rest/security/dependabot/53) | medium | CVE-2026-59888 | `@JsonIgnore` on a Record property bypassed by a `PropertyNamingStrategy` |
| [50](https://github.com/linagora/ldap-rest/security/dependabot/50) | medium | CVE-2026-54514 | `InetSocketAddress` deserialization triggers eager DNS resolution (SSRF) |
| [49](https://github.com/linagora/ldap-rest/security/dependabot/49) | medium | CVE-2026-54515 | case-insensitive deserialization bypasses per-property `@JsonIgnoreProperties` |
| [48](https://github.com/linagora/ldap-rest/security/dependabot/48) | **high** | CVE-2026-54512 | `PolymorphicTypeValidator` bypass via generic type parameters → arbitrary class instantiation |
| [47](https://github.com/linagora/ldap-rest/security/dependabot/47) | **high** | CVE-2026-54513 | array subtype allowlist bypass in `BasicPolymorphicTypeValidator` |

## Why 2.22.1 and not 2.18.9

Both clear all five. 2.18.9 stays on the 2.18 line; 2.22.1 is the current release, and of the five only CVE-2026-59888 reaches into the 2.22 line (fixed in 2.22.1). Taking the latest avoids sitting four minors behind for the next round.

## Compatibility

- The jar is **Java 8 bytecode** (`Build-Jdk-Spec: 1.8`, class-file major 52), so the plugin's Java 11 target and the CI `setup-java@11` step are unaffected.
- Resolved compile-scope tree is clean: `jackson-databind:2.22.1`, `jackson-core:2.22.1`, `jackson-annotations:2.22`. The `jackson-dataformat-yaml:2.18.2` that also appears is `provided`, pulled by `lsc-core`, and is not shipped in our jar.
- The shade relocation of `com.fasterxml.jackson` → `org.lscproject.ldaprest.shaded.jackson` still applies to the base classes. Some `META-INF/versions/*/com/fasterxml/...` multi-release overlays stay unrelocated, but that was already true with 2.17.2 (known maven-shade limitation with MR-JARs) and is inert — nothing references the unrelocated names.

## Exposure, for context

The plugin's jackson use is narrow — `ObjectMapper.writeValueAsString` / `readTree` on its own request and response bodies. No polymorphic typing, no `@JsonIgnore`, no records, no `InetSocketAddress` binding, so I don't believe any of the five is actually reachable here. The bump is hygiene, not an incident.

## Verification

```
mvn -B test      → Tests run: 89, Failures: 0, Errors: 0, Skipped: 0
mvn -B package   → BUILD SUCCESS, shaded jar produced (1146 relocated jackson entries)
```

Run locally against a `lsc-core` 2.2 built from the v2.2 tag, same as the `lsc-plugin-test` CI job.

## Note

This branch is based on `master` and independent of #113, but both add a `## Unreleased` / `### Security` block at the top of `CHANGELOG.md` — whichever lands second needs a one-line conflict resolution there.
