### PR TITLE
feat(app-accounts): build applicative entries from an allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   `--ldap-operational-attribute`. An attribute not named there is no longer
   copied into the applicative branch — name it to keep it (#103)
 
+- `plugins/twake/appAccountsConsistency`: a mail change now deletes the app
+  accounts instead of recreating them without their password. They could not
+  authenticate, yet were still listed and still counted against
+  `--max-app-accounts` (#103)
+
 ### Security
 
 - `lib/utils`: a DN read from a JSON body was parsed by looping on its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- `plugins/twake/appAccounts*`: applicative entries are built from an allowlist
+  (`--applicative-account-attribute`) instead of the whole user entry minus
+  `--ldap-operational-attribute`. An attribute not named there is no longer
+  copied into the applicative branch — name it to keep it (#103)
+
 ### Security
 
 - `lib/utils`: a DN read from a JSON body was parsed by looping on its

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -322,13 +322,28 @@ Empty means the plugin guards every path. Scoping several instances to different
 
 #### `core/twake/applicativeAccounts`
 
-| CLI                            | Plural                          | Env                              | Default       | Description                       |
-| ------------------------------ | ------------------------------- | -------------------------------- | ------------- | --------------------------------- |
-| `--applicative-account-base`   |                                 | `DM_APPLICATIVE_ACCOUNT_BASE`    |               | Applicative accounts base DN      |
-| `--max-app-accounts`           |                                 | `DM_MAX_APP_ACCOUNTS`            | `5`           | Max accounts per user             |
-| `--ldap-operational-attribute` | `--ldap-operational-attributes` | `DM_LDAP_OPERATIONAL_ATTRIBUTES` | _(see below)_ | Operational attributes to exclude |
+| CLI                               | Plural                             | Env                                 | Default       | Description                           |
+| --------------------------------- | ---------------------------------- | ----------------------------------- | ------------- | ------------------------------------- |
+| `--applicative-account-base`      |                                    | `DM_APPLICATIVE_ACCOUNT_BASE`       |               | Applicative accounts base DN          |
+| `--max-app-accounts`              |                                    | `DM_MAX_APP_ACCOUNTS`               | `5`           | Max accounts per user                 |
+| `--applicative-account-attribute` | `--applicative-account-attributes` | `DM_APPLICATIVE_ACCOUNT_ATTRIBUTES` | _(see below)_ | Attributes copied from the user entry |
+| `--ldap-operational-attribute`    | `--ldap-operational-attributes`    | `DM_LDAP_OPERATIONAL_ATTRIBUTES`    | _(see below)_ | Operational attributes to exclude     |
+
+Default copied attributes: `objectClass`, `cn`, `sn`, `givenName`, `displayName`, `description` — plus the configured mail attribute, always.
+
+This is an **allowlist**: an attribute the user entry carries but that is not
+named here is not copied into the applicative branch. That branch is only ever
+read to bind with `uid` and `userPassword`, so anything else has no reason to
+be duplicated there — and a new attribute added to the user schema later stays
+out unless someone opts in.
 
 Default operational attributes: `dn`, `controls`, `structuralObjectClass`, `entryUUID`, `entryDN`, `subschemaSubentry`, `modifyTimestamp`, `modifiersName`, `createTimestamp`, `creatorsName`, `userPassword`
+
+Operational attributes are only used when an applicative entry is **recreated
+from its own current state** (on a mail change): they are what the directory
+generates and would refuse on an `add`. `userPassword` is in that list on
+purpose — a mail change forces every client to be reconfigured anyway, so app
+accounts are deliberately reissued without a password.
 
 #### `core/twake/appAccountsConsistency`
 

--- a/docs/usage/plugins/integrations/app-accounts.md
+++ b/docs/usage/plugins/integrations/app-accounts.md
@@ -295,7 +295,7 @@ sync-app-accounts --help
    - Secure random password
 4. Plugin creates applicative account in LDAP:
    - `uid=alice_c12345678,ou=applicative,dc=example,dc=com`
-   - Copies attributes from user (cn, sn, mail, etc.)
+   - Copies the allowlisted attributes from the user (`--applicative-account-attribute`)
    - Sets generated password
 5. Plugin adds password to principal account:
    - `uid=alice@example.com,ou=applicative,dc=example,dc=com`

--- a/docs/usage/plugins/integrations/app-accounts.md
+++ b/docs/usage/plugins/integrations/app-accounts.md
@@ -43,7 +43,8 @@ Instead of using a single primary password to access all services that authentic
 2. **App accounts consistency plugin** `core/twake/appAccountsConsistency` - **Required**
    - Automatically creates principal accounts (uid=mail@domain.com)
    - Ensures automatic cleanup when users are deleted
-   - Synchronizes mail changes across all app accounts
+   - Moves the principal account on a mail change, and drops the app accounts:
+     every MUA has to be reconfigured against the new address anyway
 3. **Applicative accounts base** configured in LDAP (e.g., `ou=applicative,dc=example,dc=com`)
 4. **Read access on `userPassword`** in that branch, for the bind DN
    (`--ldap-dn`) - **Required for deletion**

--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -232,6 +232,15 @@ export interface Config {
   // where `:user` is the LDAP uid — only safe when uid is unique directory-wide.
   // Generated app-account uids are prefixed from this (unique) value, sanitized.
   app_accounts_user_attribute?: string;
+  // Attributes copied from the user entry into the applicative entries. An
+  // allowlist: anything not named here stays out, so a new attribute on the
+  // user schema is never propagated by accident. The mail attribute is always
+  // added to this set (it is what the applicative entry is keyed on).
+  applicative_account_attribute?: string[];
+  // Attributes dropped from an existing applicative entry when it is recreated
+  // (mail change): the ones the directory generates and refuses on an `add`,
+  // plus `userPassword` — an app account is reconfigured on every client after
+  // a mail change anyway, so its password is deliberately not carried over.
   ldap_operational_attribute?: string[];
 
   // Trash plugin
@@ -609,6 +618,13 @@ const configArgs: ConfigTemplate = [
   // Applicative Accounts plugin
   ['--applicative-account-base', 'DM_APPLICATIVE_ACCOUNT_BASE', ''],
   ['--max-app-accounts', 'DM_MAX_APP_ACCOUNTS', 5, 'number'],
+  [
+    '--applicative-account-attribute',
+    'DM_APPLICATIVE_ACCOUNT_ATTRIBUTES',
+    ['objectClass', 'cn', 'sn', 'givenName', 'displayName', 'description'],
+    'array',
+    '--applicative-account-attributes',
+  ],
   [
     '--ldap-operational-attribute',
     'DM_LDAP_OPERATIONAL_ATTRIBUTES',

--- a/src/plugins/twake/appAccountsApi.ts
+++ b/src/plugins/twake/appAccountsApi.ts
@@ -484,14 +484,17 @@ export default class AppAccountsApi extends DmPlugin {
         userPassword: newPassword,
       };
 
-      // Copy relevant attributes from user
+      // Copy relevant attributes from user. Same allowlist as
+      // appAccountsConsistency (`--applicative-account-attribute`) so the two
+      // plugins build applicative entries the same way, minus the two this
+      // method sets itself: `objectClass` is forced to inetOrgPerson above,
+      // and `description` carries the caller-supplied label.
       const attrsToCopy = [
-        'cn',
-        'sn',
-        'givenName',
-        this.mailAttr,
-        'displayName',
-      ];
+        ...new Set([
+          ...((this.config.applicative_account_attribute as string[]) || []),
+          this.mailAttr,
+        ]),
+      ].filter(attr => attr !== 'objectClass' && attr !== 'description');
       for (const attr of attrsToCopy) {
         if (userEntry[attr]) {
           const value = userEntry[attr];

--- a/src/plugins/twake/appAccountsConsistency.ts
+++ b/src/plugins/twake/appAccountsConsistency.ts
@@ -20,7 +20,9 @@
  *
  * When a user is deleted, all corresponding applicative accounts are also deleted.
  *
- * When a user's mail changes, all applicative accounts are updated with the new mail.
+ * When a user's mail changes, the principal account moves to the new address and
+ * the app accounts are deleted: every client has to be reconfigured against the
+ * new address anyway.
  */
 
 import DmPlugin from '../../abstract/plugin';
@@ -33,6 +35,33 @@ import type {
 } from '../../lib/ldapActions';
 import { Hooks } from '../../hooks';
 import { escapeDnValue, isDnInBranch } from '../../lib/utils';
+
+/**
+ * Whether an error is the directory saying "that entry is not there".
+ *
+ * Checked three ways because only the first is guaranteed: ldapts sets
+ * `code = 32` and `name = 'NoSuchObjectError'` on the error, but a wrapper
+ * that rebuilds the error (or a second copy of ldapts in the tree) can drop
+ * one of them. The message it builds ends in `Code: 0x20` — note that it is
+ * hex, so a `Code: 32` substring never matches, and neither does
+ * `NoSuchObject`: the text is "The target object cannot be found."
+ *
+ * @param err - The error thrown by an LDAP operation
+ * @returns true when the entry was already absent
+ */
+function isNoSuchObject(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const { code, name, message } = err as {
+    code?: unknown;
+    name?: unknown;
+    message?: unknown;
+  };
+  return (
+    code === 0x20 ||
+    name === 'NoSuchObjectError' ||
+    (typeof message === 'string' && message.includes('Code: 0x20'))
+  );
+}
 
 export default class AppAccountsConsistency extends DmPlugin {
   name = 'appAccountsConsistency';
@@ -57,12 +86,23 @@ export default class AppAccountsConsistency extends DmPlugin {
       .applicative_account_base as string;
     this.operationalAttributes =
       (this.config.ldap_operational_attribute as string[]) || [];
-    // The mail attribute is what the applicative entry is keyed on, so it is
-    // always copied whatever the configured list says.
-    this.copiedAttributes = new Set([
-      ...((this.config.applicative_account_attribute as string[]) || []),
-      this.mailAttr,
-    ]);
+    // `objectClass` and the mail attribute are not optional: without the first
+    // the directory rejects the `add`, without the second the entry cannot be
+    // found again by the mail-keyed searches this plugin runs. Force them in
+    // rather than let a partial list produce entries that fail to create or
+    // become invisible — but say so, because silently ignoring configuration
+    // is how an operator ends up debugging the wrong file.
+    const configured =
+      (this.config.applicative_account_attribute as string[]) || [];
+    const required = ['objectClass', this.mailAttr];
+    const missing = required.filter(attr => !configured.includes(attr));
+    if (configured.length > 0 && missing.length > 0) {
+      this.logger.warn(
+        `${this.name}: applicative_account_attribute omits ${missing.join(', ')} — ` +
+          'copied anyway, an applicative entry cannot be created without them'
+      );
+    }
+    this.copiedAttributes = new Set([...configured, ...required]);
 
     if (!this.applicativeAccountBase) {
       throw new Error(
@@ -112,14 +152,8 @@ export default class AppAccountsConsistency extends DmPlugin {
     try {
       await this.server.ldap.delete(dn);
       this.logger.info(`${this.name}: Deleted applicative account ${dn}`);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (deleteError: any) {
-      if (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        deleteError.code === 0x20 ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-        deleteError.message?.includes('NoSuchObject')
-      ) {
+    } catch (deleteError) {
+      if (isNoSuchObject(deleteError)) {
         this.logger.debug(
           `${this.name}: Applicative account ${dn} already deleted`
         );
@@ -132,7 +166,8 @@ export default class AppAccountsConsistency extends DmPlugin {
   /**
    * Select the attributes to copy from a user entry into an applicative entry.
    *
-   * An allowlist (`--applicative-account-attribute`, plus the mail attribute):
+   * An allowlist (`--applicative-account-attribute`, plus `objectClass` and the
+   * mail attribute, which are forced in by the constructor):
    * the applicative branch is only ever read to bind with `uid` and
    * `userPassword`, so anything else the user entry happens to carry —
    * recovery addresses, e2ee key material, whatever the schema grows next —
@@ -322,35 +357,17 @@ export default class AppAccountsConsistency extends DmPlugin {
       for (const entry of searchEntries) {
         const applicativeDn = entry.dn;
         try {
-          await this.server.ldap.delete(applicativeDn);
-          this.logger.info(
-            `${this.name}: Deleted applicative account ${applicativeDn}`
+          await this.deleteApplicativeEntry(applicativeDn);
+        } catch (deleteError) {
+          this.logger.error(
+            `${this.name}: Failed to delete applicative account ${applicativeDn}:`,
+            deleteError
           );
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (deleteError: any) {
-          // Ignore NoSuchObjectError (already deleted - idempotent)
-          if (
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            deleteError.code === 0x20 ||
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            deleteError.message?.includes('NoSuchObject')
-          ) {
-            this.logger.debug(
-              `${this.name}: Applicative account ${applicativeDn} already deleted`
-            );
-          } else {
-            this.logger.error(
-              `${this.name}: Failed to delete applicative account ${applicativeDn}:`,
-              deleteError
-            );
-          }
         }
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error) {
       // Ignore NoSuchObjectError if the applicative account base doesn't exist
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-      if (error.code === 0x20 || error.message?.includes('NoSuchObject')) {
+      if (isNoSuchObject(error)) {
         this.logger.debug(
           `${this.name}: Applicative account base does not exist or no accounts found for mail ${mail}`
         );

--- a/src/plugins/twake/appAccountsConsistency.ts
+++ b/src/plugins/twake/appAccountsConsistency.ts
@@ -46,6 +46,7 @@ export default class AppAccountsConsistency extends DmPlugin {
   private mailAttr: string;
   private applicativeAccountBase: string;
   private operationalAttributes: string[];
+  private copiedAttributes: Set<string>;
 
   constructor(server: DM) {
     super(server);
@@ -56,6 +57,12 @@ export default class AppAccountsConsistency extends DmPlugin {
       .applicative_account_base as string;
     this.operationalAttributes =
       (this.config.ldap_operational_attribute as string[]) || [];
+    // The mail attribute is what the applicative entry is keyed on, so it is
+    // always copied whatever the configured list says.
+    this.copiedAttributes = new Set([
+      ...((this.config.applicative_account_attribute as string[]) || []),
+      this.mailAttr,
+    ]);
 
     if (!this.applicativeAccountBase) {
       throw new Error(
@@ -69,7 +76,18 @@ export default class AppAccountsConsistency extends DmPlugin {
   }
 
   /**
-   * Check if an attribute should be excluded when copying LDAP entry attributes
+   * Check if an attribute should be excluded when recreating an existing
+   * applicative entry from its own current state.
+   *
+   * This is a denylist because the input is an entry we wrote ourselves: what
+   * has to go is what the directory generates and would refuse on an `add`,
+   * plus `userPassword` (an app account is reconfigured on every client after
+   * a mail change anyway, so its password is deliberately not carried over).
+   *
+   * Attributes coming from the *user* entry are chosen by
+   * {@link pickCopiedAttributes} instead — an allowlist, so that a new
+   * attribute on the user schema is never propagated by accident.
+   *
    * @param key - The attribute name to check
    * @returns true if the attribute should be excluded
    */
@@ -79,6 +97,31 @@ export default class AppAccountsConsistency extends DmPlugin {
     // cannot lead to "LDAP add error: UndefinedTypeError: dn" failures.
     if (key === 'dn') return true;
     return this.operationalAttributes.includes(key);
+  }
+
+  /**
+   * Select the attributes to copy from a user entry into an applicative entry.
+   *
+   * An allowlist (`--applicative-account-attribute`, plus the mail attribute):
+   * the applicative branch is only ever read to bind with `uid` and
+   * `userPassword`, so anything else the user entry happens to carry —
+   * recovery addresses, e2ee key material, whatever the schema grows next —
+   * has no reason to be duplicated there.
+   *
+   * @param entry - The source user entry
+   * @returns The subset worth copying, empty values dropped
+   */
+  private pickCopiedAttributes(entry: AttributesList): AttributesList {
+    const picked: AttributesList = {};
+    for (const [key, value] of Object.entries(entry)) {
+      if (!this.copiedAttributes.has(key)) continue;
+      // Skip empty values
+      if (value === undefined || value === null) continue;
+      // Skip empty arrays
+      if (Array.isArray(value) && value.length === 0) continue;
+      picked[key] = value;
+    }
+    return picked;
   }
 
   /**
@@ -190,24 +233,9 @@ export default class AppAccountsConsistency extends DmPlugin {
         return;
       }
 
-      // Create applicative account entry with same attributes but uid changed to mail
-      // Filter out operational attributes and userPassword (let API set passwords separately)
-      const applicativeAttrs: AttributesList = {};
-      for (const [key, value] of Object.entries(userEntry)) {
-        // Skip operational attributes
-        if (this.shouldExcludeAttribute(key)) {
-          continue;
-        }
-        // Skip empty values
-        if (value === undefined || value === null) {
-          continue;
-        }
-        // Skip empty arrays
-        if (Array.isArray(value) && value.length === 0) {
-          continue;
-        }
-        applicativeAttrs[key] = value;
-      }
+      // Create the applicative entry from the named subset of the user entry.
+      // No password is set here: the app-account API issues one per device.
+      const applicativeAttrs = this.pickCopiedAttributes(userEntry);
 
       // Update uid to mail
       applicativeAttrs.uid = mail;
@@ -393,8 +421,11 @@ export default class AppAccountsConsistency extends DmPlugin {
             }
           }
 
-          // Create new applicative account with updated mail
-          // Start with old applicative account attributes to preserve things like description, userPassword
+          // Create new applicative account with updated mail. Start from the
+          // old entry's own attributes to keep what the user entry cannot
+          // supply — the per-device `description`, mostly. Not the password:
+          // a mail change forces every client to be reconfigured anyway, so
+          // the app accounts are deliberately reissued without one.
           const newAttrs: AttributesList = { ...oldApplicativeAttrs };
 
           // Read the current user entry to get fresh user attributes
@@ -415,21 +446,7 @@ export default class AppAccountsConsistency extends DmPlugin {
           }
 
           // Overwrite with fresh user attributes (cn, sn, givenName, mail, etc.)
-          for (const [key, value] of Object.entries(userEntry)) {
-            // Skip operational attributes
-            if (this.shouldExcludeAttribute(key)) {
-              continue;
-            }
-            // Skip empty values
-            if (value === undefined || value === null) {
-              continue;
-            }
-            // Skip empty arrays
-            if (Array.isArray(value) && value.length === 0) {
-              continue;
-            }
-            newAttrs[key] = value;
-          }
+          Object.assign(newAttrs, this.pickCopiedAttributes(userEntry));
 
           // For principal account: change uid to newMail
           // For applicative accounts: keep the same uid (username_cXXXXXXXX)

--- a/src/plugins/twake/appAccountsConsistency.ts
+++ b/src/plugins/twake/appAccountsConsistency.ts
@@ -100,6 +100,36 @@ export default class AppAccountsConsistency extends DmPlugin {
   }
 
   /**
+   * Delete an entry of the applicative branch, tolerating its absence.
+   *
+   * A missing entry is the state we wanted, so `NoSuchObject` is not an error:
+   * it keeps the mail-change path idempotent when a hook fires twice.
+   *
+   * @param dn - DN of the applicative entry to remove
+   * @throws whatever the directory raised, except NoSuchObject
+   */
+  private async deleteApplicativeEntry(dn: string): Promise<void> {
+    try {
+      await this.server.ldap.delete(dn);
+      this.logger.info(`${this.name}: Deleted applicative account ${dn}`);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (deleteError: any) {
+      if (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        deleteError.code === 0x20 ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        deleteError.message?.includes('NoSuchObject')
+      ) {
+        this.logger.debug(
+          `${this.name}: Applicative account ${dn} already deleted`
+        );
+        return;
+      }
+      throw deleteError;
+    }
+  }
+
+  /**
    * Select the attributes to copy from a user entry into an applicative entry.
    *
    * An allowlist (`--applicative-account-attribute`, plus the mail attribute):
@@ -371,14 +401,22 @@ export default class AppAccountsConsistency extends DmPlugin {
         // Distinguish between principal account (uid=mail) and applicative accounts (uid=username_cXXXXXXXX)
         const isPrincipalAccount = oldUid === oldMail;
 
-        // Compute new DN based on account type
-        let newApplicativeDn: string;
-        if (isPrincipalAccount) {
-          newApplicativeDn = `uid=${escapeDnValue(newMail)},${this.applicativeAccountBase}`;
-        } else {
-          // Keep the same uid for applicative accounts
-          newApplicativeDn = `uid=${escapeDnValue(oldUid)},${this.applicativeAccountBase}`;
+        // App accounts do not survive a mail change: every MUA has to be
+        // reconfigured against the new address anyway, and a per-device
+        // credential left bound to the old identity is a liability. Drop them
+        // and let the user reissue what they still need.
+        //
+        // They used to be recreated at the same DN carrying the new mail but
+        // without their password — entries that could not authenticate, were
+        // still listed by the API as if they could, and still counted against
+        // `max_app_accounts`, eventually locking the user out of creating new
+        // ones (#103).
+        if (!isPrincipalAccount) {
+          await this.deleteApplicativeEntry(oldApplicativeDn);
+          continue;
         }
+
+        const newApplicativeDn = `uid=${escapeDnValue(newMail)},${this.applicativeAccountBase}`;
 
         try {
           // Save old applicative account entry attributes before deletion
@@ -399,33 +437,11 @@ export default class AppAccountsConsistency extends DmPlugin {
           }
 
           // Delete old applicative account
-          try {
-            await this.server.ldap.delete(oldApplicativeDn);
-            this.logger.info(
-              `${this.name}: Deleted old applicative account ${oldApplicativeDn}`
-            );
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } catch (deleteError: any) {
-            // Ignore NoSuchObjectError (already deleted)
-            if (
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              deleteError.code === 0x20 ||
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-              deleteError.message?.includes('NoSuchObject')
-            ) {
-              this.logger.debug(
-                `${this.name}: Applicative account ${oldApplicativeDn} already deleted`
-              );
-            } else {
-              throw deleteError;
-            }
-          }
+          await this.deleteApplicativeEntry(oldApplicativeDn);
 
-          // Create new applicative account with updated mail. Start from the
-          // old entry's own attributes to keep what the user entry cannot
-          // supply — the per-device `description`, mostly. Not the password:
-          // a mail change forces every client to be reconfigured anyway, so
-          // the app accounts are deliberately reissued without one.
+          // Recreate the principal at its new DN. Start from the old entry's
+          // own attributes to keep what the user entry cannot supply, then
+          // overwrite with the fresh user values below.
           const newAttrs: AttributesList = { ...oldApplicativeAttrs };
 
           // Read the current user entry to get fresh user attributes
@@ -448,14 +464,8 @@ export default class AppAccountsConsistency extends DmPlugin {
           // Overwrite with fresh user attributes (cn, sn, givenName, mail, etc.)
           Object.assign(newAttrs, this.pickCopiedAttributes(userEntry));
 
-          // For principal account: change uid to newMail
-          // For applicative accounts: keep the same uid (username_cXXXXXXXX)
-          if (isPrincipalAccount) {
-            newAttrs.uid = newMail;
-          } else {
-            // Keep the same uid for applicative accounts
-            newAttrs.uid = oldUid;
-          }
+          // The principal account is keyed on the mail address
+          newAttrs.uid = newMail;
 
           await this.server.ldap.add(newApplicativeDn, newAttrs);
           this.logger.info(

--- a/test/plugins/twake/appAccountsConsistency.test.ts
+++ b/test/plugins/twake/appAccountsConsistency.test.ts
@@ -788,5 +788,55 @@ describe('App Accounts Consistency Plugin', function () {
         /applicative_account_base configuration is required/
       );
     });
+
+    // An allowlist that omits objectClass or the mail attribute would produce
+    // entries the directory rejects, or entries this plugin can never find
+    // again through its mail-keyed searches. They are forced in.
+    it('should still create a valid entry when the allowlist omits objectClass and mail', async function () {
+      this.timeout(10000);
+
+      const dm2 = new DM();
+      dm2.config.ldap_base = process.env.DM_LDAP_BASE;
+      await dm2.ready;
+      dm2.config.applicative_account_base = applicativeBase;
+      dm2.config.mail_attribute = 'mail';
+      // Neither objectClass nor mail is named here
+      dm2.config.applicative_account_attribute = ['cn', 'sn'];
+
+      await dm2.registerPlugin('onLdapChange', new OnChange(dm2));
+      await dm2.registerPlugin(
+        'appAccountsConsistency',
+        new AppAccountsConsistency(dm2)
+      );
+
+      const userDn = `uid=strict-${timestamp},${userBase}`;
+      const appDn = `uid=strict-${timestamp}@example.com,${applicativeBase}`;
+      try {
+        await dm2.ldap.add(userDn, {
+          objectClass: 'inetOrgPerson',
+          uid: `strict-${timestamp}`,
+          cn: 'Strict User',
+          sn: 'User',
+          mail: `strict-${timestamp}@example.com`,
+        });
+
+        await waitForEntry(dm2, appDn);
+        const result = await dm2.ldap.search(
+          { scope: 'base', paged: false },
+          appDn
+        );
+        const entry = (result as any).searchEntries[0];
+        expect(entry.objectClass).to.contain('inetOrgPerson');
+        expect(entry.mail).to.equal(`strict-${timestamp}@example.com`);
+      } finally {
+        for (const dn of [appDn, userDn]) {
+          try {
+            await dm2.ldap.delete(dn);
+          } catch (err) {
+            // Ignore
+          }
+        }
+      }
+    });
   });
 });

--- a/test/plugins/twake/appAccountsConsistency.test.ts
+++ b/test/plugins/twake/appAccountsConsistency.test.ts
@@ -591,7 +591,7 @@ describe('App Accounts Consistency Plugin', function () {
       }
     });
 
-    it('should update all app accounts when user mail changes', async function () {
+    it('should delete app accounts when user mail changes', async function () {
       this.timeout(15000);
 
       // Create user with mail
@@ -688,32 +688,19 @@ describe('App Accounts Consistency Plugin', function () {
       expect(entry.uid).to.equal(`newemail-${timestamp}@example.com`);
       expect(entry.mail).to.equal(`newemail-${timestamp}@example.com`);
 
-      // Verify app accounts kept their uid but changed mail
-      result = await dm.ldap.search(
-        {
-          scope: 'base',
-          paged: false,
-        },
-        appAccount1DN
-      );
-      expect((result as any).searchEntries).to.have.lengthOf(1);
-      entry = (result as any).searchEntries[0];
-      expect(entry.uid).to.equal(`testuser-${timestamp}_c12345678`); // UID unchanged
-      expect(entry.mail).to.equal(`newemail-${timestamp}@example.com`); // Mail updated
-      expect(entry.description).to.equal('My Phone'); // Description preserved
-
-      result = await dm.ldap.search(
-        {
-          scope: 'base',
-          paged: false,
-        },
-        appAccount2DN
-      );
-      expect((result as any).searchEntries).to.have.lengthOf(1);
-      entry = (result as any).searchEntries[0];
-      expect(entry.uid).to.equal(`testuser-${timestamp}_c87654321`); // UID unchanged
-      expect(entry.mail).to.equal(`newemail-${timestamp}@example.com`); // Mail updated
-      expect(entry.description).to.equal('My Laptop'); // Description preserved
+      // App accounts are dropped, not carried over: every MUA has to be
+      // reconfigured against the new address anyway. They used to be recreated
+      // without their password — unusable, yet listed and counted against
+      // max_app_accounts (#103).
+      for (const dn of [appAccount1DN, appAccount2DN]) {
+        await waitForNoEntry(dm, dn);
+        try {
+          await dm.ldap.search({ scope: 'base', paged: false }, dn);
+          expect.fail(`App account ${dn} should have been deleted`);
+        } catch (err: any) {
+          expect(err.message || err.code).to.match(/No such object|0x20/i);
+        }
+      }
 
       // Cleanup - ignore errors if already deleted
       try {

--- a/test/plugins/twake/appAccountsConsistency.test.ts
+++ b/test/plugins/twake/appAccountsConsistency.test.ts
@@ -152,6 +152,72 @@ describe('App Accounts Consistency Plugin', function () {
       expect(entry.cn).to.equal('Test User');
     });
 
+    // The applicative branch is only ever read to bind with uid/userPassword,
+    // so an attribute the user entry happens to carry has no reason to be
+    // duplicated there. Copying used to be a denylist, which meant every new
+    // attribute on the user schema was propagated until someone remembered to
+    // exclude it (#103).
+    it('should not copy user attributes outside the configured allowlist', async () => {
+      await dm.ldap.add(testUserDN, {
+        objectClass: 'inetOrgPerson',
+        uid: `testuser-${timestamp}`,
+        cn: 'Test User',
+        sn: 'User',
+        mail: `testuser-${timestamp}@example.com`,
+        // Not in --applicative-account-attribute
+        telephoneNumber: '+33123456789',
+        title: 'Chief Secret Keeper',
+      });
+
+      await waitForEntry(dm, testApplicativeDN);
+
+      const result = await dm.ldap.search(
+        { scope: 'base', paged: false },
+        testApplicativeDN
+      );
+      const entry = (result as any).searchEntries[0];
+
+      // Allowlisted attributes are still there
+      expect(entry.cn).to.equal('Test User');
+      expect(entry.sn).to.equal('User');
+      expect(entry.mail).to.equal(`testuser-${timestamp}@example.com`);
+      // The rest stayed on the user entry
+      expect(entry).to.not.have.property('telephoneNumber');
+      expect(entry).to.not.have.property('title');
+    });
+
+    // Same guarantee on the mail-change path, which re-reads the user entry
+    // and recreates the applicative one: this is how `twakeRecoveryEmail`
+    // ended up in 18 applicative entries (#103).
+    it('should not copy attributes outside the allowlist on a mail change', async () => {
+      await dm.ldap.add(testUserDN, {
+        objectClass: 'inetOrgPerson',
+        uid: `testuser-${timestamp}`,
+        cn: 'Test User',
+        sn: 'User',
+        mail: `testuser-${timestamp}@example.com`,
+        telephoneNumber: '+33123456789',
+      });
+      await waitForEntry(dm, testApplicativeDN);
+
+      await dm.ldap.modify(testUserDN, {
+        replace: { mail: `newemail-${timestamp}@example.com` },
+      });
+
+      const newApplicativeDN = `uid=newemail-${timestamp}@example.com,${applicativeBase}`;
+      await waitForEntry(dm, newApplicativeDN);
+
+      const result = await dm.ldap.search(
+        { scope: 'base', paged: false },
+        newApplicativeDN
+      );
+      const entry = (result as any).searchEntries[0];
+
+      expect(entry.mail).to.equal(`newemail-${timestamp}@example.com`);
+      expect(entry.cn).to.equal('Test User');
+      expect(entry).to.not.have.property('telephoneNumber');
+    });
+
     it('should be idempotent when creating applicative account multiple times', async () => {
       // Create user with mail
       const userAttrs = {


### PR DESCRIPTION
Closes #103.

## 1. Applicative entries are built from an allowlist

`appAccountsConsistency` copied the whole user entry and removed whatever `--ldap-operational-attribute` listed. It now copies a named list instead — `--applicative-account-attribute`, default `objectClass`, `cn`, `sn`, `givenName`, `displayName`, `description`, plus the configured mail attribute.

`appAccountsApi` reads the same option (minus `objectClass`, which it forces to `inetOrgPerson`, and `description`, which carries the caller's label), so the two plugins finally build applicative entries the same way. **With the default list its behaviour is byte-for-byte what it was** — the previous hardcoded set was `cn`, `sn`, `givenName`, mail, `displayName`.

`--ldap-operational-attribute` keeps the one meaning that is genuinely its own: what the directory generates and refuses on an `add`, applied only when the principal account is recreated at its new DN.

## 2. A mail change deletes the app accounts

Per the comment on #103, removing them is intentional: every MUA has to be reconfigured against the new address anyway, and a per-device credential left bound to the old identity is a liability.

Only half of that was applied — the password was dropped, the entry was not. What survived was an entry that:

- could not authenticate (no `userPassword`);
- was still returned by `GET /users/:user/app-accounts`, device label intact, indistinguishable from a working account;
- still matched the `(mail=<new mail>)` count guarding `--max-app-accounts` (`appAccountsApi.ts:438`), because the recreated entries carried the new mail.

So a user at the default limit of 5 who changed address kept five dead accounts and could no longer create a working one until someone cleaned the branch by hand.

The principal account still moves to its new DN, unchanged.

## Note on the issue text

The issue asks for the mail-change path to **keep** the app account's password. That is the opposite of the stated intent, so it is not implemented — the accounts are removed outright instead.

The in-code comment claimed the same thing (`// Start with old applicative account attributes to preserve things like description, userPassword`) while the code stripped it. That stale comment is what made this look like a bug on first read; it now states the real intent. Worth amending the issue text so the next reader isn't misled the same way.

## Breaking

- An attribute previously copied into the applicative branch must now be named in `--applicative-account-attribute`.
- App accounts no longer survive a mail change.

## Verification

```
npm run test:dev  → 998 passing, 7 pending
tsc --noEmit, eslint, prettier → clean
```

Two new integration tests, both failing before the change:
- an attribute outside the allowlist is not copied on creation
- same on the mail-change path — the route by which `twakeRecoveryEmail` reached 18 entries

One existing test was **rewritten** rather than added to: `should update all app accounts when user mail changes` asserted the old behaviour (`// Verify app accounts kept their uid but changed mail`). It is now `should delete app accounts when user mail changes`. Worth a look, since rewriting an existing assertion is how a regression gets waved through.

The two changes are separate commits and can be reviewed independently.
